### PR TITLE
Add aliases for standard refined types

### DIFF
--- a/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/contrib/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -5,7 +5,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.scalacheck.numeric._
-import eu.timepit.refined.util.time.Minute
+import eu.timepit.refined.types.time.Minute
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import shapeless.nat._

--- a/core/shared/src/main/scala/eu/timepit/refined/types/AllTypes.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/types/AllTypes.scala
@@ -1,0 +1,3 @@
+package eu.timepit.refined.types
+
+trait AllTypes extends NumericTypes with TimeTypes

--- a/core/shared/src/main/scala/eu/timepit/refined/types/NumericTypes.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/types/NumericTypes.scala
@@ -1,0 +1,31 @@
+package eu.timepit.refined.types
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, Positive}
+
+trait NumericTypes {
+
+  /** An `Int` in the range from 1 to `Int.MaxValue`. */
+  type PosInt = Int Refined Positive
+
+  /** An `Int` in the range from 0 to `Int.MaxValue`. */
+  type NonNegInt = Int Refined NonNegative
+
+  /** An `Int` in the range from `Int.MinValue` to -1. */
+  type NegInt = Int Refined Negative
+
+  /** An `Int` in the range from `Int.MinValue` to 0. */
+  type NonPosInt = Int Refined NonPositive
+
+  /** A `Long` in the range from 1 to `Long.MaxValue`. */
+  type PosLong = Long Refined Positive
+
+  /** A `Long` in the range from 0 to `Long.MaxValue`. */
+  type NonNegLong = Long Refined NonNegative
+
+  /** A `Long` in the range from `Long.MinValue` to -1. */
+  type NegLong = Long Refined Negative
+
+  /** A `Long` in the range from `Long.MinValue` to 0. */
+  type NonPosLong = Long Refined NonPositive
+}

--- a/core/shared/src/main/scala/eu/timepit/refined/types/TimeTypes.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/types/TimeTypes.scala
@@ -1,12 +1,10 @@
-package eu.timepit.refined
-package util
+package eu.timepit.refined.types
 
+import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Interval
 
-/** Module for date and time related refined types. */
-@deprecated("`util.time` has been renamed `types.time`", "0.6.2")
-object time {
+trait TimeTypes {
 
   /** An `Int` in the range from 1 to 12 representing the month-of-year. */
   type Month = Int Refined Interval.Closed[W.`1`.T, W.`12`.T]

--- a/core/shared/src/main/scala/eu/timepit/refined/types/package.scala
+++ b/core/shared/src/main/scala/eu/timepit/refined/types/package.scala
@@ -1,0 +1,13 @@
+package eu.timepit.refined
+
+package object types {
+
+  /** Module for all predefined refined types. */
+  object all extends AllTypes
+
+  /** Module for numeric refined types. */
+  object numeric extends NumericTypes
+
+  /** Module for date and time related refined types. */
+  object time extends TimeTypes
+}

--- a/notes/0.6.2.markdown
+++ b/notes/0.6.2.markdown
@@ -1,0 +1,10 @@
+### Changes
+
+* Add aliases for standard refined types like
+  `type PosInt = Int Refined Positive` or
+  `type NegInt = Int Refined Negative` to the
+  `eu.timepit.refined.types` package. The date and time related type
+  aliases haven been moved from `util.time` to the `types.time` package.
+  ([#236][#236])
+
+[#236]: https://github.com/fthomas/refined/pull/236


### PR DESCRIPTION
This is a draft that adds type aliases for standard refined types such as `Int Refined Positive` or `Int Refined Negative` as proposed in #185. Names of these type aliases are up to debate but I think the current scheme for numeric types is both precise and scalable. Having these aliases in the core module does not force their usage on users. Users are still free to use whatever name they like.

/cc @benhutchison