### PR TITLE
Change refined-pureconfig to use pureconfig 0.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -221,9 +221,7 @@ lazy val moduleJvmSettings = Def.settings(
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core._
     import com.typesafe.tools.mima.core.ProblemFilters._
-    Seq(
-      exclude[DirectMissingMethodProblem](
-        "eu.timepit.refined.internal.RefinePartiallyApplied.force"))
+    Seq()
   }
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val scalaCheckVersion = "1.13.4"
 val scalaXmlVersion = "1.0.6"
 val scalazVersion = "7.2.9"
 val scodecVersion = "1.10.3"
-val pureconfigVersion = "0.5.1"
+val pureconfigVersion = "0.6.0"
 
 // needed for tests with Scala 2.10
 val macroParadise = compilerPlugin(

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -1,6 +1,6 @@
 latestVersion in ThisBuild := "0.7.0"
 
-latestVersionInSeries in ThisBuild := Some("0.7.0")
+latestVersionInSeries in ThisBuild := None
 
 unreleasedModules in ThisBuild := Set(
 // Example:

--- a/modules/pureconfig/jvm/src/main/scala/eu/timepit/refined/pureconfig/error/PredicateFailedException.scala
+++ b/modules/pureconfig/jvm/src/main/scala/eu/timepit/refined/pureconfig/error/PredicateFailedException.scala
@@ -1,4 +1,0 @@
-package eu.timepit.refined.pureconfig.error
-
-final case class PredicateFailedException(message: String)
-    extends IllegalArgumentException(message)

--- a/modules/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
+++ b/modules/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
@@ -22,13 +22,12 @@ class RefTypeConfigConvertSpec extends Properties("RefTypeConfigConvert") {
   property("load failure (predicate)") = secure {
     loadConfigWithValue("0") =?
       Left(
-        ConfigReaderFailures(
-          CannotConvert(
-            value = "0",
-            toTyp = "",
-            because = "Predicate failed: (0 > 0).",
-            location = None
-          )))
+        ConfigReaderFailures(CannotConvert(
+          value = "0",
+          toTyp = "eu.timepit.refined.api.Refined[Int,eu.timepit.refined.numeric.Greater[shapeless.nat._0]]",
+          because = "Predicate failed: (0 > 0).",
+          location = None
+        )))
   }
 
   property("load failure (wrong type)") = secure {

--- a/modules/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
+++ b/modules/pureconfig/jvm/src/test/scala/eu/timepit/refined/pureconfig/RefTypeConfigConvertSpec.scala
@@ -19,7 +19,7 @@ class RefTypeConfigConvertSpec extends Properties("RefTypeConfigConvert") {
       Right(Config(1))
   }
 
-  property("load failure") = secure {
+  property("load failure (predicate)") = secure {
     loadConfigWithValue("0") =?
       Left(
         ConfigReaderFailures(
@@ -27,6 +27,18 @@ class RefTypeConfigConvertSpec extends Properties("RefTypeConfigConvert") {
             value = "0",
             toTyp = "",
             because = "Predicate failed: (0 > 0).",
+            location = None
+          )))
+  }
+
+  property("load failure (wrong type)") = secure {
+    loadConfigWithValue("abc") =?
+      Left(
+        ConfigReaderFailures(
+          CannotConvert(
+            value = "abc",
+            toTyp = "Int",
+            because = "java.lang.NumberFormatException: For input string: \"abc\"",
             location = None
           )))
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.1-SNAPSHOT"
+version in ThisBuild := "0.8.0-SNAPSHOT"


### PR DESCRIPTION
Outstanding questions:
- ~~We need to populate the `toTyp` parameter of `CannotConvert` with a `String` representation of `F[T, P]`. I don't see a straightforward way to do this without using type tags, and we would then lose any type aliases. Adding the type tag breaks binary compatibility (according to MiMa).~~
- ~~`PredicateFailedException` is now unused but has not been removed as that would break binary compatibility (according to MiMa).~~