### PR TITLE
Reorder implicits parameters in macros

### DIFF
--- a/contrib/scalaz/src/main/scala/eu/timepit/refined/scalaz/auto.scala
+++ b/contrib/scalaz/src/main/scala/eu/timepit/refined/scalaz/auto.scala
@@ -13,6 +13,6 @@ object auto {
    */
   implicit def autoRefineScalazTag[T, P](t: T)(
     implicit
-    v: Validate[T, P], rt: RefType[@@]
+    rt: RefType[@@], v: Validate[T, P]
   ): T @@ P = macro RefineMacro.impl[@@, T, P]
 }

--- a/core/shared/src/main/scala/eu/timepit/refined/auto.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/auto.scala
@@ -14,7 +14,7 @@ trait auto {
    */
   implicit def autoInfer[F[_, _], T, A, B](ta: F[T, A])(
     implicit
-    ir: A ==> B, rt: RefType[F]
+    rt: RefType[F], ir: A ==> B
   ): F[T, B] = macro InferMacro.impl[F, T, A, B]
 
   /**
@@ -37,7 +37,7 @@ trait auto {
    */
   implicit def autoRefineV[T, P](t: T)(
     implicit
-    v: Validate[T, P], rt: RefType[Refined]
+    rt: RefType[Refined], v: Validate[T, P]
   ): Refined[T, P] = macro RefineMacro.impl[Refined, T, P]
 
   /**
@@ -49,7 +49,7 @@ trait auto {
    */
   implicit def autoRefineT[T, P](t: T)(
     implicit
-    v: Validate[T, P], rt: RefType[@@]
+    rt: RefType[@@], v: Validate[T, P]
   ): T @@ P = macro RefineMacro.impl[@@, T, P]
 }
 

--- a/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
@@ -6,5 +6,5 @@ import eu.timepit.refined.macros.RefineMacro
 
 final class RefineMFullyApplied[F[_, _], T, P] {
 
-  def apply(t: T)(implicit v: Validate[T, P], rt: RefType[F]): F[T, P] = macro RefineMacro.impl[F, T, P]
+  def apply(t: T)(implicit rt: RefType[F], v: Validate[T, P]): F[T, P] = macro RefineMacro.impl[F, T, P]
 }

--- a/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMPartiallyApplied.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMPartiallyApplied.scala
@@ -13,5 +13,5 @@ import eu.timepit.refined.macros.RefineMacro
  */
 final class RefineMPartiallyApplied[F[_, _], P] {
 
-  def apply[T](t: T)(implicit v: Validate[T, P], rt: RefType[F]): F[T, P] = macro RefineMacro.impl[F, T, P]
+  def apply[T](t: T)(implicit rt: RefType[F], v: Validate[T, P]): F[T, P] = macro RefineMacro.impl[F, T, P]
 }

--- a/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
@@ -12,7 +12,7 @@ class InferMacro(val c: blackbox.Context) extends MacroUtils {
   import c.universe._
 
   def impl[F[_, _], T, A: c.WeakTypeTag, B: c.WeakTypeTag](ta: c.Expr[F[T, A]])(
-    ir: c.Expr[A ==> B], rt: c.Expr[RefType[F]]
+    rt: c.Expr[RefType[F]], ir: c.Expr[A ==> B]
   ): c.Expr[F[T, B]] = {
 
     val inference = eval(ir)

--- a/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -11,7 +11,7 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
   import c.universe._
 
   def impl[F[_, _], T, P](t: c.Expr[T])(
-    v: c.Expr[Validate[T, P]], rt: c.Expr[RefType[F]]
+    rt: c.Expr[RefType[F]], v: c.Expr[Validate[T, P]]
   ): c.Expr[F[T, P]] = {
 
     val validate = eval(v)


### PR DESCRIPTION
The standard in the code base is that an implicit RefType comes always
before a Validate or Inference parameter.