### PR TITLE
Rename force to unsafeFrom

### DIFF
--- a/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefPartiallyApplied.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefPartiallyApplied.scala
@@ -17,4 +17,10 @@ final class ApplyRefPartiallyApplied[FTP] {
     ev: F[T, P] =:= FTP, rt: RefType[F], v: Validate[T, P]
   ): Either[String, FTP] =
     rt.refine[P](t).right.map(ev)
+
+  def unsafeFrom[F[_, _], T, P](t: T)(
+    implicit
+    ev: F[T, P] =:= FTP, rt: RefType[F], v: Validate[T, P]
+  ): FTP =
+    apply(t).fold(err => throw new IllegalArgumentException(err), identity)
 }

--- a/core/shared/src/main/scala/eu/timepit/refined/internal/RefinePartiallyApplied.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/internal/RefinePartiallyApplied.scala
@@ -18,6 +18,10 @@ final class RefinePartiallyApplied[F[_, _], P](rt: RefType[F]) {
     else Left(v.showResult(t, res))
   }
 
-  def force[T](t: T)(implicit v: Validate[T, P]): F[T, P] =
+  def unsafeFrom[T](t: T)(implicit v: Validate[T, P]): F[T, P] =
     apply(t).fold(err => throw new IllegalArgumentException(err), identity)
+
+  @deprecated("force has been renamed to unsafeFrom", "0.5.0")
+  def force[T](t: T)(implicit v: Validate[T, P]): F[T, P] =
+    unsafeFrom(t)
 }

--- a/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -56,12 +56,12 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F]) exten
     rt.refine[DigitsOnly]("123").isRight
   }
 
-  property("refine.force success") = secure {
-    rt.refine[Positive].force(5) ?= rt.unsafeWrap[Int, Positive](5)
+  property("refine.unsafeFrom success") = secure {
+    rt.refine[Positive].unsafeFrom(5) ?= rt.unsafeWrap[Int, Positive](5)
   }
 
-  property("refine.force failure") = secure {
-    throws(classOf[IllegalArgumentException])(rt.refine[Positive].force(-5))
+  property("refine.unsafeFrom failure") = secure {
+    throws(classOf[IllegalArgumentException])(rt.refine[Positive].unsafeFrom(-5))
   }
 
   property("mapRefine success with Positive") = secure {
@@ -83,6 +83,14 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F]) exten
   property("refine ~= RefType.applyRef") = forAll { (i: Int) =>
     type PosInt = F[Int, Positive]
     rt.refine[Positive](i) ?= RefType.applyRef[PosInt](i)
+  }
+
+  property("RefType.applyRef.unsafeFrom success") = secure {
+    RefType.applyRef[F[Int, Positive]].unsafeFrom(5) ?= rt.unsafeWrap[Int, Positive](5)
+  }
+
+  property("RefType.applyRef.unsafeFrom success") = secure {
+    throws(classOf[IllegalArgumentException])(RefType.applyRef[F[Int, Positive]].unsafeFrom(-5))
   }
 }
 

--- a/notes/0.4.1.markdown
+++ b/notes/0.4.1.markdown
@@ -14,6 +14,8 @@
   val y: Int Refined Eval[W.`"(x: Int) => x > 0"`.T] = 1
   ```
   ([#153])
+* Renamed `RefinePartiallyApplied.force` to `unsafeFrom` and add
+  `ApplyRefPartiallyApplied.unsafeFrom`. ([#175])
 * Add `Arbitrary` instance for `Equal`. ([#170])
 
 ### Updates
@@ -28,3 +30,4 @@
 [#165]: https://github.com/fthomas/refined/pull/165
 [#170]: https://github.com/fthomas/refined/pull/170
 [#172]: https://github.com/fthomas/refined/pull/172
+[#175]: https://github.com/fthomas/refined/pull/175


### PR DESCRIPTION
... and add `ApplyRefPartiallyApplied.unsafeFrom`. These methods
refine an unrefined value and throw an exception in case the value
does not satisfy the predicate.