### PR TITLE
Fix return type of ApplyRefPartiallyApplied.apply

### DIFF
--- a/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
@@ -109,7 +109,7 @@ object RefType {
    *      | import eu.timepit.refined.numeric._
    *
    * scala> RefType.applyRef[Int Refined Positive](10)
-   * res1: Either[String, Refined[Int, Positive]] = Right(Refined(10))
+   * res1: Either[String, Int Refined Positive] = Right(Refined(10))
    * }}}
    *
    * Note: The return type is `[[internal.ApplyRefPartiallyApplied]][FTP]`,

--- a/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefPartiallyApplied.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefPartiallyApplied.scala
@@ -14,7 +14,7 @@ final class ApplyRefPartiallyApplied[FTP] {
 
   def apply[F[_, _], T, P](t: T)(
     implicit
-    ev: FTP =:= F[T, P], rt: RefType[F], v: Validate[T, P]
-  ): Either[String, F[T, P]] =
-    rt.refine[P](t)
+    ev: F[T, P] =:= FTP, rt: RefType[F], v: Validate[T, P]
+  ): Either[String, FTP] =
+    rt.refine[P](t).right.map(ev)
 }

--- a/notes/0.3.8.markdown
+++ b/notes/0.3.8.markdown
@@ -1,5 +1,7 @@
 ### Changes
 
+* Fix the return type of `RefType.applyRef`. ([#137])
 * Update to Scala.js 0.6.8. ([#136])
 
 [#136]: https://github.com/fthomas/refined/pull/136
+[#137]: https://github.com/fthomas/refined/pull/137


### PR DESCRIPTION
This changes the return type of `ApplyRefPartiallyApplied.apply`
such that `res0` in the following example contains `Natural`:

```scala
scala> type Natural = Long Refined NonNegative
defined type alias Natural

scala> RefType.applyRef[Natural](4L)
res0: Either[String,Natural] = Right(Refined(4))
```

Without this change, we get:
```scala
scala> RefType.applyRef[Natural](4L)
res0: Either[String,Long Refined NonNegative] = Right(Refined(4))
```