### PR TITLE
Improve MacroUtils.eval

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
@@ -13,7 +13,9 @@ trait MacroUtils {
     c.abort(c.enclosingPosition, msg)
 
   def eval[T](t: c.Expr[T]): T = {
-    val expr = c.Expr[T](c.untypecheck(t.tree))
+    // Duplicate and untypecheck before calling `eval`, see:
+    // http://www.scala-lang.org/api/2.12.0/scala-reflect/scala/reflect/macros/Evals.html#eval[T]%28expr:Evals.this.Expr[T]%29:T
+    val expr = c.Expr[T](c.untypecheck(t.tree.duplicate))
 
     // Try evaluating expr twice before failing, see
     // https://github.com/fthomas/refined/issues/3


### PR DESCRIPTION
by calling `duplicate` before untypechecking the tree.

This is an attempt to fix https://github.com/fthomas/refined/issues/260