### PR TITLE
Arbitrary instances for numeric predicates indexed by Nats

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ The library comes with these predefined predicates:
 
 * [Alexandre Archambault](https://github.com/alexarchambault) ([@alxarchambault](https://twitter.com/alxarchambault))
 * [Frank S. Thomas](https://github.com/fthomas) ([@fst9000](https://twitter.com/fst9000))
+* [Jean-Rémi Desjardins](https://github.com/jedesah) ([@jrdesjardins](https://twitter.com/jrdesjardins))
 * [Vladimir Koshelev](https://github.com/koshelev) ([@vlad_koshelev](https://twitter.com/vlad_koshelev))
 * Your name here :-)
 

--- a/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined
 package scalacheck
 
-import eu.timepit.refined.api.RefType
+import eu.timepit.refined.api.{ RefType, Validate }
 import eu.timepit.refined.numeric._
 import org.scalacheck.Gen.Choose
 import org.scalacheck.{ Arbitrary, Gen }
@@ -43,6 +43,18 @@ object numeric {
     implicit val short: Bounded[Short] =
       Bounded(Short.MinValue, Short.MaxValue)
   }
+
+  /**
+   * A generator that generates a random value in the given (inclusive)
+   * range that satisfies the predicate `P`. If the range is invalid,
+   * the generator will not generate any value.
+   */
+  def chooseRefinedNum[F[_, _], T: Numeric: Choose, P](min: F[T, P], max: F[T, P])(
+    implicit
+    rt: RefType[F],
+    v: Validate[T, P]
+  ): Gen[F[T, P]] =
+    Gen.chooseNum(rt.unwrap(min), rt.unwrap(max)).filter(v.isValid).map(rt.unsafeWrap)
 
   ///
 

--- a/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -3,7 +3,6 @@ package scalacheck
 
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.numeric._
-import eu.timepit.refined.boolean.Not
 import org.scalacheck.Gen.Choose
 import org.scalacheck.{ Arbitrary, Gen }
 import shapeless.ops.nat.ToInt
@@ -11,163 +10,158 @@ import shapeless.{ Nat, Witness }
 
 object numeric {
 
-  trait Bounded[T] extends {
+  trait Bounded[T] {
     def minValue: T
     def maxValue: T
   }
 
   object Bounded {
-    def apply[T](min: T, max: T): Bounded[T] = new Bounded[T] {
-      val minValue = min
-      val maxValue = max
-    }
-    implicit val int: Bounded[Int] = Bounded(Int.MinValue, Int.MaxValue)
-    implicit val short: Bounded[Short] = Bounded(Short.MinValue, Short.MaxValue)
-    implicit val long: Bounded[Long] = Bounded(Long.MinValue, Long.MaxValue)
+    def apply[T](min: T, max: T): Bounded[T] =
+      new Bounded[T] {
+        val minValue = min
+        val maxValue = max
+      }
+
+    implicit val byte: Bounded[Byte] =
+      Bounded(Byte.MinValue, Byte.MaxValue)
+
+    implicit val char: Bounded[Char] =
+      Bounded(Char.MinValue, Char.MaxValue)
+
+    implicit val double: Bounded[Double] =
+      Bounded(Double.MinValue, Double.MaxValue)
+
+    implicit val float: Bounded[Float] =
+      Bounded(Float.MinValue, Float.MaxValue)
+
+    implicit val int: Bounded[Int] =
+      Bounded(Int.MinValue, Int.MaxValue)
+
+    implicit val long: Bounded[Long] =
+      Bounded(Long.MinValue, Long.MaxValue)
+
+    implicit val short: Bounded[Short] =
+      Bounded(Short.MinValue, Short.MaxValue)
   }
 
-  implicit def lessArbitrary[F[_, _]: RefType, T: Choose: Numeric: Bounded, N <: T](implicit wn: Witness.Aux[N]): Arbitrary[F[T, Less[N]]] =
-    lessArbitraryImpl(wn.value)
+  ///
 
-  implicit def lessArbitraryNat[F[_, _]: RefType, T: Choose: Bounded, N <: Nat: ToInt](implicit num: Numeric[T]): Arbitrary[F[T, Less[N]]] =
-    lessArbitraryImpl(num.fromInt(Nat.toInt[N]))
-
-  private def lessArbitraryImpl[F[_, _]: RefType, T: Choose, N](value: T)(
+  implicit def lessArbitraryWit[F[_, _]: RefType, T: Numeric: Choose, N <: T](
     implicit
-    num: Numeric[T],
-    bound: Bounded[T]
-  ): Arbitrary[F[T, Less[N]]] = {
-    val gen = Gen.chooseNum(bound.minValue, value).filter(!num.equiv(_, value))
-    arbitraryRefType(gen)
-  }
+    bounded: Bounded[T],
+    wn: Witness.Aux[N]
+  ): Arbitrary[F[T, Less[N]]] =
+    rangeClosedOpenArbitrary(bounded.minValue, wn.value)
 
-  implicit def lessEqualArbitrary[F[_, _]: RefType, T: Choose, N <: T](
+  implicit def lessArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat](
     implicit
-    wn: Witness.Aux[N],
+    bounded: Bounded[T],
     nt: Numeric[T],
-    bound: Bounded[T]
-  ): Arbitrary[F[T, LessEqual[N]]] = {
-    val gen = Gen.chooseNum(bound.minValue, wn.value)
-    arbitraryRefType(gen)
-  }
+    tn: ToInt[N]
+  ): Arbitrary[F[T, Less[N]]] =
+    rangeClosedOpenArbitrary(bounded.minValue, nt.fromInt(tn()))
 
-  implicit def lessEqualArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat: ToInt](
+  implicit def lessEqualArbitraryWit[F[_, _]: RefType, T: Numeric: Choose, N <: T](
     implicit
-    num: Numeric[T],
-    bound: Bounded[T]
-  ): Arbitrary[F[T, LessEqual[N]]] = {
-    val gen = Gen.chooseNum(bound.minValue, num.fromInt(Nat.toInt[N]))
-    arbitraryRefType(gen)
-  }
+    bounded: Bounded[T],
+    wn: Witness.Aux[N]
+  ): Arbitrary[F[T, LessEqual[N]]] =
+    rangeClosedArbitrary(bounded.minValue, wn.value)
 
-  implicit def greaterArbitrary[F[_, _]: RefType, T: Choose: Numeric, N <: T](
+  implicit def lessEqualArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat](
     implicit
-    wn: Witness.Aux[N],
-    bound: Bounded[T]
-  ): Arbitrary[F[T, Greater[N]]] =
-    greaterArbitraryImpl(min = wn.value, max = bound.maxValue)
-
-  implicit def greaterArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat: ToInt](
-    implicit
-    num: Numeric[T],
-    bound: Bounded[T]
-  ): Arbitrary[F[T, Greater[N]]] =
-    greaterArbitraryImpl(min = num.fromInt(Nat.toInt[N]), max = bound.maxValue)
-
-  private def greaterArbitraryImpl[F[_, _]: RefType, T: Choose, N](min: T, max: T)(
-    implicit
-    num: Numeric[T]
-  ): Arbitrary[F[T, Greater[N]]] = {
-    val gen = Gen.chooseNum(min, max).filter(!num.equiv(_, min))
-    arbitraryRefType(gen)
-  }
-
-  def greaterArbitraryRange[F[_, _], T: Choose: Numeric, N <: Nat](min: F[T, Greater[N]], max: F[T, Greater[N]])(
-    implicit
-    rt: RefType[F]
-  ): Arbitrary[F[T, Greater[N]]] =
-    greaterArbitraryImpl(min = rt.unwrap(min), max = rt.unwrap(max))
-
-  def greaterArbitraryMax[F[_, _], T: Choose, N <: Nat: ToInt](max: F[T, Greater[N]])(
-    implicit
-    rt: RefType[F],
-    num: Numeric[T]
-  ): Arbitrary[F[T, Greater[N]]] =
-    greaterArbitraryImpl(min = num.fromInt(Nat.toInt[N]), max = rt.unwrap(max))
-
-  implicit def greaterEqualArbitrary[F[_, _]: RefType, T: Choose, N <: T](
-    implicit
-    wn: Witness.Aux[N],
+    bounded: Bounded[T],
     nt: Numeric[T],
-    bound: Bounded[T]
-  ): Arbitrary[F[T, GreaterEqual[N]]] = {
-    val gen = Gen.chooseNum(wn.value, bound.maxValue)
-    arbitraryRefType(gen)
-  }
+    tn: ToInt[N]
+  ): Arbitrary[F[T, LessEqual[N]]] =
+    rangeClosedArbitrary(bounded.minValue, nt.fromInt(tn()))
 
-  implicit def intervalOpenArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
+  implicit def greaterArbitraryWit[F[_, _]: RefType, T: Numeric: Choose, N <: T](
+    implicit
+    bounded: Bounded[T],
+    wn: Witness.Aux[N]
+  ): Arbitrary[F[T, Greater[N]]] =
+    rangeOpenClosedArbitrary(wn.value, bounded.maxValue)
+
+  implicit def greaterArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat](
+    implicit
+    bounded: Bounded[T],
+    nt: Numeric[T],
+    tn: ToInt[N]
+  ): Arbitrary[F[T, Greater[N]]] =
+    rangeOpenClosedArbitrary(nt.fromInt(tn()), bounded.maxValue)
+
+  implicit def greaterEqualArbitraryWit[F[_, _]: RefType, T: Numeric: Choose, N <: T](
+    implicit
+    bounded: Bounded[T],
+    wn: Witness.Aux[N]
+  ): Arbitrary[F[T, GreaterEqual[N]]] =
+    rangeClosedArbitrary(wn.value, bounded.maxValue)
+
+  implicit def greaterEqualArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat](
+    implicit
+    bounded: Bounded[T],
+    nt: Numeric[T],
+    tn: ToInt[N]
+  ): Arbitrary[F[T, GreaterEqual[N]]] =
+    rangeClosedArbitrary(nt.fromInt(tn()), bounded.maxValue)
+
+  ///
+
+  implicit def intervalOpenArbitrary[F[_, _]: RefType, T: Numeric: Choose, L <: T, H <: T](
     implicit
     wl: Witness.Aux[L],
-    wh: Witness.Aux[H],
-    nt: Numeric[T]
-  ): Arbitrary[F[T, Interval.Open[L, H]]] = {
-    val gen = Gen.chooseNum(wl.value, wh.value).filter(t => nt.gt(t, wl.value) && nt.lt(t, wh.value))
-    arbitraryRefType(gen)
-  }
+    wh: Witness.Aux[H]
+  ): Arbitrary[F[T, Interval.Open[L, H]]] =
+    rangeOpenArbitrary(wl.value, wh.value)
 
-  implicit def intervalOpenClosedArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
+  implicit def intervalOpenClosedArbitrary[F[_, _]: RefType, T: Numeric: Choose, L <: T, H <: T](
     implicit
     wl: Witness.Aux[L],
-    wh: Witness.Aux[H],
-    nt: Numeric[T]
-  ): Arbitrary[F[T, Interval.OpenClosed[L, H]]] = {
-    val gen = Gen.chooseNum(wl.value, wh.value).filter(t => nt.gt(t, wl.value))
-    arbitraryRefType(gen)
-  }
+    wh: Witness.Aux[H]
+  ): Arbitrary[F[T, Interval.OpenClosed[L, H]]] =
+    rangeOpenClosedArbitrary(wl.value, wh.value)
 
-  implicit def intervalClosedOpenArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
+  implicit def intervalClosedOpenArbitrary[F[_, _]: RefType, T: Numeric: Choose, L <: T, H <: T](
     implicit
     wl: Witness.Aux[L],
-    wh: Witness.Aux[H],
-    nt: Numeric[T]
-  ): Arbitrary[F[T, Interval.ClosedOpen[L, H]]] = {
-    val gen = Gen.chooseNum(wl.value, wh.value).filter(t => nt.lt(t, wh.value))
-    arbitraryRefType(gen)
-  }
+    wh: Witness.Aux[H]
+  ): Arbitrary[F[T, Interval.ClosedOpen[L, H]]] =
+    rangeClosedOpenArbitrary(wl.value, wh.value)
 
-  implicit def intervalClosedArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
+  implicit def intervalClosedArbitrary[F[_, _]: RefType, T: Numeric: Choose, L <: T, H <: T](
     implicit
     wl: Witness.Aux[L],
-    wh: Witness.Aux[H],
+    wh: Witness.Aux[H]
+  ): Arbitrary[F[T, Interval.Closed[L, H]]] =
+    rangeClosedArbitrary(wl.value, wh.value)
+
+  ///
+
+  private def rangeOpenArbitrary[F[_, _]: RefType, T: Choose, P](min: T, max: T)(
+    implicit
     nt: Numeric[T]
-  ): Arbitrary[F[T, Interval.Closed[L, H]]] = {
-    val gen = Gen.chooseNum(wl.value, wh.value)
-    arbitraryRefType(gen)
+  ): Arbitrary[F[T, P]] = {
+    import nt.mkOrderingOps
+    arbitraryRefType(Gen.chooseNum(min, max).filter(t => t > min && t < max))
   }
 
-  implicit def notLessArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat: ToInt](
+  private def rangeOpenClosedArbitrary[F[_, _]: RefType, T: Choose, P](min: T, max: T)(
     implicit
-    num: Numeric[T],
-    bound: Bounded[T]
-  ): Arbitrary[F[T, Not[Less[N]]]] = {
-    val gen = Gen.chooseNum(num.fromInt(Nat.toInt[N]), bound.maxValue)
-    arbitraryRefType(gen)
+    nt: Numeric[T]
+  ): Arbitrary[F[T, P]] = {
+    import nt.mkOrderingOps
+    arbitraryRefType(Gen.chooseNum(min, max).filter(_ > min))
   }
 
-  def notLessArbitraryRange[F[_, _], T: Choose: Numeric, N <: Nat: ToInt](min: F[T, Not[Less[N]]], max: F[T, Not[Less[N]]])(
+  private def rangeClosedOpenArbitrary[F[_, _]: RefType, T: Choose, P](min: T, max: T)(
     implicit
-    rt: RefType[F]
-  ): Arbitrary[F[T, Not[Less[N]]]] = {
-    val gen = Gen.chooseNum(rt.unwrap(min), rt.unwrap(max))
-    arbitraryRefType(gen)
+    nt: Numeric[T]
+  ): Arbitrary[F[T, P]] = {
+    import nt.mkOrderingOps
+    arbitraryRefType(Gen.chooseNum(min, max).filter(_ < max))
   }
 
-  def notLessArbitraryMax[F[_, _], T: Choose, N <: Nat: ToInt](max: F[T, Not[Less[N]]])(
-    implicit
-    rt: RefType[F],
-    num: Numeric[T]
-  ): Arbitrary[F[T, Not[Less[N]]]] = {
-    val gen = Gen.chooseNum(num.fromInt(Nat.toInt[N]), rt.unwrap(max))
-    arbitraryRefType(gen)
-  }
+  private def rangeClosedArbitrary[F[_, _]: RefType, T: Numeric: Choose, P](min: T, max: T): Arbitrary[F[T, P]] =
+    arbitraryRefType(Gen.chooseNum(min, max))
 }

--- a/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -3,92 +3,171 @@ package scalacheck
 
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.numeric._
+import eu.timepit.refined.boolean.Not
+import org.scalacheck.Gen.Choose
 import org.scalacheck.{ Arbitrary, Gen }
-import shapeless.Witness
+import shapeless.ops.nat.ToInt
+import shapeless.{ Nat, Witness }
 
 object numeric {
 
-  implicit def lessArbitrary[F[_, _], T, N <: T](
+  trait Bounded[T] extends {
+    def minValue: T
+    def maxValue: T
+  }
+
+  object Bounded {
+    def apply[T](min: T, max: T): Bounded[T] = new Bounded[T] {
+      val minValue = min
+      val maxValue = max
+    }
+    implicit val int: Bounded[Int] = Bounded(Int.MinValue, Int.MaxValue)
+    implicit val short: Bounded[Short] = Bounded(Short.MinValue, Short.MaxValue)
+    implicit val long: Bounded[Long] = Bounded(Long.MinValue, Long.MaxValue)
+  }
+
+  implicit def lessArbitrary[F[_, _]: RefType, T: Choose: Numeric: Bounded, N <: T](implicit wn: Witness.Aux[N]): Arbitrary[F[T, Less[N]]] =
+    lessArbitraryImpl(wn.value)
+
+  implicit def lessArbitraryNat[F[_, _]: RefType, T: Choose: Bounded, N <: Nat: ToInt](implicit num: Numeric[T]): Arbitrary[F[T, Less[N]]] =
+    lessArbitraryImpl(num.fromInt(Nat.toInt[N]))
+
+  private def lessArbitraryImpl[F[_, _]: RefType, T: Choose, N](value: T)(
     implicit
-    rt: RefType[F],
-    wn: Witness.Aux[N],
-    nt: Numeric[T],
-    c: Gen.Choose[T]
+    num: Numeric[T],
+    bound: Bounded[T]
   ): Arbitrary[F[T, Less[N]]] = {
-    val gen = Gen.chooseNum(nt.fromInt(Int.MinValue), wn.value).filter(nt.lt(_, wn.value))
+    val gen = Gen.chooseNum(bound.minValue, value).filter(!num.equiv(_, value))
     arbitraryRefType(gen)
   }
 
-  implicit def lessEqualArbitrary[F[_, _], T, N <: T](
+  implicit def lessEqualArbitrary[F[_, _]: RefType, T: Choose, N <: T](
     implicit
-    rt: RefType[F],
     wn: Witness.Aux[N],
     nt: Numeric[T],
-    c: Gen.Choose[T]
+    bound: Bounded[T]
   ): Arbitrary[F[T, LessEqual[N]]] = {
-    val gen = Gen.chooseNum(nt.fromInt(Int.MinValue), wn.value)
+    val gen = Gen.chooseNum(bound.minValue, wn.value)
     arbitraryRefType(gen)
   }
 
-  implicit def greaterArbitrary[F[_, _], T, N <: T](
+  implicit def lessEqualArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat: ToInt](
     implicit
-    rt: RefType[F],
+    num: Numeric[T],
+    bound: Bounded[T]
+  ): Arbitrary[F[T, LessEqual[N]]] = {
+    val gen = Gen.chooseNum(bound.minValue, num.fromInt(Nat.toInt[N]))
+    arbitraryRefType(gen)
+  }
+
+  implicit def greaterArbitrary[F[_, _]: RefType, T: Choose: Numeric, N <: T](
+    implicit
     wn: Witness.Aux[N],
-    nt: Numeric[T],
-    c: Gen.Choose[T]
+    bound: Bounded[T]
+  ): Arbitrary[F[T, Greater[N]]] =
+    greaterArbitraryImpl(min = wn.value, max = bound.maxValue)
+
+  implicit def greaterArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat: ToInt](
+    implicit
+    num: Numeric[T],
+    bound: Bounded[T]
+  ): Arbitrary[F[T, Greater[N]]] =
+    greaterArbitraryImpl(min = num.fromInt(Nat.toInt[N]), max = bound.maxValue)
+
+  private def greaterArbitraryImpl[F[_, _]: RefType, T: Choose, N](min: T, max: T)(
+    implicit
+    num: Numeric[T]
   ): Arbitrary[F[T, Greater[N]]] = {
-    val gen = Gen.chooseNum(wn.value, nt.fromInt(Int.MaxValue)).filter(nt.gt(_, wn.value))
+    val gen = Gen.chooseNum(min, max).filter(!num.equiv(_, min))
     arbitraryRefType(gen)
   }
 
-  implicit def greaterEqualArbitrary[F[_, _], T, N <: T](
+  def greaterArbitraryRange[F[_, _], T: Choose: Numeric, N <: Nat](min: F[T, Greater[N]], max: F[T, Greater[N]])(
+    implicit
+    rt: RefType[F]
+  ): Arbitrary[F[T, Greater[N]]] =
+    greaterArbitraryImpl(min = rt.unwrap(min), max = rt.unwrap(max))
+
+  def greaterArbitraryMax[F[_, _], T: Choose, N <: Nat: ToInt](max: F[T, Greater[N]])(
     implicit
     rt: RefType[F],
+    num: Numeric[T]
+  ): Arbitrary[F[T, Greater[N]]] =
+    greaterArbitraryImpl(min = num.fromInt(Nat.toInt[N]), max = rt.unwrap(max))
+
+  implicit def greaterEqualArbitrary[F[_, _]: RefType, T: Choose, N <: T](
+    implicit
     wn: Witness.Aux[N],
     nt: Numeric[T],
-    c: Gen.Choose[T]
+    bound: Bounded[T]
   ): Arbitrary[F[T, GreaterEqual[N]]] = {
-    val gen = Gen.chooseNum(wn.value, nt.fromInt(Int.MaxValue))
+    val gen = Gen.chooseNum(wn.value, bound.maxValue)
     arbitraryRefType(gen)
   }
 
-  implicit def intervalOpenArbitrary[F[_, _], T, L <: T, H <: T](
+  implicit def intervalOpenArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
     implicit
-    rt: RefType[F],
     wl: Witness.Aux[L],
     wh: Witness.Aux[H],
-    nt: Numeric[T],
-    c: Gen.Choose[T]
-  ): Arbitrary[F[T, Interval.Open[L, H]]] =
-    arbitraryRefType(Gen.chooseNum(wl.value, wh.value).filter(t => nt.gt(t, wl.value) && nt.lt(t, wh.value)))
+    nt: Numeric[T]
+  ): Arbitrary[F[T, Interval.Open[L, H]]] = {
+    val gen = Gen.chooseNum(wl.value, wh.value).filter(t => nt.gt(t, wl.value) && nt.lt(t, wh.value))
+    arbitraryRefType(gen)
+  }
 
-  implicit def intervalOpenClosedArbitrary[F[_, _], T, L <: T, H <: T](
+  implicit def intervalOpenClosedArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
     implicit
-    rt: RefType[F],
     wl: Witness.Aux[L],
     wh: Witness.Aux[H],
-    nt: Numeric[T],
-    c: Gen.Choose[T]
-  ): Arbitrary[F[T, Interval.OpenClosed[L, H]]] =
-    arbitraryRefType(Gen.chooseNum(wl.value, wh.value).filter(t => nt.gt(t, wl.value)))
+    nt: Numeric[T]
+  ): Arbitrary[F[T, Interval.OpenClosed[L, H]]] = {
+    val gen = Gen.chooseNum(wl.value, wh.value).filter(t => nt.gt(t, wl.value))
+    arbitraryRefType(gen)
+  }
 
-  implicit def intervalClosedOpenArbitrary[F[_, _], T, L <: T, H <: T](
+  implicit def intervalClosedOpenArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
     implicit
-    rt: RefType[F],
     wl: Witness.Aux[L],
     wh: Witness.Aux[H],
-    nt: Numeric[T],
-    c: Gen.Choose[T]
-  ): Arbitrary[F[T, Interval.ClosedOpen[L, H]]] =
-    arbitraryRefType(Gen.chooseNum(wl.value, wh.value).filter(t => nt.lt(t, wh.value)))
+    nt: Numeric[T]
+  ): Arbitrary[F[T, Interval.ClosedOpen[L, H]]] = {
+    val gen = Gen.chooseNum(wl.value, wh.value).filter(t => nt.lt(t, wh.value))
+    arbitraryRefType(gen)
+  }
 
-  implicit def intervalClosedArbitrary[F[_, _], T, L <: T, H <: T](
+  implicit def intervalClosedArbitrary[F[_, _]: RefType, T: Choose, L <: T, H <: T](
     implicit
-    rt: RefType[F],
     wl: Witness.Aux[L],
     wh: Witness.Aux[H],
-    nt: Numeric[T],
-    c: Gen.Choose[T]
-  ): Arbitrary[F[T, Interval.Closed[L, H]]] =
-    arbitraryRefType(Gen.chooseNum(wl.value, wh.value))
+    nt: Numeric[T]
+  ): Arbitrary[F[T, Interval.Closed[L, H]]] = {
+    val gen = Gen.chooseNum(wl.value, wh.value)
+    arbitraryRefType(gen)
+  }
+
+  implicit def notLessArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat: ToInt](
+    implicit
+    num: Numeric[T],
+    bound: Bounded[T]
+  ): Arbitrary[F[T, Not[Less[N]]]] = {
+    val gen = Gen.chooseNum(num.fromInt(Nat.toInt[N]), bound.maxValue)
+    arbitraryRefType(gen)
+  }
+
+  def notLessArbitraryRange[F[_, _], T: Choose: Numeric, N <: Nat: ToInt](min: F[T, Not[Less[N]]], max: F[T, Not[Less[N]]])(
+    implicit
+    rt: RefType[F]
+  ): Arbitrary[F[T, Not[Less[N]]]] = {
+    val gen = Gen.chooseNum(rt.unwrap(min), rt.unwrap(max))
+    arbitraryRefType(gen)
+  }
+
+  def notLessArbitraryMax[F[_, _], T: Choose, N <: Nat: ToInt](max: F[T, Not[Less[N]]])(
+    implicit
+    rt: RefType[F],
+    num: Numeric[T]
+  ): Arbitrary[F[T, Not[Less[N]]]] = {
+    val gen = Gen.chooseNum(num.fromInt(Nat.toInt[N]), rt.unwrap(max))
+    arbitraryRefType(gen)
+  }
 }

--- a/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -1,16 +1,14 @@
 package eu.timepit.refined
 package scalacheck
 
-import eu.timepit.refined.api.{ RefType, Validate, Refined }
+import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
-import eu.timepit.refined.boolean.Not
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.util.time.Minute
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-
-import shapeless.Nat
+import shapeless.nat._
 
 class NumericArbitrarySpec extends Properties("NumericArbitrary") {
 
@@ -20,8 +18,8 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("Less.negative") =
     checkArbitraryRefType[Refined, Int, Less[W.`-100`.T]]
 
-  property("Less.natural") =
-    checkArbitraryRefType[Refined, Long, Less[Nat._10]]
+  property("Less.Nat") =
+    checkArbitraryRefType[Refined, Long, Less[_10]]
 
   property("LessEqual.positive") =
     checkArbitraryRefType[Refined, Int, LessEqual[W.`42`.T]]
@@ -29,8 +27,8 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("LessEqual.negative") =
     checkArbitraryRefType[Refined, Int, LessEqual[W.`-42`.T]]
 
-  property("LessEqual.natural") =
-    checkArbitraryRefType[Refined, Long, LessEqual[Nat._10]]
+  property("LessEqual.Nat") =
+    checkArbitraryRefType[Refined, Long, LessEqual[_10]]
 
   property("Greater.positive") =
     checkArbitraryRefType[Refined, Int, Greater[W.`100`.T]]
@@ -38,17 +36,8 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("Greater.negative") =
     checkArbitraryRefType[Refined, Int, Greater[W.`-100`.T]]
 
-  property("Greater.natural") =
-    checkArbitraryRefType[Refined, Long, Greater[Nat._10]]
-
-  property("Greater range") =
-    forAll { (min: Refined[Long, Greater[Nat._10]], max: Refined[Long, Greater[Nat._10]]) =>
-      checkArbitraryRefType[Refined, Long, Greater[Nat._10]](
-        greaterArbitraryRange[Refined, Long, Nat._10](min, max),
-        implicitly[RefType[Refined]],
-        Validate.fromPredicate((t: Long) => true, (t: Long) => t.toString, Greater[Nat._10](Nat(10)))
-      )
-    }
+  property("Greater.Nat") =
+    checkArbitraryRefType[Refined, Long, Greater[_10]]
 
   property("GreaterEqual.positive") =
     checkArbitraryRefType[Refined, Int, GreaterEqual[W.`123456`.T]]
@@ -56,8 +45,20 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("GreaterEqual.negative") =
     checkArbitraryRefType[Refined, Int, GreaterEqual[W.`-123456`.T]]
 
-  property("NotLess.natural") =
-    checkArbitraryRefType[Refined, Long, Not[Less[Nat._10]]]
+  property("GreaterEqual.Nat") =
+    checkArbitraryRefType[Refined, Int, GreaterEqual[_10]]
+
+  property("Positive") =
+    checkArbitraryRefType[Refined, Float, Positive]
+
+  property("NonPositive") =
+    checkArbitraryRefType[Refined, Short, NonPositive]
+
+  property("Negative") =
+    checkArbitraryRefType[Refined, Double, Negative]
+
+  property("NonNegative") =
+    checkArbitraryRefType[Refined, Long, NonNegative]
 
   property("Interval.Open") =
     checkArbitraryRefType[Refined, Int, Interval.Open[W.`-23`.T, W.`42`.T]]

--- a/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -1,13 +1,16 @@
 package eu.timepit.refined
 package scalacheck
 
-import eu.timepit.refined.api.Refined
+import eu.timepit.refined.api.{ RefType, Validate, Refined }
 import eu.timepit.refined.auto._
+import eu.timepit.refined.boolean.Not
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.util.time.Minute
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
+
+import shapeless.Nat
 
 class NumericArbitrarySpec extends Properties("NumericArbitrary") {
 
@@ -17,11 +20,17 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("Less.negative") =
     checkArbitraryRefType[Refined, Int, Less[W.`-100`.T]]
 
+  property("Less.natural") =
+    checkArbitraryRefType[Refined, Long, Less[Nat._10]]
+
   property("LessEqual.positive") =
     checkArbitraryRefType[Refined, Int, LessEqual[W.`42`.T]]
 
   property("LessEqual.negative") =
     checkArbitraryRefType[Refined, Int, LessEqual[W.`-42`.T]]
+
+  property("LessEqual.natural") =
+    checkArbitraryRefType[Refined, Long, LessEqual[Nat._10]]
 
   property("Greater.positive") =
     checkArbitraryRefType[Refined, Int, Greater[W.`100`.T]]
@@ -29,11 +38,26 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("Greater.negative") =
     checkArbitraryRefType[Refined, Int, Greater[W.`-100`.T]]
 
+  property("Greater.natural") =
+    checkArbitraryRefType[Refined, Long, Greater[Nat._10]]
+
+  property("Greater range") =
+    forAll { (min: Refined[Long, Greater[Nat._10]], max: Refined[Long, Greater[Nat._10]]) =>
+      checkArbitraryRefType[Refined, Long, Greater[Nat._10]](
+        greaterArbitraryRange[Refined, Long, Nat._10](min, max),
+        implicitly[RefType[Refined]],
+        Validate.fromPredicate((t: Long) => true, (t: Long) => t.toString, Greater[Nat._10](Nat(10)))
+      )
+    }
+
   property("GreaterEqual.positive") =
     checkArbitraryRefType[Refined, Int, GreaterEqual[W.`123456`.T]]
 
   property("GreaterEqual.negative") =
     checkArbitraryRefType[Refined, Int, GreaterEqual[W.`-123456`.T]]
+
+  property("NotLess.natural") =
+    checkArbitraryRefType[Refined, Long, Not[Less[Nat._10]]]
 
   property("Interval.Open") =
     checkArbitraryRefType[Refined, Int, Interval.Open[W.`-23`.T, W.`42`.T]]

--- a/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -74,4 +74,11 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
 
   property("Interval.alias") =
     forAll { m: Minute => m >= 0 && m <= 59 }
+
+  property("chooseRefinedNum") = {
+    type Natural = Int Refined NonNegative
+    forAll(chooseRefinedNum(23: Natural, 42: Natural)) { n =>
+      n >= 23 && n <= 42
+    }
+  }
 }

--- a/notes/0.3.3.markdown
+++ b/notes/0.3.3.markdown
@@ -1,9 +1,14 @@
 ### Changes
 
+* Add `Arbitrary` instances for numeric predicates indexed by `Nat`s and
+  improve the implementation of the other numeric `Arbitrary` instances.
+  Thanks to Jean-Rémi Desjardins! ([#106], [#109])
 * Add the `RefType.refineMF` macro which requires that the base type must
   be specified and cannot be inferred from its argument. This allows to
   define aliases for the `RefineM` macro where the base type and
   predicate are fixed. ([#107])
 * Update `refined-scalaz` to Scalaz 7.2.0
 
+[#106]: https://github.com/fthomas/refined/pull/106
 [#107]: https://github.com/fthomas/refined/issues/107
+[#109]: https://github.com/fthomas/refined/pull/109


### PR DESCRIPTION
This expands on #106 by using four helper functions to implement all numeric `Arbitrary` instances independent of the predicates being indexed by literal singleton types or `Nat`s. I think that is the best we can do to avoid duplication in those definitions.

Thanks to @jedesah for the initial implementation!

@jedesah I hope you don't mind moving this forward. I think it is in your interest to get this and #108 released ASAP.