### PR TITLE
Add RefType.applyRefM

### DIFF
--- a/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
@@ -119,6 +119,28 @@ object RefType {
   def applyRef[FTP]: ApplyRefPartiallyApplied[FTP] =
     new ApplyRefPartiallyApplied
 
+  /**
+   * Macro that returns a value of type `T` refined as `FTP` if  it
+   * satisfies the predicate in `FTP`, or fails to compile otherwise.
+   *
+   * Example: {{{
+   * scala> import eu.timepit.refined.api._
+   *      | import eu.timepit.refined.numeric._
+   *
+   * scala> type PosInt = Int Refined Positive
+   * scala> RefType.applyRefM[PosInt](10)
+   * res1: PosInt = Refined(10)
+   * }}}
+   *
+   * Note: `M` stands for '''m'''acro.
+   *
+   * Note: The return type is `[[internal.ApplyRefMPartiallyApplied]][FTP]`,
+   * which has an `apply` method on it, allowing `applyRefM` to be called
+   * like in the given example.
+   */
+  def applyRefM[FTP]: ApplyRefMPartiallyApplied[FTP] =
+    new ApplyRefMPartiallyApplied
+
   implicit val refinedRefType: RefType[Refined] =
     new RefType[Refined] {
       override def unsafeWrap[T, P](t: T): Refined[T, P] =

--- a/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefMPartiallyApplied.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefMPartiallyApplied.scala
@@ -1,0 +1,19 @@
+package eu.timepit.refined
+package internal
+
+import eu.timepit.refined.api.{ RefType, Validate }
+
+/**
+ * Helper class that allows the types `F`, `T`, and `P` to be inferred
+ * from calls like `[[api.RefType.applyRefM]][F[T, P]](t)`.
+ *
+ * See [[http://tpolecat.github.io/2015/07/30/infer.html]] for a detailed
+ * explanation of this trick.
+ */
+final class ApplyRefMPartiallyApplied[FTP] {
+
+  def apply[F[_, _], T, P](t: T)(
+    implicit
+    ev: F[T, P] =:= FTP, rt: RefType[F], v: Validate[T, P]
+  ): FTP = macro macros.RefineMacro.implApplyRef[FTP, F, T, P]
+}

--- a/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -15,7 +15,6 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
   ): c.Expr[F[T, P]] = {
 
     val validate = eval(v)
-
     val tValue: T = t.tree match {
       case Literal(Constant(value)) => value.asInstanceOf[T]
       case _ if validate.isConstant => null.asInstanceOf[T]
@@ -26,7 +25,11 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
     if (res.isFailed) {
       abort(validate.showResult(tValue, res))
     }
-
     reify(rt.splice.unsafeWrap(t.splice))
   }
+
+  def implApplyRef[FTP, F[_, _], T, P](t: c.Expr[T])(
+    ev: c.Expr[F[T, P] =:= FTP], rt: c.Expr[RefType[F]], v: c.Expr[Validate[T, P]]
+  ): c.Expr[FTP] =
+    c.Expr(impl(t)(rt, v).tree)
 }

--- a/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -88,7 +88,7 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F]) exten
 
 class RefTypeSpecRefined extends RefTypeSpec[Refined]("Refined") {
 
-  property("refineM with type alias") = secure {
+  property("refineM alias") = secure {
     type PositiveInt = Int Refined Positive
 
     val x: PositiveInt = RefType[Refined].refineM(5)
@@ -110,6 +110,18 @@ class RefTypeSpecRefined extends RefTypeSpec[Refined]("Refined") {
     x == y && y == z
   }
 
+  property("applyRefM alias") = secure {
+    type Natural = Long Refined NonNegative
+    val Natural = RefType.applyRefM[Natural]
+
+    val x: Natural = Natural(1L)
+    val y: Natural = 1L
+    val z = 1L: Natural
+    illTyped("Natural(-1L)", "Predicate.*fail.*")
+    illTyped("Natural(1.3)", "Cannot prove that.*")
+    x == y && y == z
+  }
+
   property("(T Refined P) <:! T") = wellTyped {
     val x = implicitly[(Int Refined Positive) <:!< Int]
   }
@@ -117,7 +129,7 @@ class RefTypeSpecRefined extends RefTypeSpec[Refined]("Refined") {
 
 class RefTypeSpecTag extends RefTypeSpec[@@]("@@") {
 
-  property("refineM with type alias") = wellTyped {
+  property("refineM alias") = wellTyped {
     type PositiveInt = Int @@ Positive
 
     // This is expected, see https://github.com/fthomas/refined/issues/21:

--- a/notes/0.3.8.markdown
+++ b/notes/0.3.8.markdown
@@ -1,7 +1,19 @@
 ### Changes
 
+* Add `RefType.applyRefM`, the the macro variant of `RefType.applyRef`.
+  `applyRefM` is useful when working with type aliases for refined
+  types and without any implicits, for example:
+  ```scala
+  scala> type Natural = Long @@ NonNegative
+  defined type alias Natural
+
+  scala> RefType.applyRefM[Natural](42L)
+  res0: Natural = 42
+  ```
+  ([#112], [#138])
 * Fix the return type of `RefType.applyRef`. ([#137])
 * Update to Scala.js 0.6.8. ([#136])
 
+[#112]: https://github.com/fthomas/refined/issues/112
 [#136]: https://github.com/fthomas/refined/pull/136
 [#137]: https://github.com/fthomas/refined/pull/137


### PR DESCRIPTION
Add `RefType.applyRefM`, the the macro variant of `RefType.applyRef`.
`applyRefM` is useful when working with type aliases for refined
types and without any implicits, for example:

```scala
scala> type Natural = Long @@ NonNegative
defined type alias Natural

scala> RefType.applyRefM[Natural](42L)
res0: Natural = 42
```

Closes #112.