### PR TITLE
Build with 2.12.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,7 @@ lazy val metadataSettings = Def.settings(
 
 lazy val compileSettings = Def.settings(
   scalaVersion := "2.11.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.10.6"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.10.6", "2.12.0-RC2"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding",


### PR DESCRIPTION
This currently fails because shapeless 2.3.2 is not yet available for 2.12.0-RC2.