### PR TITLE
Do not use eval for known RefType instances

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -1,10 +1,11 @@
 package eu.timepit.refined
 package macros
 
-import eu.timepit.refined.api.{RefType, Validate}
+import eu.timepit.refined.api.{Refined, RefType, Validate}
 import eu.timepit.refined.internal.Resources
 import macrocompat.bundle
 import scala.reflect.macros.blackbox
+import shapeless.tag.@@
 
 @bundle
 class RefineMacro(val c: blackbox.Context) extends MacroUtils {
@@ -26,8 +27,7 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
       abort(validate.showResult(tValue, res))
     }
 
-    val refType = eval(rt)
-    refType.unsafeWrapM(c)(t)
+    refTypeObj(rt).unsafeWrapM(c)(t)
   }
 
   def implApplyRef[FTP, F[_, _], T, P](t: c.Expr[T])(
@@ -36,4 +36,12 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils {
       v: c.Expr[Validate[T, P]]
   ): c.Expr[FTP] =
     c.Expr(impl(t)(rt, v).tree)
+
+  private def refTypeObj[F[_, _]](rt: c.Expr[RefType[F]]): RefType[F] =
+    if (rt.tree.tpe =:= weakTypeOf[RefType[Refined]])
+      RefType[Refined].asInstanceOf[RefType[F]]
+    else if (rt.tree.tpe =:= weakTypeOf[RefType[@@]])
+      RefType[@@].asInstanceOf[RefType[F]]
+    else
+      eval(rt)
 }

--- a/notes/0.8.4.markdown
+++ b/notes/0.8.4.markdown
@@ -1,0 +1,8 @@
+### Improvements
+
+* Avoid calling `eval` in the refine macro for known `RefType` instances.
+  This reduces compilation times by roughly 26% for all compile-time
+  refinements.
+  ([#332][#332])
+
+[#332]: https://github.com/fthomas/refined/pull/332


### PR DESCRIPTION
This avoids to call `eval` for known `RefType` instances in
`RefineMacro.impl`. This is similar to #330 but more general
since it is an optimization for all macros in the library and
not only for `autoRefine{V,T}`.

The performance improvements are similar to that of #330:
```
[info] Result "eu.timepit.refined.benchmark.RefineMacroBenchmark.autoRefineV_PosInt":
[info]   0.408 ±(99.9%) 0.003 s/op [Average]
[info]   (min, avg, max) = (0.387, 0.408, 0.442), stdev = 0.012
[info]   CI (99.9%): [0.405, 0.411] (assumes normal distribution)
[info] # Run complete. Total time: 00:09:11
[info] Benchmark                                Mode  Cnt  Score   Error Units
[info] RefineMacroBenchmark.autoRefineV_PosInt  avgt  200  0.408 ± 0.003 s/op

```