### PR TITLE
First draft of a scalacheck module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,10 @@
 lazy val root = project.in(file("."))
-  .aggregate(coreJVM, coreJS, docs)
+  .aggregate(
+    coreJVM,
+    coreJS,
+    docs,
+    scalacheckJVM,
+    scalacheckJS)
   .settings(commonSettings)
   .settings(noPublishSettings)
   .settings(releaseSettings)
@@ -36,9 +41,23 @@ lazy val docs = project
   )
   .dependsOn(coreJVM)
 
+lazy val scalacheck = crossProject
+  .settings(moduleName := "refined-scalacheck")
+  .settings(commonSettings: _*)
+  .settings(publishSettings: _*)
+  .settings(styleSettings: _*)
+  .settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalaCheckVersion)
+  .dependsOn(core)
+
+lazy val scalacheckJVM = scalacheck.jvm
+lazy val scalacheckJS = scalacheck.js
+
 val rootPkg = "eu.timepit.refined"
 val gitPubUrl = "https://github.com/fthomas/refined.git"
 val gitDevUrl = "git@github.com:fthomas/refined.git"
+
+lazy val shapelessVersion = "2.2.5"
+lazy val scalaCheckVersion = "1.12.5"
 
 lazy val commonSettings =
   projectSettings ++
@@ -81,8 +100,8 @@ lazy val compileSettings = Seq(
 
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-    "com.chuusai" %%% "shapeless" % "2.2.5",
-    "org.scalacheck" %%% "scalacheck" % "1.12.5" % "test"
+    "com.chuusai" %%% "shapeless" % shapelessVersion,
+    "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
   ),
 
   libraryDependencies ++= {
@@ -230,9 +249,11 @@ lazy val styleSettings =
 addCommandAlias("validate", Seq(
   "clean",
   "coreJS/test",
+  "scalacheckJS/test",
   "coverage",
   "compile",
   "coreJVM/test",
+  "scalacheckJVM/test",
   "scalastyle",
   "test:scalastyle",
   "doc",

--- a/notes/0.3.1.markdown
+++ b/notes/0.3.1.markdown
@@ -1,0 +1,6 @@
+### Changes
+
+* Add a refined-scalacheck module which provides ScalaCheck `Arbitrary`
+  instances of refined types for some of refined's predicates.  ([#58])
+
+[#58]: https://github.com/fthomas/refined/issues/58

--- a/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numericArbitrary.scala
+++ b/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numericArbitrary.scala
@@ -1,0 +1,41 @@
+package eu.timepit.refined
+package scalacheck
+
+import eu.timepit.refined.api.RefType
+import eu.timepit.refined.numeric.{ Greater, Interval, Less }
+import org.scalacheck.{ Arbitrary, Gen }
+import shapeless.Witness
+
+object numericArbitrary {
+
+  implicit def arbLess[F[_, _], T, N <: T](
+    implicit
+    rt: RefType[F],
+    wn: Witness.Aux[N],
+    nt: Numeric[T], c: Gen.Choose[T]
+  ): Arbitrary[F[T, Less[N]]] = {
+    val gen = Gen.chooseNum(nt.fromInt(Int.MinValue), nt.minus(wn.value, nt.one))
+    Arbitrary(gen.map(rt.unsafeWrap))
+  }
+
+  implicit def arbGreater[F[_, _], T, N <: T](
+    implicit
+    rt: RefType[F],
+    wn: Witness.Aux[N],
+    nt: Numeric[T],
+    c: Gen.Choose[T]
+  ): Arbitrary[F[T, Greater[N]]] = {
+    val gen = Gen.chooseNum(nt.plus(wn.value, nt.one), nt.fromInt(Int.MaxValue))
+    Arbitrary(gen.map(rt.unsafeWrap))
+  }
+
+  implicit def arbInterval[F[_, _], T, L <: T, H <: T](
+    implicit
+    rt: RefType[F],
+    wl: Witness.Aux[L],
+    wh: Witness.Aux[H],
+    nt: Numeric[T],
+    c: Gen.Choose[T]
+  ): Arbitrary[F[T, Interval[L, H]]] =
+    Arbitrary(Gen.chooseNum(wl.value, wh.value).map(rt.unsafeWrap))
+}

--- a/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -1,0 +1,37 @@
+package eu.timepit.refined
+package scalacheck
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric.{ Greater, Less, Interval }
+import eu.timepit.refined.scalacheck.numericArbitrary._
+import eu.timepit.refined.util.time.Minute
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class NumericArbitrarySpec extends Properties("NumericArbitrary") {
+
+  property("Less.positive") = forAll { (i: Int Refined Less[W.`100`.T]) =>
+    i >= Int.MinValue && i < 100
+  }
+
+  property("Less.negative") = forAll { (i: Int Refined Less[W.`-100`.T]) =>
+    i >= Int.MinValue && i < -100
+  }
+
+  property("Greater.positive") = forAll { (i: Int Refined Greater[W.`100`.T]) =>
+    i > 100 && i <= Int.MaxValue
+  }
+
+  property("Greater.negative") = forAll { (i: Int Refined Greater[W.`-100`.T]) =>
+    i > -100 && i <= Int.MaxValue
+  }
+
+  property("Interval") = forAll { (i: Int Refined Interval[W.`0`.T, W.`100`.T]) =>
+    i >= 0 && i <= 100
+  }
+
+  property("Interval.alias") = forAll { m: Minute =>
+    m >= 0 && m <= 59
+  }
+}


### PR DESCRIPTION
This is just a draft of a possible `refined-scalacheck` module, see #58. It only has an `Arbitrary` instance for `F[T, Interval[H, L]]` but there are a few others which should be just as easy to write (e.g. `Letter`, `Digit`, `EndsWith`, `StartsWith`, `Empty`, `Size`, etc.). 

@koshelev since you was the first to ask for this, do you have any specific predicates in mind for which we should provide `Arbitrary` instances?