### PR TITLE
Require a Traversable for collection predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,20 +234,20 @@ The library comes with these predefined predicates:
 
 [`collection`](https://github.com/fthomas/refined/blob/master/core/shared/src/main/scala/eu/timepit/refined/collection.scala)
 
-* `Contains[U]`: checks if a `TraversableOnce` contains a value equal to `U`
-* `Count[PA, PC]`: counts the number of elements in a `TraversableOnce` which satisfy the predicate `PA` and passes the result to the predicate `PC`
-* `Empty`: checks if a `TraversableOnce` is empty
-* `NonEmpty`: checks if a `TraversableOnce` is not empty
-* `Forall[P]`: checks if the predicate `P` holds for all elements of a `TraversableOnce`
-* `Exists[P]`: checks if the predicate `P` holds for some elements of a `TraversableOnce`
+* `Contains[U]`: checks if a `Traversable` contains a value equal to `U`
+* `Count[PA, PC]`: counts the number of elements in a `Traversable` which satisfy the predicate `PA` and passes the result to the predicate `PC`
+* `Empty`: checks if a `Traversable` is empty
+* `NonEmpty`: checks if a `Traversable` is not empty
+* `Forall[P]`: checks if the predicate `P` holds for all elements of a `Traversable`
+* `Exists[P]`: checks if the predicate `P` holds for some elements of a `Traversable`
 * `Head[P]`: checks if the predicate `P` holds for the first element of a `Traversable`
 * `Index[N, P]`: checks if the predicate `P` holds for the element at index `N` of a sequence
 * `Last[P]`: checks if the predicate `P` holds for the last element of a `Traversable`
-* `Size[P]`: checks if the size of a `TraversableOnce` satisfies the predicate `P`
+* `Size[P]`: checks if the size of a `Traversable` satisfies the predicate `P`
 * `Init[P]`: checks if the predicate `P` holds for all but last element of a `Traversable`
 * `Tail[P]`: checks if the predicate `P` holds for all but head element of a `Traversable`
-* `MinSize[N]`: checks if the size of a `TraversableOnce` is greater than or equal to `N`
-* `MaxSize[N]`: checks if the size of a `TraversableOnce` is less than or equal to `N`
+* `MinSize[N]`: checks if the size of a `Traversable` is greater than or equal to `N`
+* `MaxSize[N]`: checks if the size of a `Traversable` is less than or equal to `N`
 
 [`generic`](https://github.com/fthomas/refined/blob/master/core/shared/src/main/scala/eu/timepit/refined/generic.scala)
 


### PR DESCRIPTION
This changes all collection predicates that required a
TraversableOnce to require a Traversable instead. Refining
is pointless if the values of a collection can't be accessed
anymore after refining.