### PR TITLE
Prevent the creation of a synthetic Refined.copy method. closes #57

### DIFF
--- a/notes/0.3.0.markdown
+++ b/notes/0.3.0.markdown
@@ -7,5 +7,8 @@
 * Rename the `implicits` object to `auto` since the purpose of the
   implicit conversions there is to automatically convert base types to
   refined types. ([#61])
+* Add a `copy` method to `Refined` to prevent the creation of a synthetic
+  `copy` method that would subvert the private constructor. ([#57])
 
+[#57]: https://github.com/fthomas/refined/issues/57
 [#61]: https://github.com/fthomas/refined/issues/61

--- a/shared/src/main/scala/eu/timepit/refined/api/Refined.scala
+++ b/shared/src/main/scala/eu/timepit/refined/api/Refined.scala
@@ -6,7 +6,13 @@ package api
  * this class can be created with `[[refineV]]` and `[[refineMV]]` which
  * verify that the wrapped value satisfies `P`.
  */
-final case class Refined[T, P] private (get: T) extends AnyVal
+final case class Refined[T, P] private (get: T) extends AnyVal {
+
+  // Prevent the creation of a synthetic copy method that subverts the
+  // private constructor. See https://github.com/fthomas/refined/issues/57
+  private def copy[T2, P2](t: T2): Refined[T2, P2] =
+    new Refined(t)
+}
 
 object Refined {
 


### PR DESCRIPTION
This prevents the creation of a synthetic copy method that subverts
`Refined`'s private constructor:

```scala
scala> val r = refineMV[Positive](5)
r: eu.timepit.refined.api.Refined[Int,eu.timepit.refined.numeric.Positive] = Refined(5)

scala> r.copy[Int, Positive](-5)
<console>:48: error: method copy in class Refined cannot be accessed in eu.timepit.refined.api.Refined[Int,eu.timepit.refined.numeric.Positive]
       r.copy[Int, Positive](-5)
         ^
```