### PR TITLE
Add RefType.refineMF

### DIFF
--- a/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined
 package api
 
-import eu.timepit.refined.internal.{ ApplyRefPartiallyApplied, RefineMPartiallyApplied, RefinePartiallyApplied }
+import eu.timepit.refined.internal._
 import shapeless.tag.@@
 
 import scala.reflect.macros.blackbox
@@ -68,6 +68,28 @@ trait RefType[F[_, _]] extends Serializable {
    */
   def refineM[P]: RefineMPartiallyApplied[F, P] =
     new RefineMPartiallyApplied
+
+  /**
+   * Macro that returns a value of type `T` refined as `F[T, P]` if
+   * it satisfies the predicate `P`, or fails to compile otherwise.
+   *
+   * Example: {{{
+   * scala> import eu.timepit.refined._
+   *      | import eu.timepit.refined.numeric._
+   *
+   * scala> RefType[Refined].refineMF[Long, Positive](10)
+   * res1: Refined[Long, Positive] = Refined(10)
+   * }}}
+   *
+   * Note: `M` stands for '''m'''acro and `F` for '''f'''ully applied.
+   *
+   * Note: The return type is `[[internal.RefineMFullyApplied]][F, T, P]`,
+   * which has an `apply` method on it, allowing `refineMF` to be called
+   * like in the given example. In contrast to `[[refineM]]`, the type
+   * `T` needs to be specified before `apply` can be called.
+   */
+  def refineMF[T, P]: RefineMFullyApplied[F, T, P] =
+    new RefineMFullyApplied
 
   def mapRefine[T, P, U](tp: F[T, P])(f: T => U)(implicit v: Validate[U, P]): Either[String, F[U, P]] =
     refine(f(unwrap(tp)))

--- a/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
@@ -1,0 +1,9 @@
+package eu.timepit.refined
+package internal
+
+import eu.timepit.refined.api.{ RefType, Validate }
+
+final class RefineMFullyApplied[F[_, _], T, P] {
+
+  def apply(t: T)(implicit v: Validate[T, P], rt: RefType[F]): F[T, P] = macro RefineM.macroImpl[F, T, P]
+}

--- a/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -89,6 +89,18 @@ class RefTypeSpecRefined extends RefTypeSpec[Refined]("Refined") {
     x == y && y == z
   }
 
+  property("refineMF alias") = secure {
+    type Natural = Long Refined NonNegative
+    val Natural = RefType[Refined].refineMF[Long, NonNegative]
+
+    val x: Natural = Natural(1L)
+    val y: Natural = 1L
+    val z = 1L: Natural
+    illTyped("Natural(-1L)", "Predicate.*fail.*")
+    illTyped("Natural(1.3)", "(?s)type mismatch.*")
+    x == y && y == z
+  }
+
   property("(T Refined P) <:! T") = wellTyped {
     val x = implicitly[(Int Refined Positive) <:!< Int]
   }
@@ -103,6 +115,17 @@ class RefTypeSpecTag extends RefTypeSpec[@@]("@@") {
     illTyped("val x: PositiveInt = RefType[@@]refineM(5)", "could not find implicit value.*")
     illTyped("val y: PositiveInt = 5", "(?s)type mismatch.*")
     illTyped("val z: PositiveInt = -5", "(?s)type mismatch.*")
+  }
+
+  property("refineMF alias") = secure {
+    val Natural = RefType[@@].refineMF[Long, NonNegative]
+
+    val x: Long @@ NonNegative = Natural(1L)
+    val y: Long @@ NonNegative = 1L
+    val z = 1L: Long @@ NonNegative
+    illTyped("Natural(-1L)", "Predicate.*fail.*")
+    illTyped("Natural(1.3)", "(?s)type mismatch.*")
+    (x: Long) == (y: Long) && (y: Long) == (z: Long)
   }
 
   property("(T @@ P) <: T") = wellTyped {

--- a/notes/0.3.3.markdown
+++ b/notes/0.3.3.markdown
@@ -1,3 +1,9 @@
 ### Changes
 
+* Add the `RefType.refineMF` macro which requires that the base type must
+  be specified and cannot be inferred from its argument. This allows to
+  define aliases for the `RefineM` macro where the base type and
+  predicate are fixed. ([#107])
 * Update `refined-scalaz` to Scalaz 7.2.0
+
+[#107]: https://github.com/fthomas/refined/issues/107


### PR DESCRIPTION
`refineMF` is a variation of `refineM` but which requires that the base type is specified before `apply` can be called. This allows to create aliases like `val Natural = RefType[Refined].refineMF[Long, NonNegative]` which only can be called with `Long` arguments.

closes #107

/cc @jedesah and @wemrysi