### PR TITLE
Add date- and time-related types

### DIFF
--- a/notes/0.3.0.markdown
+++ b/notes/0.3.0.markdown
@@ -10,7 +10,10 @@
   refined types. ([#61])
 * Add `coflatMapRefine` to `RefType` which is similar to `coflatMap` on
   a `Comonad`.
+* Add `util.time` module with date- and time-related refined types
+  (`Month`, `DayOfMonth`, `Hour`, `Minute`, and `Second`). ([#64])
 
 [#51]: https://github.com/fthomas/refined/pull/51
 [#61]: https://github.com/fthomas/refined/issues/61
+[#64]: https://github.com/fthomas/refined/issues/64
 [#68]: https://github.com/fthomas/refined/pull/68

--- a/shared/src/main/scala/eu/timepit/refined/util/time.scala
+++ b/shared/src/main/scala/eu/timepit/refined/util/time.scala
@@ -1,0 +1,25 @@
+package eu.timepit.refined
+package util
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Interval
+
+object time {
+
+  /** An `Int` in the range from 1 to 12. */
+  type Month = Int Refined Interval[W.`1`.T, W.`12`.T]
+
+  /** An `Int` in the range from 1 to 31. */
+  type DayOfMonth = Int Refined Interval[W.`1`.T, W.`31`.T]
+
+  /** An `Int` in the range from 0 to 23. */
+  type Hour = Int Refined Interval[W.`0`.T, W.`23`.T]
+
+  /** An `Int` in the range from 0 to 59. */
+  type Minute = Int Refined Interval[W.`0`.T, W.`59`.T]
+
+  /** An `Int` in the range from 0 to 59. */
+  type Second = Int Refined Interval[W.`0`.T, W.`59`.T]
+
+  // Add safe constructors for java.time types once we require Java 8 or higher.
+}


### PR DESCRIPTION
This adds the `util.time` module with these refined types:

* `Month`: an `Int` in the range from 1 to 12
* `DayOfMonth`: an `Int` in the range from 1 to 31
* `Hour`: an `Int` in the range from 0 to 23
* `Minute`: an `Int` in the range from 0 to 59
* `Second`: an `Int` in the range from 0 to 59

closes #64