### PR TITLE
Optimize Validate.fromPartial

### DIFF
--- a/modules/benchmark/src/main/scala/eu/timepit/refined/benchmark/RefineVBenchmark.scala
+++ b/modules/benchmark/src/main/scala/eu/timepit/refined/benchmark/RefineVBenchmark.scala
@@ -1,8 +1,9 @@
 package eu.timepit.refined.benchmark
 
+import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
-import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.string.Regex
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit}
 
@@ -11,6 +12,11 @@ class RefineVBenchmark {
 
   @Benchmark
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
-  def refineV_Positive: Either[String, PosInt] =
+  def refineV_Positive: Either[String, Int Refined Positive] =
     refineV[Positive](1)
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def refineV_Regex: Either[String, String Refined Regex] =
+    refineV[Regex](".*")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
@@ -3,6 +3,7 @@ package api
 
 import eu.timepit.refined.internal.Resources
 import scala.util.Try
+import scala.util.control.NonFatal
 
 /**
  * Type class for validating values of type `T` according to a type-level
@@ -90,7 +91,12 @@ object Validate {
       override type R = P
 
       override def validate(t: T): Res =
-        Result.fromBoolean(Try(pf(t)).isSuccess, p)
+        try {
+          pf(t)
+          Passed(p)
+        } catch {
+          case NonFatal(_) => Failed(p)
+        }
 
       override def showExpr(t: T): String =
         Resources.isValidName(name, t)

--- a/notes/0.8.4.markdown
+++ b/notes/0.8.4.markdown
@@ -8,9 +8,13 @@
   In combination with the above change, this can reduce compilation times
   up to 67%. ([#334][#334])
 * Inline `Validate.instance` in the definition of `Validate.fromPredicate`.
-  This makes `refineV[Positive](x)` for instance 25% faster.
+  This makes `refineV[Positive](x)` for instance 25% faster. ([#335][#335])
+* Optimize `Validate` instances that are built with `Validate.fromPartial`.
+  ([#336][#336])
+
 
 [#332]: https://github.com/fthomas/refined/pull/332
 [#333]: https://github.com/fthomas/refined/pull/333
 [#334]: https://github.com/fthomas/refined/pull/334
 [#335]: https://github.com/fthomas/refined/pull/335
+[#336]: https://github.com/fthomas/refined/pull/336


### PR DESCRIPTION
Benchmark results for this change:
```
master:
[info] Result "eu.timepit.refined.benchmark.RefineVBenchmark.refineV_Regex":
[info]   121.400 ±(99.9%) 1.297 ns/op [Average]
[info]   (min, avg, max) = (110.969, 121.400, 159.030), stdev = 5.493
[info]   CI (99.9%): [120.103, 122.698] (assumes normal distribution)
[info] # Run complete. Total time: 00:06:43
[info] Benchmark                       Mode  Cnt    Score   Error  Units
[info] RefineVBenchmark.refineV_Regex  avgt  200  121.400 ± 1.297  ns/op

this branch:
[info] Result "eu.timepit.refined.benchmark.RefineVBenchmark.refineV_Regex":
[info]   108.263 ±(99.9%) 0.893 ns/op [Average]
[info]   (min, avg, max) = (100.935, 108.263, 138.393), stdev = 3.780
[info]   CI (99.9%): [107.370, 109.156] (assumes normal distribution)
[info] # Run complete. Total time: 00:06:43
[info] Benchmark                       Mode  Cnt    Score   Error  Units
[info] RefineVBenchmark.refineV_Regex  avgt  200  108.263 ± 0.893  ns/op
```