### PR TITLE
Add string checks for IPv4, IPv6

### DIFF
--- a/modules/core/jvm/src/test/scala/eu/timepit/refined/StringValidateSpecJvm.scala
+++ b/modules/core/jvm/src/test/scala/eu/timepit/refined/StringValidateSpecJvm.scala
@@ -6,6 +6,21 @@ import org.scalacheck.Prop._
 import org.scalacheck.Properties
 
 class StringValidateSpecJvm extends Properties("StringValidate") {
+  property("IPv4.isValid") = secure {
+    isValid[IPv4]("10.0.0.1")
+  }
+
+  property("IPv4.showResult.Failed") = secure {
+    showResult[IPv4]("::1") ?= "IPv4 predicate failed: requirement failed"
+  }
+
+  property("IPv6.isValid") = secure {
+    isValid[IPv6]("::1")
+  }
+
+  property("IPv6.showResult.Failed") = secure {
+    showResult[IPv6]("10.0.0.1") ?= "IPv6 predicate failed: requirement failed"
+  }
 
   property("Regex.showResult") = secure {
     showResult[Regex]("(a|b") ?=

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -15,6 +15,12 @@ object string extends StringValidate with StringInference {
   /** Predicate that checks if a `String` ends with the suffix `S`. */
   final case class EndsWith[S](s: S)
 
+  /** Predicate that checks if a `String` is a valid IPv4 */
+  final case class IPv4()
+
+  /** Predicate that checks if a `String` is a valid IPv6 */
+  final case class IPv6()
+
   /** Predicate that checks if a `String` matches the regular expression `S`. */
   final case class MatchesRegex[S](s: S)
 
@@ -47,6 +53,20 @@ private[refined] trait StringValidate {
     Validate.fromPredicate(_.endsWith(ws.value),
                            t => s""""$t".endsWith("${ws.value}")""",
                            EndsWith(ws.value))
+
+  implicit def ipv4Validate: Validate.Plain[String, IPv4] =
+    Validate.fromPartial(
+      s => require(java.net.InetAddress.getByName(s).isInstanceOf[java.net.Inet4Address]),
+      "IPv4",
+      IPv4()
+    )
+
+  implicit def ipv6Validate: Validate.Plain[String, IPv6] =
+    Validate.fromPartial(
+      s => require(java.net.InetAddress.getByName(s).isInstanceOf[java.net.Inet6Address]),
+      "IPv6",
+      IPv6()
+    )
 
   implicit def matchesRegexValidate[S <: String](
       implicit ws: Witness.Aux[S]): Validate.Plain[String, MatchesRegex[S]] =


### PR DESCRIPTION
Uses `java.net.Inet{,4,6}Address` to determine whether a String is a valid IPv4/IPv6.