### PR TITLE
Add refined-pureconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,14 @@ If you're using sbt, add the following to your build:
 ```sbt
 libraryDependencies ++= Seq(
   "eu.timepit" %% "refined"            % "0.6.0",
-  "eu.timepit" %% "refined-scalaz"     % "0.6.0",         // optional
-  "eu.timepit" %% "refined-scodec"     % "0.6.0",         // optional
-  "eu.timepit" %% "refined-scalacheck" % "0.6.0" % "test" // optional
+  "eu.timepit" %% "refined-scalaz"     % "0.6.0",          // optional
+  "eu.timepit" %% "refined-scodec"     % "0.6.0",          // optional
+  "eu.timepit" %% "refined-scalacheck" % "0.6.0" % "test", // optional
+  "eu.timepit" %% "refined-pureconfig" % "0.6.0"           // optional
 )
 ```
 
-For Scala.js just replace `%%` with `%%%` above.
+For Scala.js just replace `%%` with `%%%` above (except for `refined-pureconfig` which is not available for Scala.js).
 
 Instructions for Maven and other build tools are available at [search.maven.org][search.maven].
 
@@ -186,6 +187,7 @@ other tag types or integration of refined types in other libraries:
 * `refined-scodec` for integration with [scodec](http://scodec.org/)
 * `refined-scalacheck` for [ScalaCheck](http://scalacheck.org/) type
   class instances of refined types
+* `refined-pureconfig` for [PureConfig](https://github.com/melrief/pureconfig) integration
 
 See also the list of [projects that use refined][built-with-refined]
 for libraries that directly provide support for **refined**.

--- a/contrib/pureconfig/jvm/src/main/scala/eu/timepit/refined/pureconfig/error/PredicateFailedException.scala
+++ b/contrib/pureconfig/jvm/src/main/scala/eu/timepit/refined/pureconfig/error/PredicateFailedException.scala
@@ -1,0 +1,4 @@
+package eu.timepit.refined.pureconfig.error
+
+final case class PredicateFailedException(message: String)
+    extends IllegalArgumentException(message)

--- a/contrib/pureconfig/jvm/src/main/scala/eu/timepit/refined/pureconfig/package.scala
+++ b/contrib/pureconfig/jvm/src/main/scala/eu/timepit/refined/pureconfig/package.scala
@@ -1,0 +1,27 @@
+package eu.timepit.refined
+
+import _root_.pureconfig.ConfigConvert
+import com.typesafe.config.ConfigValue
+import eu.timepit.refined.api.{RefType, Validate}
+import eu.timepit.refined.pureconfig.error.PredicateFailedException
+import scala.util.{Failure, Success, Try}
+
+package object pureconfig {
+
+  implicit def refTypeConfigConvert[F[_, _], T, P](
+      implicit configConvert: ConfigConvert[T],
+      refType: RefType[F],
+      validate: Validate[T, P]
+  ): ConfigConvert[F[T, P]] = new ConfigConvert[F[T, P]] {
+    override def from(config: ConfigValue): Try[F[T, P]] =
+      configConvert.from(config).flatMap { t ⇒
+        refType.refine[P](t).left.map(PredicateFailedException) match {
+          case Right(refined) ⇒ Success(refined)
+          case Left(exception) ⇒ Failure(exception)
+        }
+      }
+
+    override def to(t: F[T, P]): ConfigValue =
+      configConvert.to(refType.unwrap(t))
+  }
+}

--- a/contrib/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
+++ b/contrib/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
@@ -1,0 +1,30 @@
+package eu.timepit.refined.pureconfig
+
+import com.typesafe.config.ConfigFactory
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.pureconfig.error.PredicateFailedException
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+import pureconfig._
+import scala.util.{Failure, Success, Try}
+
+class RefTypeConfigConvertSpec extends Properties("RefTypeConfigConvert") {
+
+  type PosInt = Int Refined Positive
+  case class Config(value: PosInt)
+
+  property("load success") = secure {
+    loadConfigWithValue("1") ?=
+      Success(Config(1))
+  }
+
+  property("load failure") = secure {
+    loadConfigWithValue("0") =?
+      Failure(PredicateFailedException("Predicate failed: (0 > 0)."))
+  }
+
+  def loadConfigWithValue(value: String): Try[Config] =
+    loadConfig[Config](ConfigFactory.parseString(s"value = $value"))
+}

--- a/contrib/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
+++ b/contrib/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
@@ -25,6 +25,13 @@ class RefTypeConfigConvertSpec extends Properties("RefTypeConfigConvert") {
       Failure(PredicateFailedException("Predicate failed: (0 > 0)."))
   }
 
+  property("roundtrip success") = secure {
+    val config = Config(1)
+    val configValue = ConfigConvert[Config].to(config)
+    ConfigConvert[Config].from(configValue) ?=
+      Success(config)
+  }
+
   def loadConfigWithValue(value: String): Try[Config] =
     loadConfig[Config](ConfigFactory.parseString(s"value = $value"))
 }


### PR DESCRIPTION
Adds a `refined-pureconfig` project containing a tiny integration with [pureconfig](https://github.com/melrief/pureconfig).  
I've tried to keep things as similar as possible to `refined-scodec` where possible.