### PR TITLE
Remove macro code from RefType

### DIFF
--- a/contrib/scalaz/src/main/scala/eu/timepit/refined/scalaz/package.scala
+++ b/contrib/scalaz/src/main/scala/eu/timepit/refined/scalaz/package.scala
@@ -2,7 +2,6 @@ package eu.timepit.refined
 
 import _root_.scalaz.@@
 import eu.timepit.refined.api.RefType
-import scala.reflect.macros.blackbox
 
 package object scalaz {
 
@@ -14,10 +13,7 @@ package object scalaz {
       override def unwrap[T, P](tp: T @@ P): T =
         tp.asInstanceOf[T]
 
-      override def unsafeWrapM[T: c.WeakTypeTag, P: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[T]): c.Expr[T @@ P] =
-        c.universe.reify(t.splice.asInstanceOf[T @@ P])
-
-      override def unsafeRewrapM[T: c.WeakTypeTag, A: c.WeakTypeTag, B: c.WeakTypeTag](c: blackbox.Context)(ta: c.Expr[T @@ A]): c.Expr[T @@ B] =
-        c.universe.reify(ta.splice.asInstanceOf[T @@ B])
+      override def unsafeRewrap[T, A, B](ta: T @@ A): T @@ B =
+        ta.asInstanceOf[T @@ B]
     }
 }

--- a/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
@@ -21,7 +21,6 @@ class InferMacro(val c: blackbox.Context) extends MacroUtils {
       abort(Resources.invalidInference(weakTypeOf[A].toString, weakTypeOf[B].toString))
     }
 
-    val refType = eval(rt)
-    refType.unsafeRewrapM(c)(ta)
+    reify(rt.splice.unsafeRewrap(ta.splice))
   }
 }

--- a/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -28,7 +28,6 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
       abort(validate.showResult(tValue, res))
     }
 
-    val refType = eval(rt)
-    refType.unsafeWrapM(c)(t)
+    reify(rt.splice.unsafeWrap(t.splice))
   }
 }

--- a/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -21,6 +21,15 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F]) exten
     rt.unsafeWrap(s).unwrap == s
   }
 
+  property("unsafeRewrap.unsafeRewrap ~= id") = forAll { (c: Char) =>
+    trait A
+    trait B
+    val c1: F[Char, A] = rt.unsafeWrap(c)
+    val c2: F[Char, B] = rt.unsafeRewrap(c1)
+    val c3: F[Char, A] = rt.unsafeRewrap(c2)
+    c1 == c3
+  }
+
   property("RefinePartiallyApplied instance") = secure {
     val pa = rt.refine[Digit]
     pa('0').isRight

--- a/notes/0.3.4.markdown
+++ b/notes/0.3.4.markdown
@@ -2,5 +2,8 @@
 
 * Improve the compiler error message of invalid type inference of
   refined types. ([#117])
+* Remove macro code from `RefType` and do not eval `RefType` instances
+  during macro expansion.
 
 [#117]: https://github.com/fthomas/refined/pull/117
+[#120]: https://github.com/fthomas/refined/pull/120


### PR DESCRIPTION
This has the advantage that we don't need to eval `RefType` instances during macro expansion which is somewhat error prone (see #3).