### PR TITLE
Make parameter types of function literals optional

### DIFF
--- a/core/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
+++ b/core/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
@@ -12,8 +12,11 @@ class GenericValidateSpecJvm extends Properties("GenericValidate") {
 
   type IsEven = Eval[W.`"(x: Int) => x % 2 == 0"`.T]
 
-  property("Eval.isValid") = forAll { (i: Int) =>
-    Validate[Int, IsEven].isValid(i) ?= (i % 2 == 0)
+  property("Eval.isValid") = {
+    val v = Validate[Int, IsEven]
+    forAll { (i: Int) =>
+      v.isValid(i) ?= (i % 2 == 0)
+    }
   }
 
   property("Eval.showExpr") = secure {
@@ -23,6 +26,10 @@ class GenericValidateSpecJvm extends Properties("GenericValidate") {
   property("Eval.refineMV") = wellTyped {
     refineMV[IsEven](2)
     illTyped("refineMV[IsEven](3)", "Predicate.*fail.*")
+  }
+
+  property("Eval.refineV.no parameter type") = {
+    refineV[Eval[W.`"_.head >= 0"`.T]](List(1, -2)).isRight
   }
 
   property("Eval.refineMV.scope") = wellTyped {

--- a/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -55,7 +55,10 @@ private[refined] trait GenericValidate {
     mt: Manifest[T],
     ws: Witness.Aux[S]
   ): Validate.Plain[T, Eval[S]] = {
+    // The ascription (T => Boolean) allows to omit the parameter
+    // type in ws.value (i.e. "x => ..." instead of "(x: T) => ...").
     val tree = toolBox.parse(s"(${ws.value}): ($mt => Boolean)")
+
     val predicate = toolBox.eval(tree).asInstanceOf[T => Boolean]
     Validate.fromPredicate(predicate, _ => ws.value, Eval(ws.value))
   }

--- a/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -4,7 +4,6 @@ import eu.timepit.refined.api.{ Inference, Validate }
 import eu.timepit.refined.api.Inference.==>
 import eu.timepit.refined.generic._
 import scala.reflect.runtime.currentMirror
-import scala.reflect.runtime.universe.TypeTag
 import scala.tools.reflect.ToolBox
 import shapeless._
 import shapeless.ops.coproduct.ToHList
@@ -53,10 +52,10 @@ private[refined] trait GenericValidate {
 
   implicit def evalValidate[T, S <: String](
     implicit
-    tt: TypeTag[T],
+    mt: Manifest[T],
     ws: Witness.Aux[S]
   ): Validate.Plain[T, Eval[S]] = {
-    val tree = toolBox.parse(s"(${ws.value}): (${tt.tpe} => Boolean)")
+    val tree = toolBox.parse(s"(${ws.value}): ($mt => Boolean)")
     val predicate = toolBox.eval(tree).asInstanceOf[T => Boolean]
     Validate.fromPredicate(predicate, _ => ws.value, Eval(ws.value))
   }

--- a/notes/0.4.1.markdown
+++ b/notes/0.4.1.markdown
@@ -1,0 +1,14 @@
+### Changes
+
+* Make parameter types of function literals in the `Eval` predicate
+  optional. This allows to write
+  ```scala
+  val x: Int Refined Eval[W.`"x => x > 0"`.T] = 1
+  ```
+  instead of
+  ```scala
+  val y: Int Refined Eval[W.`"(x: Int) => x > 0"`.T] = 1
+  ```
+  ([#153])
+
+[#153]: https://github.com/fthomas/refined/pull/153

--- a/notes/0.4.1.markdown
+++ b/notes/0.4.1.markdown
@@ -2,6 +2,7 @@
 
 * Make parameter types of function literals in the `Eval` predicate
   optional. This allows to write
+
   ```scala
   val x: Int Refined Eval[W.`"x => x > 0"`.T] = 1
   ```


### PR DESCRIPTION
This makes parameter types of function literals in the `Eval` predicate
optional. It allows to write
```scala
val x: Int Refined Eval[W.`"x => x > 0"`.T] = 1
```
instead of
```scala
val y: Int Refined Eval[W.`"(x: Int) => x > 0"`.T] = 1
```