### PR TITLE
Remove notion of constant Validate instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,6 @@ lazy val compileSettings = Seq(
 
   wartremoverErrors in (Compile, compile) ++= Warts.unsafe diff Seq(
     Wart.Any,
-    Wart.DefaultArguments,
     Wart.AsInstanceOf,
     Wart.NonUnitStatements,
     Wart.Null,

--- a/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
@@ -23,13 +23,6 @@ trait Validate[T, P] extends Serializable { self =>
   def showResult(t: T, r: Res): String =
     Resources.predicateResultDetailDot(r, showExpr(t))
 
-  /**
-   * Denotes whether this `[[Validate]]` is constant (which is false by
-   * default). A constant `[[Validate]]` ignores the argument passed to
-   * `[[validate]]`.
-   */
-  val isConstant: Boolean = false
-
   /** Checks if `t` satisfies the predicate `P`. */
   final def isValid(t: T): Boolean =
     validate(t).isPassed
@@ -49,7 +42,6 @@ trait Validate[T, P] extends Serializable { self =>
     new Validate[U, P] {
       override type R = self.R
       override def validate(u: U): Res = self.validate(f(u))
-      override val isConstant: Boolean = self.isConstant
       override def showExpr(u: U): String = self.showExpr(f(u))
       override def showResult(u: U, r: Res): String = self.showResult(f(u), r)
       override def accumulateShowExpr(u: U): List[String] = self.accumulateShowExpr(f(u))
@@ -65,17 +57,16 @@ object Validate {
   def apply[T, P](implicit v: Validate[T, P]): Aux[T, P, v.R] = v
 
   /** Constructs a `[[Validate]]` from its parameters. */
-  def instance[T, P, R0](f: T => Result[R0], g: T => String, constant: Boolean = false): Aux[T, P, R0] =
+  def instance[T, P, R0](f: T => Result[R0], g: T => String): Aux[T, P, R0] =
     new Validate[T, P] {
       override type R = R0
       override def validate(t: T): Res = f(t)
       override def showExpr(t: T): String = g(t)
-      override val isConstant: Boolean = constant
     }
 
   /** Constructs a constant `[[Validate]]` from its parameters. */
   def constant[T, P, R](isValidV: Result[R], showV: String): Aux[T, P, R] =
-    instance(_ => isValidV, _ => showV, constant = true)
+    instance(_ => isValidV, _ => showV)
 
   /**
    * Constructs a `[[Validate]]` from the predicate `f`. All values of type

--- a/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
@@ -72,8 +72,6 @@ private[refined] trait BooleanValidate {
           case Failed(_) => Resources.showResultNotInnerFailed(expr)
         }
       }
-
-      override val isConstant: Boolean = v.isConstant
     }
 
   implicit def andValidate[T, A, RA, B, RB](
@@ -106,8 +104,6 @@ private[refined] trait BooleanValidate {
             Resources.showResultAndBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
         }
       }
-
-      override val isConstant: Boolean = va.isConstant && vb.isConstant
     }
 
   implicit def orValidate[T, A, RA, B, RB](
@@ -140,8 +136,6 @@ private[refined] trait BooleanValidate {
             Resources.showResultOrBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
         }
       }
-
-      override val isConstant: Boolean = va.isConstant && vb.isConstant
     }
 
   implicit def xorValidate[T, A, RA, B, RB](
@@ -174,8 +168,6 @@ private[refined] trait BooleanValidate {
             Resources.showResultOrBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
         }
       }
-
-      override val isConstant: Boolean = va.isConstant && vb.isConstant
     }
 
   implicit def allOfHNilValidate[T]: Validate.Plain[T, AllOf[HNil]] =
@@ -200,8 +192,6 @@ private[refined] trait BooleanValidate {
 
       override def accumulateShowExpr(t: T): List[String] =
         vh.showExpr(t) :: vt.accumulateShowExpr(t)
-
-      override val isConstant: Boolean = vh.isConstant && vt.isConstant
     }
 
   implicit def anyOfHNilValidate[T]: Validate.Plain[T, AnyOf[HNil]] =
@@ -226,8 +216,6 @@ private[refined] trait BooleanValidate {
 
       override def accumulateShowExpr(t: T): List[String] =
         vh.showExpr(t) :: vt.accumulateShowExpr(t)
-
-      override val isConstant: Boolean = vh.isConstant && vt.isConstant
     }
 
   implicit def oneOfHNilValidate[T]: Validate.Plain[T, OneOf[HNil]] =
@@ -254,8 +242,6 @@ private[refined] trait BooleanValidate {
 
       override def accumulateShowExpr(t: T): List[String] =
         vh.showExpr(t) :: vt.accumulateShowExpr(t)
-
-      override val isConstant: Boolean = vh.isConstant && vt.isConstant
     }
 }
 

--- a/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -17,7 +17,6 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
     val validate = eval(v)
     val tValue: T = t.tree match {
       case Literal(Constant(value)) => value.asInstanceOf[T]
-      case _ if validate.isConstant => null.asInstanceOf[T]
       case _ => abort(Resources.refineNonCompileTimeConstant)
     }
 

--- a/core/shared/src/test/scala/eu/timepit/refined/RefineMSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/RefineMSpec.scala
@@ -71,11 +71,6 @@ class RefineMSpec extends Properties("refineM") {
     illTyped("refineMV[Greater[W.`2.3`.T]](2.2)", "Predicate.*fail.*")
   }
 
-  property("refineM success with constant predicate") = wellTyped {
-    def ignore1: List[Int] Refined Not[False] = refineMV(List(1, 2, 3))
-    def ignore2: List[Int] @@ Not[False] = refineMT(List(1, 2, 3))
-  }
-
   property("refineM failure with non-literals") = wellTyped {
     illTyped("refineMV[NonEmpty](List(1, 2, 3))", "compile-time refinement.*")
     illTyped("refineMT[NonEmpty](List(1, 2, 3))", "compile-time refinement.*")

--- a/docs/ctorfieldnames.md
+++ b/docs/ctorfieldnames.md
@@ -3,13 +3,12 @@ predicates that are implemented with [shapeless'][shapeless]
 `LabelledGeneric`.
 
 ```scala
-import eu.timepit.refined.W
+import eu.timepit.refined._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.generic._
 import eu.timepit.refined.numeric.GreaterEqual
 import eu.timepit.refined.string.StartsWith
-import shapeless.tag.@@
 
 case class Person(firstName: String, lastName: String, age: Int)
 val p = Person("John", "Doe", 32)
@@ -19,25 +18,21 @@ The `FieldNames` predicate takes as argument a predicate that validates a
 `List[String]` which are the field names of a product type (`Person` in these
 examples):
 ```scala
-scala> p: Person @@ FieldNames[Forall[Size[GreaterEqual[W.`3`.T]]]]
-res1: shapeless.tag.@@[Person,eu.timepit.refined.generic.FieldNames[eu.timepit.refined.collection.Forall[eu.timepit.refined.collection.Size[eu.timepit.refined.numeric.GreaterEqual[Int(3)]]]]] = Person(John,Doe,32)
+scala> refineV[FieldNames[Forall[Size[GreaterEqual[W.`3`.T]]]]](p)
+res1: Either[String,eu.timepit.refined.api.Refined[Person,eu.timepit.refined.generic.FieldNames[eu.timepit.refined.collection.Forall[eu.timepit.refined.collection.Size[eu.timepit.refined.numeric.GreaterEqual[Int(3)]]]]]] = Right(Person(John,Doe,32))
 
-scala> p: Person @@ FieldNames[Exists[StartsWith[W.`"last"`.T]]]
-res2: shapeless.tag.@@[Person,eu.timepit.refined.generic.FieldNames[eu.timepit.refined.collection.Exists[eu.timepit.refined.string.StartsWith[String("last")]]]] = Person(John,Doe,32)
+scala> refineV[FieldNames[Exists[StartsWith[W.`"last"`.T]]]](p)
+res2: Either[String,eu.timepit.refined.api.Refined[Person,eu.timepit.refined.generic.FieldNames[eu.timepit.refined.collection.Exists[eu.timepit.refined.string.StartsWith[String("last")]]]]] = Right(Person(John,Doe,32))
 ```
 
 These examples fail since `Person` has no field that is called "name" and it
 has three fields instead of four:
 ```scala
-scala> p: Person @@ FieldNames[Contains[W.`"name"`.T]]
-<console>:28: error: Predicate failed: !(!(firstName == name) && !(lastName == name) && !(age == name)).
-       p: Person @@ FieldNames[Contains[W.`"name"`.T]]
-       ^
+scala> refineV[FieldNames[Contains[W.`"name"`.T]]](p)
+res3: Either[String,eu.timepit.refined.api.Refined[Person,eu.timepit.refined.generic.FieldNames[eu.timepit.refined.collection.Contains[String("name")]]]] = Left(Predicate failed: !(!(firstName == name) && !(lastName == name) && !(age == name)).)
 
-scala> p: Person @@ FieldNames[Size[Equal[W.`4`.T]]]
-<console>:28: error: Predicate failed: (3 == 4).
-       p: Person @@ FieldNames[Size[Equal[W.`4`.T]]]
-       ^
+scala> refineV[FieldNames[Size[Equal[W.`4`.T]]]](p)
+res4: Either[String,eu.timepit.refined.api.Refined[Person,eu.timepit.refined.generic.FieldNames[eu.timepit.refined.collection.Size[eu.timepit.refined.generic.Equal[Int(4)]]]]] = Left(Predicate failed: (3 == 4).)
 ```
 
 The `ConstructorNames` predicate validates the names of a sealed family of
@@ -46,24 +41,20 @@ classes:
 scala> val o: Option[Unit] = Some(())
 o: Option[Unit] = Some(())
 
-scala> o: Option[Unit] @@ ConstructorNames[Size[Equal[W.`2`.T]]]
-res5: shapeless.tag.@@[Option[Unit],eu.timepit.refined.generic.ConstructorNames[eu.timepit.refined.collection.Size[eu.timepit.refined.generic.Equal[Int(2)]]]] = Some(())
+scala> refineV[ConstructorNames[Size[Equal[W.`2`.T]]]](o)
+res5: Either[String,eu.timepit.refined.api.Refined[Option[Unit],eu.timepit.refined.generic.ConstructorNames[eu.timepit.refined.collection.Size[eu.timepit.refined.generic.Equal[Int(2)]]]]] = Right(Some(()))
 
-scala> o: Option[Unit] @@ ConstructorNames[Contains[W.`"None"`.T]]
-res6: shapeless.tag.@@[Option[Unit],eu.timepit.refined.generic.ConstructorNames[eu.timepit.refined.collection.Contains[String("None")]]] = Some(())
+scala> refineV[ConstructorNames[Contains[W.`"None"`.T]]](o)
+res6: Either[String,eu.timepit.refined.api.Refined[Option[Unit],eu.timepit.refined.generic.ConstructorNames[eu.timepit.refined.collection.Contains[String("None")]]]] = Right(Some(()))
 ```
 
 Let's see what happens if we use predicates that should fail:
 ```scala
-scala> o: Option[Unit] @@ ConstructorNames[Size[Equal[W.`3`.T]]]
-<console>:26: error: Predicate failed: (2 == 3).
-       o: Option[Unit] @@ ConstructorNames[Size[Equal[W.`3`.T]]]
-       ^
+scala> refineV[ConstructorNames[Size[Equal[W.`3`.T]]]](o)
+res7: Either[String,eu.timepit.refined.api.Refined[Option[Unit],eu.timepit.refined.generic.ConstructorNames[eu.timepit.refined.collection.Size[eu.timepit.refined.generic.Equal[Int(3)]]]]] = Left(Predicate failed: (2 == 3).)
 
-scala> o: Option[Unit] @@ ConstructorNames[Contains[W.`"Just"`.T]]
-<console>:26: error: Predicate failed: !(!(None == Just) && !(Some == Just)).
-       o: Option[Unit] @@ ConstructorNames[Contains[W.`"Just"`.T]]
-       ^
+scala> refineV[ConstructorNames[Contains[W.`"Just"`.T]]](o)
+res8: Either[String,eu.timepit.refined.api.Refined[Option[Unit],eu.timepit.refined.generic.ConstructorNames[eu.timepit.refined.collection.Contains[String("Just")]]]] = Left(Predicate failed: !(!(None == Just) && !(Some == Just)).)
 ```
 
 [shapeless]: https://github.com/milessabin/shapeless

--- a/docs/src/ctorfieldnames.md
+++ b/docs/src/ctorfieldnames.md
@@ -3,13 +3,12 @@ predicates that are implemented with [shapeless'][shapeless]
 `LabelledGeneric`.
 
 ```tut:silent
-import eu.timepit.refined.W
+import eu.timepit.refined._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.generic._
 import eu.timepit.refined.numeric.GreaterEqual
 import eu.timepit.refined.string.StartsWith
-import shapeless.tag.@@
 
 case class Person(firstName: String, lastName: String, age: Int)
 val p = Person("John", "Doe", 32)
@@ -19,17 +18,17 @@ The `FieldNames` predicate takes as argument a predicate that validates a
 `List[String]` which are the field names of a product type (`Person` in these
 examples):
 ```tut:nofail
-p: Person @@ FieldNames[Forall[Size[GreaterEqual[W.`3`.T]]]]
+refineV[FieldNames[Forall[Size[GreaterEqual[W.`3`.T]]]]](p)
 
-p: Person @@ FieldNames[Exists[StartsWith[W.`"last"`.T]]]
+refineV[FieldNames[Exists[StartsWith[W.`"last"`.T]]]](p)
 ```
 
 These examples fail since `Person` has no field that is called "name" and it
 has three fields instead of four:
 ```tut:nofail
-p: Person @@ FieldNames[Contains[W.`"name"`.T]]
+refineV[FieldNames[Contains[W.`"name"`.T]]](p)
 
-p: Person @@ FieldNames[Size[Equal[W.`4`.T]]]
+refineV[FieldNames[Size[Equal[W.`4`.T]]]](p)
 ```
 
 The `ConstructorNames` predicate validates the names of a sealed family of
@@ -37,16 +36,16 @@ classes:
 ```tut:nofail
 val o: Option[Unit] = Some(())
 
-o: Option[Unit] @@ ConstructorNames[Size[Equal[W.`2`.T]]]
+refineV[ConstructorNames[Size[Equal[W.`2`.T]]]](o)
 
-o: Option[Unit] @@ ConstructorNames[Contains[W.`"None"`.T]]
+refineV[ConstructorNames[Contains[W.`"None"`.T]]](o)
 ```
 
 Let's see what happens if we use predicates that should fail:
 ```tut:nofail
-o: Option[Unit] @@ ConstructorNames[Size[Equal[W.`3`.T]]]
+refineV[ConstructorNames[Size[Equal[W.`3`.T]]]](o)
 
-o: Option[Unit] @@ ConstructorNames[Contains[W.`"Just"`.T]]
+refineV[ConstructorNames[Contains[W.`"Just"`.T]]](o)
 ```
 
 [shapeless]: https://github.com/milessabin/shapeless

--- a/notes/0.3.8.markdown
+++ b/notes/0.3.8.markdown
@@ -16,6 +16,9 @@
 * Fix the return type of `RefType.applyRef`. ([#137])
 * Update to Scala.js 0.6.8. ([#136])
 * Update `refined-scalaz` to Scalaz 7.2.2. ([#147])
+* Remove the notion of "constant" `Validate` instances that allowed to
+  refine non-literal values at compile-time. This feature hasn't proven
+  to be useful after all. ([#148])
 
 ### New predicates
 
@@ -34,3 +37,4 @@ Thanks to Shohei Shimomura for both predicates!
 [#141]: https://github.com/fthomas/refined/pull/141
 [#143]: https://github.com/fthomas/refined/pull/143
 [#147]: https://github.com/fthomas/refined/pull/147
+[#148]: https://github.com/fthomas/refined/pull/148


### PR DESCRIPTION
This removes the notion of "constant" `Validate` instances
that allowed to refine non-literal values at compile-time.
This feature hasn't proven to be useful after all.

See #26 for the original issue that introduced constant
predicates.