### PR TITLE
Remove Arbitrary suffix from scalacheck modules

### DIFF
--- a/notes/0.3.2.markdown
+++ b/notes/0.3.2.markdown
@@ -5,9 +5,11 @@
   ``type Minute = Int Refined Interval[W.`0`.T, W.`59`.T]`` more
   convenient because one can use `Minute` as parameter for `applyRef`,
   e.g. `applyRef[Minute](45)`. ([#78])
-* Add an `anyArbitrary` module which provides `Arbitrary` instances for
-  any refined type by using an `Arbitrary` of the base type and a
-  `Validate` of the refinement's predicate to pick only valid values.
+* Add an `any` module which provides `Arbitrary` instances for any
+  refined type by using an `Arbitrary` of the base type and a `Validate`
+  of the refinement's predicate to pick only valid values.
 * Add `Arbitrary` instances for `LessEqual` and `GreaterEqual`.
+* Remove the `Arbitrary` suffix from modules providing `Arbitrary`
+  instances. 
 
 [#78]: https://github.com/fthomas/refined/issues/78

--- a/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/any.scala
+++ b/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/any.scala
@@ -4,7 +4,7 @@ package scalacheck
 import eu.timepit.refined.api.{ RefType, Validate }
 import org.scalacheck.Arbitrary
 
-object anyArbitrary {
+object any {
 
   implicit def arbitraryFromValidate[F[_, _], T, P](
     implicit

--- a/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/boolean.scala
+++ b/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/boolean.scala
@@ -5,7 +5,7 @@ import eu.timepit.refined.api.RefType
 import eu.timepit.refined.boolean.Or
 import org.scalacheck.{ Arbitrary, Gen }
 
-object booleanArbitrary {
+object boolean {
 
   implicit def orArbitrary[F[_, _], T, A, B](
     implicit

--- a/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/char.scala
+++ b/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/char.scala
@@ -5,7 +5,7 @@ import eu.timepit.refined.api.RefType
 import eu.timepit.refined.char.{ Digit, Letter, LowerCase, UpperCase }
 import org.scalacheck.{ Arbitrary, Gen }
 
-object charArbitrary {
+object char {
 
   implicit def digitArbitrary[F[_, _]: RefType]: Arbitrary[F[Char, Digit]] =
     arbitraryRefType(Gen.numChar)

--- a/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -6,7 +6,7 @@ import eu.timepit.refined.numeric._
 import org.scalacheck.{ Arbitrary, Gen }
 import shapeless.Witness
 
-object numericArbitrary {
+object numeric {
 
   implicit def lessArbitrary[F[_, _], T, N <: T](
     implicit

--- a/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -6,7 +6,7 @@ import eu.timepit.refined.string.{ EndsWith, StartsWith }
 import org.scalacheck.Arbitrary
 import shapeless.Witness
 
-object stringArbitrary {
+object string {
 
   implicit def endsWithArbitrary[F[_, _], S <: String](
     implicit

--- a/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CharArbitrarySpec.scala
+++ b/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CharArbitrarySpec.scala
@@ -3,8 +3,8 @@ package scalacheck
 
 import eu.timepit.refined.char._
 import eu.timepit.refined.scalacheck.TestUtils._
-import eu.timepit.refined.scalacheck.booleanArbitrary._
-import eu.timepit.refined.scalacheck.charArbitrary._
+import eu.timepit.refined.scalacheck.boolean._
+import eu.timepit.refined.scalacheck.char._
 import org.scalacheck.Properties
 
 class CharArbitrarySpec extends Properties("CharArbitrarySpec") {

--- a/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -3,8 +3,8 @@ package scalacheck
 
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
-import eu.timepit.refined.scalacheck.numericArbitrary._
 import eu.timepit.refined.scalacheck.TestUtils._
+import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.util.time.Minute
 import org.scalacheck.Prop._
 import org.scalacheck.Properties

--- a/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -1,10 +1,10 @@
 package eu.timepit.refined
 package scalacheck
 
-import eu.timepit.refined.scalacheck.anyArbitrary._
-import eu.timepit.refined.scalacheck.stringArbitrary._
+import eu.timepit.refined.scalacheck.any._
+import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.scalacheck.TestUtils._
-import eu.timepit.refined.string.{ EndsWith, MatchesRegex, StartsWith }
+import eu.timepit.refined.string._
 import org.scalacheck.Properties
 
 class StringArbitrarySpec extends Properties("StringArbitrary") {


### PR DESCRIPTION
This is consistent with the naming of modules under `eu.timepit.refined.util.string`.