### PR TITLE
Add RefType.coflatMap

### DIFF
--- a/notes/0.3.0.markdown
+++ b/notes/0.3.0.markdown
@@ -7,5 +7,8 @@
 * Rename the `implicits` object to `auto` since the purpose of the
   implicit conversions there is to automatically convert base types to
   refined types. ([#61])
+* Add `coflatMapRefine` to `RefType` which is similar to `coflatMap` on
+  a `Comonad`.
 
 [#61]: https://github.com/fthomas/refined/issues/61
+[#68]: https://github.com/fthomas/refined/pull/68

--- a/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
+++ b/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
@@ -71,6 +71,20 @@ trait RefType[F[_, _]] extends Serializable {
 
   def mapRefine[T, P, U](tp: F[T, P])(f: T => U)(implicit v: Validate[U, P]): Either[String, F[U, P]] =
     refine(f(unwrap(tp)))
+
+  def coflatMapRefine[T, P, U](tp: F[T, P])(f: F[T, P] => U)(implicit v: Validate[U, P]): Either[String, F[U, P]] =
+    refine(f(tp))
+
+  // Note that we could define mapRefine in terms of coflatMapRefine
+  // and unwrap:
+  //
+  //   tp.mapRefine(f) = tp.coflatMapRefine(f compose unwrap)
+  //
+  // This is similar how a Comonad fa can define map in terms of coflatMap
+  // and extract:
+  //
+  //   fa.map(f) = fa.coflatMap(f compose extract)
+
 }
 
 object RefType {
@@ -113,6 +127,9 @@ object RefType {
 
     def mapRefine[U](f: T => U)(implicit v: Validate[U, P]): Either[String, F[U, P]] =
       F.mapRefine(tp)(f)
+
+    def coflatMapRefine[U](f: F[T, P] => U)(implicit v: Validate[U, P]): Either[String, F[U, P]] =
+      F.coflatMapRefine(tp)(f)
   }
 
   object ops {

--- a/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -52,6 +52,10 @@ abstract class RefTypeProperties[F[_, _]](name: String)(implicit rt: RefType[F])
     rt.refine[Positive](5).right.flatMap(_.mapRefine(_ - 10)).isLeft
   }
 
+  property("coflatMapRefine success with Positive") = secure {
+    rt.refine[Positive](5).right.flatMap(_.coflatMapRefine(_.unwrap)).isRight
+  }
+
   property("implicit unwrap") = secure {
     rt.refine[Positive](5).right.map(_ + 1) == Right(6)
   }


### PR DESCRIPTION
`coflatMapRefine` is a generalization of `mapRefine` in the sense that `mapRefine` can be implemented in terms of `coflatMapRefine` and `unwrap`. What is interesting here is that this situation is similar to a `Comonad` where `map` can be implemented in terms of `coflatMap` and `extract` in exactly the same way.