### PR TITLE
Add IPv6 string validation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -272,7 +272,9 @@ lazy val moduleJvmSettings = Def.settings(
       ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.scalacheck.util.OurMath$"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.StringValidate.*"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.types.*"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.NumericValidate.*")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.NumericValidate.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "eu.timepit.refined.StringValidate.ipv6Validate")
     )
   }
 )

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
@@ -82,6 +82,41 @@ class StringValidateSpec extends Properties("StringValidate") {
   property("IPv4.showResult.Failed") = secure {
     showResult[IPv4]("::1") ?= "Predicate failed: ::1 is a valid IPv4."
   }
+  property("IPv6.isValid.full") = secure {
+    isValid[IPv6]("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+  }
+
+  property("IPv6.isValid.noLeadingZeros") = secure {
+    isValid[IPv6]("2001:db8:85a3:0:0:8a2e:370:7334")
+  }
+
+  property("IPv6.isValid.compact") = secure {
+    isValid[IPv6]("2001:db8:85a3::8a2e:370:7334")
+  }
+
+  property("IPv6.isValid.local") = secure {
+    isValid[IPv6]("::1")
+  }
+
+  property("IPv6.isValid.linkLocal") = secure {
+    isValid[IPv6]("fe80::7:8%eth0")
+  }
+
+  property("IPv6.isValid.mapped") = secure {
+    isValid[IPv6]("::ffff:255.255.255.255")
+  }
+
+  property("IPv6.isValid.embedded") = secure {
+    isValid[IPv6]("2001:db8:122:344::192.0.2.33")
+  }
+
+  property("IPv6.showResult.Failed.Random") = secure {
+    showResult[IPv6]("foo") ?= "Predicate failed: foo is a valid IPv6."
+  }
+
+  property("IPv6.showResult.Failed.DoubleCompact") = secure {
+    showResult[IPv6]("2001::0::1234") ?= "Predicate failed: 2001::0::1234 is a valid IPv6."
+  }
 
   private def validNumber[N: Arbitrary, P](name: String, invalidValue: String)(
       implicit v: Validate[String, P]) = {


### PR DESCRIPTION
Looks like IPv6 validation using a regex is what makes the most sense.

- I looked at `sun.net.util.IPAddressUtil` but that's an internal JDK API, not supposed to be used, not available for Scala.JS (it is the underlying implementation for `java.net.InetAddress`)
- `java.net.InetAddress` itself always tries to make DNS calls unless you convert the String into the address bytes. That would, however, require a lot of logic to undo compacting etc.
- Guava and Apache Commons Validator are JVM-only and fairly large