### PR TITLE
Move compiler-dependent code into a module

### DIFF
--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -1,1 +1,5 @@
 latestVersion in ThisBuild := "0.6.2"
+latestVersionInSeries in ThisBuild := None
+unreleasedModules in ThisBuild := Set(
+  "refined-eval"
+)

--- a/modules/docs/macro_pitfalls.md
+++ b/modules/docs/macro_pitfalls.md
@@ -102,7 +102,7 @@ java.lang.AssertionError: assertion failed: fooValidate
 	at eu.timepit.refined.macros.RefineMacro.tryN(RefineMacro.scala:9)
 	at eu.timepit.refined.macros.MacroUtils$class.eval(MacroUtils.scala:20)
 	at eu.timepit.refined.macros.RefineMacro.eval(RefineMacro.scala:9)
-	at eu.timepit.refined.macros.RefineMacro.impl(RefineMacro.scala:17)
+	at eu.timepit.refined.macros.RefineMacro.impl(RefineMacro.scala:23)
 
          val x = refineMV[Foo](0)
                               ^

--- a/modules/docs/nonnegint.md
+++ b/modules/docs/nonnegint.md
@@ -35,7 +35,7 @@ res4: Int = 2
 ```scala
 scala> // trying to call element with a negative Int fails to compile
      | element(Vector(1, 2, 3), -1)
-<console>:20: error: Predicate (-1 < 0) did not fail.
+<console>:21: error: Predicate (-1 < 0) did not fail.
        element(Vector(1, 2, 3), -1)
                                  ^
 ```

--- a/modules/docs/type_aliases.md
+++ b/modules/docs/type_aliases.md
@@ -29,20 +29,20 @@ res1: Square = Square(e,4)
 
 ```scala
 scala> Square('i', 2)
-<console>:23: error: Right predicate of (!(i < a) && !(i > h)) failed: Predicate (i > h) did not fail.
+<console>:24: error: Right predicate of (!(i < a) && !(i > h)) failed: Predicate (i > h) did not fail.
        Square('i', 2)
               ^
 
 scala> Square('a', 9)
-<console>:23: error: Right predicate of (!(9 < 1) && !(9 > 8)) failed: Predicate (9 > 8) did not fail.
+<console>:24: error: Right predicate of (!(9 < 1) && !(9 > 8)) failed: Predicate (9 > 8) did not fail.
        Square('a', 9)
                    ^
 
 scala> Square('k', -1)
-<console>:23: error: Right predicate of (!(k < a) && !(k > h)) failed: Predicate (k > h) did not fail.
+<console>:24: error: Right predicate of (!(k < a) && !(k > h)) failed: Predicate (k > h) did not fail.
        Square('k', -1)
               ^
-<console>:23: error: Left predicate of (!(-1 < 1) && !(-1 > 8)) failed: Predicate (-1 < 1) did not fail.
+<console>:24: error: Left predicate of (!(-1 < 1) && !(-1 > 8)) failed: Predicate (-1 < 1) did not fail.
        Square('k', -1)
                     ^
 ```

--- a/modules/docs/util_string.md
+++ b/modules/docs/util_string.md
@@ -28,7 +28,7 @@ java.util.regex.PatternSyntaxException: Unclosed group near index 4
   at scala.collection.immutable.StringOps.r(StringOps.scala:29)
   at scala.collection.immutable.StringLike$class.r(StringLike.scala:244)
   at scala.collection.immutable.StringOps.r(StringOps.scala:29)
-  ... 166 elided
+  ... 202 elided
 ```
 
 The library provides its own constructor for regexes in the `util.string`

--- a/modules/eval/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
+++ b/modules/eval/jvm/src/test/scala/eu/timepit/refined/GenericValidateSpecJvm.scala
@@ -2,7 +2,7 @@ package eu.timepit.refined
 
 import eu.timepit.refined.TestUtils.wellTyped
 import eu.timepit.refined.api.Validate
-import eu.timepit.refined.generic.Eval
+import eu.timepit.refined.eval.Eval
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import scala.tools.reflect.ToolBoxError

--- a/modules/eval/shared/src/main/scala/eu/timepit/refined/eval.scala
+++ b/modules/eval/shared/src/main/scala/eu/timepit/refined/eval.scala
@@ -1,0 +1,32 @@
+package eu.timepit.refined
+
+import eu.timepit.refined.api.Validate
+import eu.timepit.refined.eval._
+import scala.reflect.runtime.currentMirror
+import scala.tools.reflect.ToolBox
+import shapeless._
+
+object eval extends EvalValidate {
+
+  /** Predicate that checks if a value applied to the predicate `S` yields `true`. */
+  final case class Eval[S](s: S)
+}
+
+private[refined] trait EvalValidate {
+
+  // Cache ToolBox for Eval Validate instances
+  private lazy val toolBox = currentMirror.mkToolBox()
+
+  implicit def evalValidate[T, S <: String](
+      implicit mt: Manifest[T],
+      ws: Witness.Aux[S]
+  ): Validate.Plain[T, Eval[S]] = {
+    // The ascription (T => Boolean) allows to omit the parameter
+    // type in ws.value (i.e. "x => ..." instead of "(x: T) => ...").
+    val tree = toolBox.parse(s"(${ws.value}): ($mt => Boolean)")
+
+    val predicate = toolBox.eval(tree).asInstanceOf[T => Boolean]
+    Validate.fromPredicate(predicate, _ => ws.value, Eval(ws.value))
+  }
+
+}

--- a/project/LatestVersion.scala
+++ b/project/LatestVersion.scala
@@ -5,21 +5,46 @@ import sbtrelease.ReleaseStateTransformations.reapply
 
 object LatestVersion extends AutoPlugin {
   object autoImport {
+
     lazy val latestVersion: SettingKey[String] =
       settingKey[String]("latest released version")
+
+    lazy val latestVersionInSeries: SettingKey[Option[String]] =
+      settingKey[Option[String]]("latest released version in this binary-compatible series")
+
+    lazy val unreleasedModules: SettingKey[Set[String]] =
+      settingKey[Set[String]]("the names of modules which are new in the upcoming release")
 
     lazy val setLatestVersion: ReleaseStep = { st: State =>
       val extracted = Project.extract(st)
       val newVersion = extracted.get(version)
 
       val latestVersionSbt = "latestVersion.sbt"
-      val content = Seq(s"""latestVersion in ThisBuild := "$newVersion"""")
+      val content = Seq(
+        s"""
+          |latestVersion in ThisBuild := "$newVersion"
+          |
+          |latestVersionInSeries in ThisBuild := Some("$newVersion")
+          |
+          |unreleasedModules in ThisBuild := Seq(
+          |// Example:
+          |// "refined-eval"
+          |)
+        """.stripMargin
+      )
 
       IO.writeLines(file(latestVersionSbt), content)
       val vcs = sbtrelease.Vcs.detect(file("."))
       vcs.foreach(_.add(latestVersionSbt) !! st.log)
 
-      reapply(Seq(latestVersion in ThisBuild := newVersion), st)
+      reapply(
+        Seq(
+          latestVersion in ThisBuild := newVersion,
+          latestVersionInSeries in ThisBuild := Some(newVersion)
+        ),
+        st
+      )
     }
   }
 }
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.3-SNAPSHOT"
+version in ThisBuild := "0.7.0-SNAPSHOT"


### PR DESCRIPTION
Fixes #207
I rejiggered the parts of the build related to binary dependency checking a bit and bumped the version to 0.7.0 (-SNAPSHOT), since the change is breaking.