### PR TITLE
Change CrossVersion.full to use CrossVersion.patch for Typelevel Scala compatibility.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val pureconfigVersion = "0.5.1"
 
 // needed for tests with Scala 2.10
 val macroParadise = compilerPlugin(
-  "org.scalamacros" % "paradise" % macroParadiseVersion % Test cross CrossVersion.full)
+  "org.scalamacros" % "paradise" % macroParadiseVersion % Test cross CrossVersion.patch)
 
 val allSubprojects =
   Seq("core", "eval", "scalacheck", "scalaz", "scodec", "pureconfig")

--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,8 @@ lazy val core = crossProject
   .settings(siteSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+      scalaOrganization.value % "scala-reflect" % scalaVersion.value,
+      scalaOrganization.value % "scala-compiler" % scalaVersion.value % Provided,
       "org.typelevel" %%% "macro-compat" % macroCompatVersion,
       "com.chuusai" %%% "shapeless" % shapelessVersion,
       "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test,
@@ -101,7 +101,7 @@ lazy val eval = crossProject
   .configureCross(moduleCrossConfig("eval"))
   .dependsOn(core % "compile->compile;test->test")
   .settings(
-    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+    libraryDependencies += scalaOrganization.value % "scala-compiler" % scalaVersion.value
   )
 
 lazy val evalJVM = eval.jvm


### PR DESCRIPTION
Including text from the issue at [typelevel/scala#135](https://github.com/typelevel/scala/issues/135): 

> To use Typelevel Scala versions which are not exactly aligned with the corresponding Lightbend Scala version (ie. because they include an additional -bin-patch-nnn suffix in their version) we need to modify project builds which use CrossVersion.full (which includes the suffix) to use CrossVersion.patch (which doesn't) where appropriate (eg. for macro-paradise and other compiler plugins).

Replaced the aforementioned, as well as updating the use of "org.scala-lang" to scalaOrganization.value in library dependencies. The line below remains, as swapping that straight out obviously doesn't work since org.scala-lang.modules is a whole separate package from org.scala-lang. The project builds successfully with this left in, so please advise if this will also need changing, or if it's no problem as is.

```
Seq("org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion)
```