### PR TITLE
Draft of a refined-scalaz subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,40 @@
+/// shared variables
+
+val projectName = "refined"
+val rootPkg = s"eu.timepit.$projectName"
+val gitPubUrl = s"https://github.com/fthomas/$projectName.git"
+val gitDevUrl = s"git@github.com:fthomas/$projectName.git"
+
+val commonImports = s"""
+  import $rootPkg._
+  import $rootPkg.api._
+  import $rootPkg.api.Inference.==>
+  import $rootPkg.api.RefType.ops._
+  import $rootPkg.auto._
+  import $rootPkg.boolean._
+  import $rootPkg.char._
+  import $rootPkg.collection._
+  import $rootPkg.generic._
+  import $rootPkg.numeric._
+  import $rootPkg.string._
+  import shapeless.{ ::, HList, HNil }
+  import shapeless.nat._
+"""
+
+val shapelessVersion = "2.2.5"
+val scalaCheckVersion = "1.12.5"
+val scalazVersion = "7.1.5"
+
+/// project definitions
+
 lazy val root = project.in(file("."))
   .aggregate(
     coreJVM,
     coreJS,
     docs,
     scalacheckJVM,
-    scalacheckJS)
+    scalacheckJS,
+    scalaz)
   .settings(commonSettings)
   .settings(noPublishSettings)
   .settings(releaseSettings)
@@ -15,7 +45,7 @@ lazy val root = project.in(file("."))
 
 lazy val core = crossProject
   .enablePlugins(BuildInfoPlugin)
-  .settings(moduleName := "refined")
+  .settings(moduleName := projectName)
   .settings(commonSettings: _*)
   .settings(scaladocSettings: _*)
   .settings(publishSettings: _*)
@@ -24,13 +54,19 @@ lazy val core = crossProject
   .settings(styleSettings: _*)
   .settings(siteSettings: _*)
   .jvmSettings(myDoctestSettings: _*)
+  .jvmSettings(
+    initialCommands := s"""
+      $commonImports
+      import shapeless.tag.@@
+    """
+  )
   .jsSettings(scalaJSStage in Test := FastOptStage)
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
 
 lazy val docs = project
-  .settings(moduleName := "refined-docs")
+  .settings(moduleName := s"$projectName-docs")
   .settings(commonSettings)
   .settings(noPublishSettings)
   .settings(tutSettings)
@@ -42,7 +78,7 @@ lazy val docs = project
   .dependsOn(coreJVM)
 
 lazy val scalacheck = crossProject
-  .settings(moduleName := "refined-scalacheck")
+  .settings(moduleName := s"$projectName-scalacheck")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(releaseSettings: _*)
@@ -54,23 +90,35 @@ lazy val scalacheck = crossProject
 lazy val scalacheckJVM = scalacheck.jvm
 lazy val scalacheckJS = scalacheck.js
 
-val rootPkg = "eu.timepit.refined"
-val gitPubUrl = "https://github.com/fthomas/refined.git"
-val gitDevUrl = "git@github.com:fthomas/refined.git"
+lazy val scalaz = project
+  .settings(moduleName := s"$projectName-scalaz")
+  .settings(commonSettings)
+  .settings(publishSettings)
+  .settings(releaseSettings)
+  .settings(styleSettings)
+  .settings(
+    libraryDependencies += "org.scalaz" %% "scalaz-core" % scalazVersion,
+    initialCommands := s"""
+      $commonImports
+      import $rootPkg.scalaz._
+      import $rootPkg.scalaz.auto._
+      import _root_.scalaz.@@
+    """
+  )
+  .dependsOn(coreJVM  % "compile->compile;test->test")
 
-lazy val shapelessVersion = "2.2.5"
-lazy val scalaCheckVersion = "1.12.5"
+/// settings definitions
 
 lazy val commonSettings =
   projectSettings ++
   compileSettings
 
 lazy val projectSettings = Seq(
-  name := "refined",
+  name := projectName,
   description := "Simple refinement types for Scala",
 
   organization := "eu.timepit",
-  homepage := Some(url("https://github.com/fthomas/refined")),
+  homepage := Some(url(s"https://github.com/fthomas/$projectName")),
   startYear := Some(2015),
   licenses += "MIT" -> url("http://opensource.org/licenses/MIT"),
 
@@ -133,7 +181,7 @@ lazy val scaladocSettings = Seq(
   ),
 
   autoAPIMappings := true,
-  apiURL := Some(url("http://fthomas.github.io/refined/latest/api/"))
+  apiURL := Some(url(s"http://fthomas.github.io/$projectName/latest/api/"))
 )
 
 lazy val publishSettings = Seq(
@@ -215,23 +263,6 @@ lazy val siteSettings =
   Seq(git.remoteRepo := gitDevUrl)
 
 lazy val miscSettings = Seq(
-  initialCommands := s"""
-    import $rootPkg._
-    import $rootPkg.api._
-    import $rootPkg.api.Inference.==>
-    import $rootPkg.api.RefType.ops._
-    import $rootPkg.auto._
-    import $rootPkg.boolean._
-    import $rootPkg.char._
-    import $rootPkg.collection._
-    import $rootPkg.generic._
-    import $rootPkg.numeric._
-    import $rootPkg.string._
-    import shapeless.{ ::, HList, HNil }
-    import shapeless.nat._
-    import shapeless.tag.@@
-  """,
-
   buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
   buildInfoPackage := s"$rootPkg.internal"
 )
@@ -256,6 +287,7 @@ addCommandAlias("validate", Seq(
   "compile",
   "coreJVM/test",
   "scalacheckJVM/test",
+  "scalaz/test",
   "scalastyle",
   "test:scalastyle",
   "doc",

--- a/core/shared/src/test/scala/eu/timepit/refined/RefineSyntaxSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/RefineSyntaxSpec.scala
@@ -67,23 +67,4 @@ class RefineSyntaxSpec extends Properties("refine syntax") {
     illTyped("testRefineMT(refineMT[Positive](-1))", "Predicate.*fail.*")
     illTyped("testRefineMT(refineMT[Positive][Int](-1))", "Predicate.*fail.*")
   }
-
-  property("refineMV with type alias") = secure {
-    type PositiveInt = Int Refined Positive
-
-    val x: PositiveInt = refineMV(5)
-    val y: PositiveInt = 5
-    val z = 5: PositiveInt
-    illTyped("val a: PositiveInt = -5", "Predicate failed: \\(-5 > 0\\).*")
-    x == y && y == z
-  }
-
-  property("refineMT with type alias") = wellTyped {
-    type PositiveInt = Int @@ Positive
-
-    // This is expected, see https://github.com/fthomas/refined/issues/21:
-    illTyped("val x: PositiveInt = refineMT(5)", "could not find implicit value.*")
-    illTyped("val y: PositiveInt = 5", "(?s)type mismatch.*")
-    illTyped("val z: PositiveInt = -5", "(?s)type mismatch.*")
-  }
 }

--- a/notes/0.3.2.markdown
+++ b/notes/0.3.2.markdown
@@ -1,5 +1,7 @@
 ### Changes
 
+* Add a refined-scalaz module which provides a `RefType` instance for
+  `scalaz.@@` (Scalaz' tag type). ([#84])
 * Add `RefType.applyRef` function that refines a value according to a
   refined type. This makes working with type aliases like
   ``type Minute = Int Refined Interval[W.`0`.T, W.`59`.T]`` more
@@ -30,3 +32,4 @@
 [#78]: https://github.com/fthomas/refined/issues/78
 [#80]: https://github.com/fthomas/refined/issues/80
 [#82]: https://github.com/fthomas/refined/pull/82
+[#84]: https://github.com/fthomas/refined/pull/84

--- a/scalaz/src/main/scala/eu/timepit/refined/scalaz/auto.scala
+++ b/scalaz/src/main/scala/eu/timepit/refined/scalaz/auto.scala
@@ -1,0 +1,19 @@
+package eu.timepit.refined.scalaz
+
+import eu.timepit.refined.api.{ RefType, Validate }
+import eu.timepit.refined.internal.RefineMPartiallyApplied
+
+import scalaz.@@
+
+object auto {
+
+  /**
+   * Implicitly tags (at compile-time) a value of type `T` with `P` if `t`
+   * satisfies the predicate `P`. If it does not satisfy the predicate,
+   * compilation fails.
+   */
+  implicit def autoRefineScalazTag[T, P](t: T)(
+    implicit
+    v: Validate[T, P], rt: RefType[@@]
+  ): T @@ P = macro RefineMPartiallyApplied.macroImpl[@@, T, P]
+}

--- a/scalaz/src/main/scala/eu/timepit/refined/scalaz/package.scala
+++ b/scalaz/src/main/scala/eu/timepit/refined/scalaz/package.scala
@@ -1,0 +1,24 @@
+package eu.timepit.refined
+
+import eu.timepit.refined.api.RefType
+
+import _root_.scalaz.{ @@, Tag }
+import scala.reflect.macros.Context
+
+package object scalaz {
+
+  implicit val scalazTagRefType: RefType[@@] =
+    new RefType[@@] {
+      override def unsafeWrap[T, P](t: T): T @@ P =
+        Tag.apply(t)
+
+      override def unwrap[T, P](tp: T @@ P): T =
+        Tag.unwrap(tp)
+
+      override def unsafeWrapM[T: c.WeakTypeTag, P: c.WeakTypeTag](c: Context)(t: c.Expr[T]): c.Expr[T @@ P] =
+        c.universe.reify(Tag.apply[T, P](t.splice))
+
+      override def unsafeRewrapM[T: c.WeakTypeTag, A: c.WeakTypeTag, B: c.WeakTypeTag](c: Context)(ta: c.Expr[T @@ A]): c.Expr[T @@ B] =
+        c.universe.reify(Tag.apply[T, B](Tag.unwrap(ta.splice)))
+    }
+}

--- a/scalaz/src/test/scala/eu/timepit/refined/scalaz/RefTypeSpecScalazTag.scala
+++ b/scalaz/src/test/scala/eu/timepit/refined/scalaz/RefTypeSpecScalazTag.scala
@@ -1,0 +1,27 @@
+package eu.timepit.refined.scalaz
+
+import eu.timepit.refined.TestUtils._
+import eu.timepit.refined.api.{RefType, RefTypeSpec}
+import eu.timepit.refined.numeric._
+import eu.timepit.refined.scalaz.auto._
+import org.scalacheck.Prop._
+import shapeless.test.illTyped
+
+import _root_.scalaz.@@
+
+class RefTypeSpecScalazTag extends RefTypeSpec[@@]("scalaz.@@") {
+
+  property("refineM with type alias") = secure {
+    type PositiveInt = Int @@ Positive
+
+    val x: PositiveInt = RefType[@@].refineM(5)
+    val y: PositiveInt = 5
+    val z = 5: PositiveInt
+    illTyped("val a: PositiveInt = -5", "Predicate failed: \\(-5 > 0\\).*")
+    x == y && y == z
+  }
+
+  property("(T @@ P) <!: T") = wellTyped {
+    illTyped("implicitly[(Int @@ Positive) <:< Int]", "Cannot prove.*")
+  }
+}


### PR DESCRIPTION
This provides a `RefType` instance for `scalaz.@@`. My main motivation for this is to see how `scalaz.@@` compares to `shapeless.tag.@@` and `Refined` as carrier for refinements.