### PR TITLE
Specialized macros for autoRefine{V,T}

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
@@ -64,9 +64,8 @@ object auto {
    * This is an implicit version of `[[refineMV]]`.
    */
   implicit def autoRefineV[T, P](t: T)(
-      implicit rt: RefType[Refined],
-      v: Validate[T, P]
-  ): Refined[T, P] = macro RefineMacro.impl[Refined, T, P]
+      implicit v: Validate[T, P]
+  ): Refined[T, P] = macro RefineMacro.impl_Refined[T, P]
 
   /**
    * Implicitly tags (at compile-time) a value of type `T` with `P` if `t`
@@ -76,7 +75,6 @@ object auto {
    * This is an implicit version of `[[refineMT]]`.
    */
   implicit def autoRefineT[T, P](t: T)(
-      implicit rt: RefType[@@],
-      v: Validate[T, P]
-  ): T @@ P = macro RefineMacro.impl[@@, T, P]
+      implicit v: Validate[T, P]
+  ): T @@ P = macro RefineMacro.impl_@@[T, P]
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -1,10 +1,11 @@
 package eu.timepit.refined
 package macros
 
-import eu.timepit.refined.api.{RefType, Validate}
+import eu.timepit.refined.api.{Refined, RefType, Validate}
 import eu.timepit.refined.internal.Resources
 import macrocompat.bundle
 import scala.reflect.macros.blackbox
+import shapeless.tag.@@
 
 @bundle
 class RefineMacro(val c: blackbox.Context) extends MacroUtils {
@@ -14,7 +15,33 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
       rt: c.Expr[RefType[F]],
       v: c.Expr[Validate[T, P]]
   ): c.Expr[F[T, P]] = {
+    checkValue(t, v)
+    val refType = eval(rt)
+    refType.unsafeWrapM[T, P](c)(t)
+  }
 
+  def impl_Refined[T: c.WeakTypeTag, P: c.WeakTypeTag](t: c.Expr[T])(
+      v: c.Expr[Validate[T, P]]
+  ): c.Expr[Refined[T, P]] = {
+    checkValue(t, v)
+    RefType[Refined].unsafeWrapM[T, P](c)(t)
+  }
+
+  def impl_@@[T: c.WeakTypeTag, P: c.WeakTypeTag](t: c.Expr[T])(
+      v: c.Expr[Validate[T, P]]
+  ): c.Expr[T @@ P] = {
+    checkValue(t, v)
+    RefType[@@].unsafeWrapM[T, P](c)(t)
+  }
+
+  def implApplyRef[FTP, F[_, _], T, P](t: c.Expr[T])(
+      ev: c.Expr[F[T, P] =:= FTP],
+      rt: c.Expr[RefType[F]],
+      v: c.Expr[Validate[T, P]]
+  ): c.Expr[FTP] =
+    c.Expr(impl(t)(rt, v).tree)
+
+  private def checkValue[T, P](t: c.Expr[T], v: c.Expr[Validate[T, P]]): Unit = {
     val tValue: T = t.tree match {
       case Literal(Constant(value)) => value.asInstanceOf[T]
       case _                        => abort(Resources.refineNonCompileTimeConstant)
@@ -25,15 +52,5 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
     if (res.isFailed) {
       abort(validate.showResult(tValue, res))
     }
-
-    val refType = eval(rt)
-    refType.unsafeWrapM(c)(t)
   }
-
-  def implApplyRef[FTP, F[_, _], T, P](t: c.Expr[T])(
-      ev: c.Expr[F[T, P] =:= FTP],
-      rt: c.Expr[RefType[F]],
-      v: c.Expr[Validate[T, P]]
-  ): c.Expr[FTP] =
-    c.Expr(impl(t)(rt, v).tree)
 }


### PR DESCRIPTION
This specializes the macro implementations for `autoRefineV` and
`autoRefineT`. Both methods were defined in terms of the generic
`RefineMacro.impl` which works for any `RefType[F]`. This generic
implementation has the drawback that it needs to `eval` the implicit
`RefType` parameter at compile-time. Since `autoRefine{V,T}` already
know which `RefType` instance they will use, it is unnecessary to `eval`
them in the macro.

Here are the benchmark results for master and this change:
```
master:

[info] Result "eu.timepit.refined.benchmark.RefineMacroBenchmark.autoRefineV_PosInt":
[info]   0.549 ±(99.9%) 0.004 s/op [Average]
[info]   (min, avg, max) = (0.520, 0.549, 0.593), stdev = 0.015
[info]   CI (99.9%): [0.546, 0.553] (assumes normal distribution)
[info] # Run complete. Total time: 00:17:45
[info] Benchmark                                Mode  Cnt  Score   Error Units
[info] RefineMacroBenchmark.autoRefineV_PosInt  avgt  200  0.549 ± 0.004 s/op

impl_Refined:

[info] Result "eu.timepit.refined.benchmark.RefineMacroBenchmark.autoRefineV_PosInt":
[info]   0.403 ±(99.9%) 0.004 s/op [Average]
[info]   (min, avg, max) = (0.377, 0.403, 0.471), stdev = 0.017
[info]   CI (99.9%): [0.399, 0.407] (assumes normal distribution)
[info] # Run complete. Total time: 00:09:07
[info] Benchmark                                Mode  Cnt  Score   Error Units
[info] RefineMacroBenchmark.autoRefineV_PosInt  avgt  200  0.403 ± 0.004 s/op
```

That is a decrease in compilation time of ~26%. This is first PR towards
reduced compilation times: https://github.com/fthomas/refined/issues/328