### PR TITLE
Inline Validate.instance in Validate.fromPredicate

### DIFF
--- a/modules/benchmark/src/main/scala/eu/timepit/refined/benchmark/RefineVBenchmark.scala
+++ b/modules/benchmark/src/main/scala/eu/timepit/refined/benchmark/RefineVBenchmark.scala
@@ -1,0 +1,16 @@
+package eu.timepit.refined.benchmark
+
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.refineV
+import eu.timepit.refined.types.numeric.PosInt
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+class RefineVBenchmark {
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def refineV_Positive: Either[String, PosInt] =
+    refineV[Positive](1)
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
@@ -72,8 +72,14 @@ object Validate {
    * Constructs a `[[Validate]]` from the predicate `f`. All values of type
    * `T` for which `f` returns `true` are considered valid according to `P`.
    */
-  def fromPredicate[T, P](f: T => Boolean, showExpr: T => String, p: P): Plain[T, P] =
-    instance(t => Result.fromBoolean(f(t), p), showExpr)
+  def fromPredicate[T, P](f: T => Boolean, showExpr: T => String, p: P): Plain[T, P] = {
+    val g = showExpr
+    new Validate[T, P] {
+      override type R = P
+      override def validate(t: T): Res = Result.fromBoolean(f(t), p)
+      override def showExpr(t: T): String = g(t)
+    }
+  }
 
   /**
    * Constructs a `[[Validate]]` from the partial function `pf`. All `T`s for

--- a/notes/0.8.4.markdown
+++ b/notes/0.8.4.markdown
@@ -1,4 +1,4 @@
-### Improvements
+### Performance improvements
 
 * Avoid calling `eval` in refine and infer macros for known `RefType`
   instances. This reduces compilation times by roughly 26% for all
@@ -7,7 +7,10 @@
 * Avoid calling `eval` in refine macros for a few `Validate` instances.
   In combination with the above change, this can reduce compilation times
   up to 67%. ([#334][#334])
+* Inline `Validate.instance` in the definition of `Validate.fromPredicate`.
+  This makes `refineV[Positive](x)` for instance 25% faster.
 
 [#332]: https://github.com/fthomas/refined/pull/332
 [#333]: https://github.com/fthomas/refined/pull/333
 [#334]: https://github.com/fthomas/refined/pull/334
+[#335]: https://github.com/fthomas/refined/pull/335


### PR DESCRIPTION
Motivation for this is the considerable effect on the newly added
benchmark:
```
master:
[info] Benchmark                          Mode  Cnt   Score   Error Units
[info] RefineVBenchmark.refineV_Positive  avgt  200  27.557 ± 0.298 ns/op

this branch:
[info] Benchmark                          Mode  Cnt   Score   Error Units
[info] RefineVBenchmark.refineV_Positive  avgt  200  20.605 ± 0.156 ns/op
```