### PR TITLE
Delegate Refined#toString to the underlying value

### DIFF
--- a/core/shared/src/main/scala-2.10/eu/timepit/refined/api/Refined.scala
+++ b/core/shared/src/main/scala-2.10/eu/timepit/refined/api/Refined.scala
@@ -6,7 +6,11 @@ package api
  * this class can be created with `[[refineV]]` and `[[refineMV]]` which
  * verify that the wrapped value satisfies `P`.
  */
-final case class Refined[T, P] private (get: T) // extends AnyVal
+final case class Refined[T, P] private (get: T) {
+
+  override def toString: String =
+    get.toString
+}
 
 object Refined {
 

--- a/core/shared/src/main/scala-2.11/eu/timepit/refined/api/Refined.scala
+++ b/core/shared/src/main/scala-2.11/eu/timepit/refined/api/Refined.scala
@@ -6,7 +6,11 @@ package api
  * this class can be created with `[[refineV]]` and `[[refineMV]]` which
  * verify that the wrapped value satisfies `P`.
  */
-final case class Refined[T, P] private (get: T) extends AnyVal
+final case class Refined[T, P] private (get: T) extends AnyVal {
+
+  override def toString: String =
+    get.toString
+}
 
 object Refined {
 

--- a/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
@@ -34,7 +34,7 @@ trait RefType[F[_, _]] extends Serializable {
    *      | import eu.timepit.refined.numeric._
    *
    * scala> RefType[Refined].refine[Positive](10)
-   * res1: Either[String, Refined[Int, Positive]] = Right(Refined(10))
+   * res1: Either[String, Refined[Int, Positive]] = Right(10)
    * }}}
    *
    * Note: The return type is `[[internal.RefinePartiallyApplied]][F, P]`,
@@ -53,7 +53,7 @@ trait RefType[F[_, _]] extends Serializable {
    *      | import eu.timepit.refined.numeric._
    *
    * scala> RefType[Refined].refineM[Positive](10)
-   * res1: Refined[Int, Positive] = Refined(10)
+   * res1: Refined[Int, Positive] = 10
    * }}}
    *
    * Note: `M` stands for '''m'''acro.
@@ -74,7 +74,7 @@ trait RefType[F[_, _]] extends Serializable {
    *      | import eu.timepit.refined.numeric._
    *
    * scala> RefType[Refined].refineMF[Long, Positive](10)
-   * res1: Refined[Long, Positive] = Refined(10)
+   * res1: Refined[Long, Positive] = 10
    * }}}
    *
    * Note: `M` stands for '''m'''acro and `F` for '''f'''ully applied.
@@ -109,7 +109,7 @@ object RefType {
    *      | import eu.timepit.refined.numeric._
    *
    * scala> RefType.applyRef[Int Refined Positive](10)
-   * res1: Either[String, Int Refined Positive] = Right(Refined(10))
+   * res1: Either[String, Int Refined Positive] = Right(10)
    * }}}
    *
    * Note: The return type is `[[internal.ApplyRefPartiallyApplied]][FTP]`,
@@ -129,7 +129,7 @@ object RefType {
    *
    * scala> type PosInt = Int Refined Positive
    * scala> RefType.applyRefM[PosInt](10)
-   * res1: PosInt = Refined(10)
+   * res1: PosInt = 10
    * }}}
    *
    * Note: `M` stands for '''m'''acro.

--- a/docs/namestartchar.md
+++ b/docs/namestartchar.md
@@ -50,7 +50,7 @@ scala> type NameStartChar = Char Refined AnyOf[
 defined type alias NameStartChar
 
 scala> val a: NameStartChar = 'Ä'
-a: NameStartChar = Refined(Ä)
+a: NameStartChar = Ä
 ```
 
 ```scala

--- a/docs/type_aliases.md
+++ b/docs/type_aliases.md
@@ -21,10 +21,10 @@ defined class Square
 
 ```scala
 scala> Square('a', 1)
-res0: Square = Square(Refined(a),Refined(1))
+res0: Square = Square(a,1)
 
 scala> Square('e', 4)
-res1: Square = Square(Refined(e),Refined(4))
+res1: Square = Square(e,4)
 ```
 
 ```scala
@@ -49,13 +49,13 @@ scala> Square('k', -1)
 
 ```scala
 scala> val a1 = Square('a', 1)
-a1: Square = Square(Refined(a),Refined(1))
+a1: Square = Square(a,1)
 
 scala> val b2 = for {
      |   f <- applyRef[File]((a1.file + 1).toChar).right
      |   r <- applyRef[Rank](a1.rank + 1).right
      | } yield Square(f, r)
-b2: scala.util.Either[String,Square] = Right(Square(Refined(b),Refined(2)))
+b2: scala.util.Either[String,Square] = Right(Square(b,2))
 
 scala> val i9 = for {
      |   f <- applyRef[File]((a1.file + 8).toChar).right

--- a/notes/0.3.8.markdown
+++ b/notes/0.3.8.markdown
@@ -1,5 +1,7 @@
 ### Changes
 
+* Overwrite `Refined#toString` by delegating it to the `toString`
+  method of the wrapped value. ([#141])
 * Add `RefType.applyRefM`, the the macro variant of `RefType.applyRef`.
   `applyRefM` is useful when working with type aliases for refined
   types and without any implicits, for example:
@@ -26,3 +28,4 @@
 [#137]: https://github.com/fthomas/refined/pull/137
 [#138]: https://github.com/fthomas/refined/pull/138
 [#140]: https://github.com/fthomas/refined/pull/140
+[#141]: https://github.com/fthomas/refined/pull/141


### PR DESCRIPTION
The rationale for this change is that the sole purpose of types like `@@` and `Refined` (which are refinement carrier) is to attach a predicate to a base type. Ideally the carrier itself has no effect at runtime. Therefore the string representation of a refined type should be just the string representation of the base type. Note that this is already the case for `@@`.