### PR TITLE
Add Adjacent type class

### DIFF
--- a/contrib/scalacheck/jvm/src/test/scala/eu/timepit/refined/scalacheck/util/OurMathSpec.scala
+++ b/contrib/scalacheck/jvm/src/test/scala/eu/timepit/refined/scalacheck/util/OurMathSpec.scala
@@ -1,0 +1,11 @@
+package eu.timepit.refined.scalacheck.util
+
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class OurMathSpec extends Properties("OurMath") {
+
+  property("OurMath.nextAfter == Math.nextAfter") = forAll { (start: Float, direction: Double) =>
+    OurMath.nextAfter(start, direction) ?= Math.nextAfter(start, direction)
+  }
+}

--- a/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Adjacent.scala
+++ b/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Adjacent.scala
@@ -1,0 +1,47 @@
+package eu.timepit.refined.scalacheck.util
+
+trait Adjacent[T] {
+  def nextUp(t: T): Option[T]
+
+  def nextDown(t: T): Option[T]
+
+  def nextUpOrSelf(t: T): T =
+    nextUp(t).getOrElse(t)
+
+  def nextDownOrSelf(t: T): T =
+    nextDown(t).getOrElse(t)
+}
+
+object Adjacent {
+  def apply[T](implicit a: Adjacent[T]): Adjacent[T] = a
+
+  def instance[T](nextUpF: T => Option[T], nextDownF: T => Option[T]): Adjacent[T] =
+    new Adjacent[T] {
+      override def nextUp(t: T): Option[T] = nextUpF(t)
+      override def nextDown(t: T): Option[T] = nextDownF(t)
+    }
+
+  implicit val doubleAdjacent: Adjacent[Double] =
+    instance(
+      t => firstIfGt(Math.nextAfter(t, Double.PositiveInfinity), t),
+      t => firstIfLt(Math.nextAfter(t, Double.NegativeInfinity), t)
+    )
+
+  implicit val floatAdjacent: Adjacent[Float] =
+    instance(
+      t => firstIfGt(OurMath.nextAfter(t, Float.PositiveInfinity), t),
+      t => firstIfLt(OurMath.nextAfter(t, Float.NegativeInfinity), t)
+    )
+
+  implicit def numericAdjacent[T](implicit nt: Numeric[T]): Adjacent[T] =
+    instance(
+      t => firstIfGt(nt.plus(t, nt.one), t),
+      t => firstIfLt(nt.minus(t, nt.one), t)
+    )
+
+  private def firstIfGt[T](x: T, y: T)(implicit nt: Numeric[T]): Option[T] =
+    if (nt.gt(x, y)) Some(x) else None
+
+  private def firstIfLt[T](x: T, y: T)(implicit nt: Numeric[T]): Option[T] =
+    if (nt.lt(x, y)) Some(x) else None
+}

--- a/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Bounded.scala
+++ b/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Bounded.scala
@@ -1,0 +1,37 @@
+package eu.timepit.refined.scalacheck.util
+
+trait Bounded[T] {
+  def minValue: T
+  def maxValue: T
+}
+
+object Bounded {
+  def apply[T](implicit b: Bounded[T]): Bounded[T] = b
+
+  def instance[T](min: T, max: T): Bounded[T] =
+    new Bounded[T] {
+      val minValue = min
+      val maxValue = max
+    }
+
+  implicit val byte: Bounded[Byte] =
+    instance(Byte.MinValue, Byte.MaxValue)
+
+  implicit val char: Bounded[Char] =
+    instance(Char.MinValue, Char.MaxValue)
+
+  implicit val double: Bounded[Double] =
+    instance(Double.MinValue, Double.MaxValue)
+
+  implicit val float: Bounded[Float] =
+    instance(Float.MinValue, Float.MaxValue)
+
+  implicit val int: Bounded[Int] =
+    instance(Int.MinValue, Int.MaxValue)
+
+  implicit val long: Bounded[Long] =
+    instance(Long.MinValue, Long.MaxValue)
+
+  implicit val short: Bounded[Short] =
+    instance(Short.MinValue, Short.MaxValue)
+}

--- a/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/OurMath.scala
+++ b/contrib/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/OurMath.scala
@@ -1,0 +1,41 @@
+package eu.timepit.refined.scalacheck.util
+
+import java.lang.{ Double => JDouble }
+import java.lang.{ Float => JFloat }
+
+// Delete this when Scala.js provides def nextAfter(a: Float, b: Double): Float
+object OurMath {
+  // scalastyle:off
+  def nextAfter(start: Float, direction: Double): Float = {
+
+    def incrBits = JFloat.intBitsToFloat(JFloat.floatToIntBits(start) + 1)
+    def decrBits = JFloat.intBitsToFloat(JFloat.floatToIntBits(start) - 1)
+
+    if (JFloat.isNaN(start) || JDouble.isNaN(direction)) {
+      Float.NaN
+    } else if (start == 0.0F && direction == 0.0) {
+      direction.toFloat
+    } else if (start == Float.NegativeInfinity && direction > start) {
+      Float.MinValue
+    } else if (start == Float.PositiveInfinity && direction < start) {
+      Float.MaxValue
+    } else if (start == Float.MinPositiveValue && direction < start) {
+      0.0F
+    } else if (start == -Float.MinPositiveValue && direction > start) {
+      -0.0F
+    } else if (start == Float.MaxValue && direction > start) {
+      Float.PositiveInfinity
+    } else if (start == Float.MinValue && direction < start) {
+      Float.NegativeInfinity
+    } else {
+      if (direction > start) {
+        if (start > 0) incrBits else if (start < 0) decrBits else Float.MinPositiveValue
+      } else if (direction < start) {
+        if (start > 0) decrBits else if (start < 0) incrBits else -Float.MinPositiveValue
+      } else {
+        direction.toFloat
+      }
+    }
+  }
+  // scalastyle:on
+}

--- a/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -63,11 +63,20 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("Interval.Open") =
     checkArbitraryRefType[Refined, Int, Interval.Open[W.`-23`.T, W.`42`.T]]
 
+  property("Interval.Open (0.554, 0.556)") =
+    checkArbitraryRefType[Refined, Double, Interval.Open[W.`0.554`.T, W.`0.556`.T]]
+
   property("Interval.OpenClosed") =
     checkArbitraryRefType[Refined, Double, Interval.OpenClosed[W.`2.71828`.T, W.`3.14159`.T]]
 
+  property("Interval.OpenClosed (0.54, 0.56]") =
+    checkArbitraryRefType[Refined, Float, Interval.OpenClosed[W.`0.54F`.T, W.`0.56F`.T]]
+
   property("Interval.ClosedOpen") =
     checkArbitraryRefType[Refined, Double, Interval.ClosedOpen[W.`-2.71828`.T, W.`3.14159`.T]]
+
+  property("Interval.ClosedOpen [0.4, 0.6)") =
+    checkArbitraryRefType[Refined, Float, Interval.ClosedOpen[W.`0.4F`.T, W.`0.6F`.T]]
 
   property("Interval.Closed") =
     checkArbitraryRefType[Refined, Int, Interval.Closed[W.`23`.T, W.`42`.T]]

--- a/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/util/AdjacentSpec.scala
+++ b/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/util/AdjacentSpec.scala
@@ -1,0 +1,23 @@
+package eu.timepit.refined.scalacheck.util
+
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class AdjacentSpec extends Properties("Adjacent") {
+
+  property("nextUpOrSelf Char") = forAll { (c: Char) =>
+    Adjacent[Char].nextUpOrSelf(c) >= c
+  }
+
+  property("nextUpOrSelf Double") = forAll { (d: Double) =>
+    Adjacent[Double].nextUpOrSelf(d) >= d
+  }
+
+  property("nextDownOrSelf Float") = forAll { (f: Float) =>
+    Adjacent[Float].nextDownOrSelf(f) <= f
+  }
+
+  property("nextDownOrSelf Long") = forAll { (l: Long) =>
+    Adjacent[Long].nextDownOrSelf(l) <= l
+  }
+}

--- a/notes/0.3.7.markdown
+++ b/notes/0.3.7.markdown
@@ -3,6 +3,10 @@
 * Update to Scala 2.11.8. ([#134])
 * Update `refined-scalaz` to Scalaz 7.2.1 and build it for Scala.js.
   ([#133])
+* Add an `Adjacent` type class to `refined-scalacheck` to make the
+  numeric `Arbitrary` instances more robust. This type class allows
+  to get rid of `filter` calls in the numeric generators.
 
 [#133]: https://github.com/fthomas/refined/pull/133
 [#134]: https://github.com/fthomas/refined/pull/134
+[#135]: https://github.com/fthomas/refined/pull/135


### PR DESCRIPTION
This adds an `Adjacent` type class to `refined-scalacheck` to make the numeric `Arbitrary` instances more robust. The type class allows to get rid of `filter` calls in the numeric generators.
