### PR TITLE
Stop compiling with JDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ scala:
 - 2.10.6
 - 2.11.8
 jdk:
-- oraclejdk7
 - oraclejdk8
 sudo: false
 addons:


### PR DESCRIPTION
This is in anticipation for Scala 2.12 and #157 which both
require Java 8.