### PR TITLE
Use Some[T] instead of Option[T] as return type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,6 +171,7 @@ lazy val submoduleJvmSettings = Seq(
       exclude[DirectMissingMethodProblem]("eu.timepit.refined.api.Refined.productIterator"),
       exclude[DirectMissingMethodProblem]("eu.timepit.refined.api.Refined.productPrefix"),
       exclude[DirectMissingMethodProblem]("eu.timepit.refined.api.Refined.apply"),
+      exclude[IncompatibleResultTypeProblem]("eu.timepit.refined.api.Refined.unapply"),
       exclude[FinalClassProblem]("eu.timepit.refined.boolean$AllOf"),
       exclude[FinalClassProblem]("eu.timepit.refined.boolean$OneOf"),
       exclude[FinalClassProblem]("eu.timepit.refined.generic$Supertype"),

--- a/core/shared/src/main/scala-2.10/eu/timepit/refined/api/Refined.scala
+++ b/core/shared/src/main/scala-2.10/eu/timepit/refined/api/Refined.scala
@@ -26,7 +26,7 @@ object Refined {
   def unsafeApply[T, P](t: T): Refined[T, P] =
     new Refined(t)
 
-  def unapply[T, P](r: Refined[T, P]): Option[T] =
+  def unapply[T, P](r: Refined[T, P]): Some[T] =
     Some(r.get)
 
 }

--- a/core/shared/src/main/scala-2.11/eu/timepit/refined/api/Refined.scala
+++ b/core/shared/src/main/scala-2.11/eu/timepit/refined/api/Refined.scala
@@ -21,7 +21,7 @@ object Refined {
   def unsafeApply[T, P](t: T): Refined[T, P] =
     new Refined(t)
 
-  def unapply[T, P](r: Refined[T, P]): Option[T] =
+  def unapply[T, P](r: Refined[T, P]): Some[T] =
     Some(r.get)
 
 }


### PR DESCRIPTION
Without this change the following code compiles without warnings:
```scala
Refined.unsafeApply(0) match {
  case Refined(x) => true
  case _ => false
}
```
although the second match can never be reached. If we refine the
the return type of `Refined.unapply` from `Option[T]` to `Some[T]`,
the compiler emits a warning about unreachable code in the example
above:
```
[error] RefinedSpec.scala:38: unreachable code
[error]       case _ => false
[error]                 ^
```