### PR TITLE
Improve uuidValidate

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -70,7 +70,9 @@ private[refined] trait StringValidate {
     Validate.fromPartial(new java.net.URL(_), "Url", Url())
 
   implicit def uuidValidate: Validate.Plain[String, Uuid] =
-    Validate.fromPartial(java.util.UUID.fromString, "Uuid", Uuid())
+    Validate.fromPartial(s => require(java.util.UUID.fromString(s).toString == s.toLowerCase),
+                         "Uuid",
+                         Uuid())
 
   implicit def xmlValidate: Validate.Plain[String, Xml] =
     Validate.fromPartial(scala.xml.XML.loadString, "Xml", Xml())


### PR DESCRIPTION
fixes #296 

```
scala> refineV[Uuid](java.util.UUID.randomUUID.toString)
res0: Either[String,eu.timepit.refined.api.Refined[String,eu.timepit.refined.string.Uuid]] = Right(15928f6a-fa6f-49db-bd96-32ca7b17eb39)

scala> refineV[Uuid](java.util.UUID.randomUUID.toString.toUpperCase)
res1: Either[String,eu.timepit.refined.api.Refined[String,eu.timepit.refined.string.Uuid]] = Right(DEA52FDE-267D-404E-83B1-311731F8A7A4)

scala> refineV[Uuid]("whops")
res2: Either[String,eu.timepit.refined.api.Refined[String,eu.timepit.refined.string.Uuid]] = Left(Uuid predicate failed: Invalid UUID string: whops)

scala> refineV[Uuid]("1-1-1-1-1")
res3: Either[String,eu.timepit.refined.api.Refined[String,eu.timepit.refined.string.Uuid]] = Left(Uuid predicate failed: requirement failed)

scala> refineV[Uuid]("aaaaaaa455781ed-10d1-4369-a977-56a8160f6e9fbbb")
res4: Either[String,eu.timepit.refined.api.Refined[String,eu.timepit.refined.string.Uuid]] = Left(Uuid predicate failed: requirement failed)
```