### PR TITLE
Add Eval predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The library comes with these predefined predicates:
 [`generic`](https://github.com/fthomas/refined/blob/master/core/shared/src/main/scala/eu/timepit/refined/generic.scala)
 
 * `Equal[U]`: checks if a value is equal to `U`
+* `Eval[S]`: checks if a value applied to the predicate `S` yields `true`
 * `ConstructorNames[P]`: checks if the constructor names of a sum type satisfy `P`
 * `FieldNames[P]`: checks if the field names of a product type satisfy `P`
 * `Subtype[U]`: witnesses that the type of a value is a subtype of `U`

--- a/core/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
+++ b/core/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
@@ -1,0 +1,17 @@
+package eu.timepit.refined
+
+import eu.timepit.refined.TestUtils._
+import eu.timepit.refined.generic.Eval
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class GenericValidateSpecJvm extends Properties("GenericValidate") {
+
+  property("Eval.isValid") = secure {
+    isValid[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](6)
+  }
+
+  property("Eval.showExpr") = secure {
+    showExpr[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](0) ?= "(x: Int) => x % 2 == 0"
+  }
+}

--- a/core/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
+++ b/core/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
@@ -8,7 +8,8 @@ import org.scalacheck.Properties
 class GenericValidateSpecJvm extends Properties("GenericValidate") {
 
   property("Eval.isValid") = secure {
-    isValid[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](6)
+    isValid[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](6) &&
+      notValid[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](7)
   }
 
   property("Eval.showExpr") = secure {

--- a/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -9,10 +9,16 @@ import shapeless.ops.hlist.ToList
 import shapeless.ops.nat.ToInt
 import shapeless.ops.record.Keys
 
+import scala.reflect.runtime.currentMirror
+import scala.tools.reflect.ToolBox
+
 object generic extends GenericValidate with GenericInference {
 
   /** Predicate that checks if a value is equal to `U`. */
   case class Equal[U](u: U)
+
+  /** Predicate that checks if a value applied to the predicate `S` yields true. */
+  case class Eval[S](s: S)
 
   /** Predicate that checks if the constructor names of a sum type satisfy `P`. */
   case class ConstructorNames[P](p: P)
@@ -40,6 +46,13 @@ private[refined] trait GenericValidate {
     tn: ToInt[N], wn: Witness.Aux[N], nt: Numeric[T]
   ): Validate.Plain[T, Equal[N]] =
     Validate.fromPredicate(t => nt.toDouble(t) == tn(), t => s"($t == ${tn()})", Equal(wn.value))
+
+  implicit def evalValidate[T, S <: String](implicit ws: Witness.Aux[S]): Validate.Plain[T, Eval[S]] = {
+    val toolBox = currentMirror.mkToolBox()
+    val tree = toolBox.parse(ws.value)
+    val predicate = toolBox.eval(tree).asInstanceOf[T => Boolean]
+    Validate.fromPredicate(predicate, _ => ws.value, Eval(ws.value))
+  }
 
   implicit def ctorNamesValidate[T, R0 <: Coproduct, R1 <: HList, K <: HList, NP, NR](
     implicit

--- a/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -17,7 +17,7 @@ object generic extends GenericValidate with GenericInference {
   /** Predicate that checks if a value is equal to `U`. */
   case class Equal[U](u: U)
 
-  /** Predicate that checks if a value applied to the predicate `S` yields true. */
+  /** Predicate that checks if a value applied to the predicate `S` yields `true`. */
   case class Eval[S](s: S)
 
   /** Predicate that checks if the constructor names of a sum type satisfy `P`. */

--- a/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
@@ -55,14 +55,6 @@ class GenericValidateSpec extends Properties("GenericValidate") {
     showResult[Equal[_1]](i) ?= showResult[Equal[W.`1`.T]](i)
   }
 
-  property("Eval.isValid") = secure {
-    isValid[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](6)
-  }
-
-  property("Eval.showExpr") = secure {
-    showExpr[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](0) ?= "(x: Int) => x % 2 == 0"
-  }
-
   property("ConstructorNames.isValid") = secure {
     isValid[ConstructorNames[Contains[W.`"Some"`.T]]](Option(0))
   }

--- a/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
@@ -55,6 +55,14 @@ class GenericValidateSpec extends Properties("GenericValidate") {
     showResult[Equal[_1]](i) ?= showResult[Equal[W.`1`.T]](i)
   }
 
+  property("Eval.isValid") = secure {
+    isValid[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](6)
+  }
+
+  property("Eval.showExpr") = secure {
+    showExpr[Eval[W.`"(x: Int) => x % 2 == 0"`.T]](0) ?= "(x: Int) => x % 2 == 0"
+  }
+
   property("ConstructorNames.isValid") = secure {
     isValid[ConstructorNames[Contains[W.`"Some"`.T]]](Option(0))
   }

--- a/notes/0.3.2.markdown
+++ b/notes/0.3.2.markdown
@@ -13,4 +13,11 @@
 * Remove the `Arbitrary` suffix from modules providing `Arbitrary`
   instances. 
 
+### New predicates
+
+[`generic`](https://github.com/fthomas/refined/blob/v0.3.2/core/shared/src/main/scala/eu/timepit/refined/generic.scala)
+
+* `Eval[S]`: checks if a value applied to the predicate `S` yields `true` ([#82])
+
 [#78]: https://github.com/fthomas/refined/issues/78
+[#82]: https://github.com/fthomas/refined/pull/82


### PR DESCRIPTION
This adds the `Eval` predicate that takes a `String` singleton type as parameter. The value of that singleton type is a definition of a predicate `T => Boolean` which is parsed and evaluated at compile-time to check if a given value satisfies it. `Eval` allows to define arbitrary predicates without writing `Validate` instances.

Example usage:
```scala
scala> type IsEven = Eval[W.`"(x: Int) => x % 2 == 0"`.T]
defined type alias IsEven

scala> val a: Int @@ IsEven = 4
a: shapeless.tag.@@[Int,IsEven] = 4

scala> val b: Int @@ IsEven = 5
<console>:47: error: Predicate failed: (x: Int) => x % 2 == 0.
       val b: Int @@ IsEven = 5
                              ^
```