### PR TITLE
Collection validate instances for ByteVector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,11 @@ lazy val scodec = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "org.scodec" %%% "scodec-core" % scodecVersion,
       macroParadise
-    )
+    ),
+    initialCommands += s"""
+      import $rootPkg.scodec.predicates.byteVector._
+      import _root_.scodec.bits.ByteVector
+    """
   )
 
 lazy val scodecJVM = scodec.jvm

--- a/modules/scodec/shared/src/main/scala/eu/timepit/refined/scodec/predicates/byteVector.scala
+++ b/modules/scodec/shared/src/main/scala/eu/timepit/refined/scodec/predicates/byteVector.scala
@@ -1,0 +1,30 @@
+package eu.timepit.refined.scodec.predicates
+
+import eu.timepit.refined.api.Validate
+import eu.timepit.refined.collection.Size
+import eu.timepit.refined.internal.Resources
+import scodec.bits.ByteVector
+
+object byteVector extends ByteVectorValidate
+
+private[refined] trait ByteVectorValidate {
+  implicit def byteVectorSizeValidate[P, RP](
+      implicit v: Validate.Aux[Long, P, RP]): Validate.Aux[ByteVector, Size[P], Size[v.Res]] =
+    new Validate[ByteVector, Size[P]] {
+      override type R = Size[v.Res]
+
+      override def validate(t: ByteVector): Res = {
+        val r = v.validate(t.size)
+        r.as(Size(r))
+      }
+
+      override def showExpr(t: ByteVector): String =
+        v.showExpr(t.size)
+
+      override def showResult(t: ByteVector, r: Res): String = {
+        val size = t.size
+        val nested = v.showResult(size, r.detail.p)
+        Resources.predicateTakingResultDetail(s"size($t) = $size", r, nested)
+      }
+    }
+}

--- a/modules/scodec/shared/src/main/scala/eu/timepit/refined/scodec/predicates/byteVector.scala
+++ b/modules/scodec/shared/src/main/scala/eu/timepit/refined/scodec/predicates/byteVector.scala
@@ -5,6 +5,7 @@ import eu.timepit.refined.collection.Size
 import eu.timepit.refined.internal.Resources
 import scodec.bits.ByteVector
 
+/** Module that provides `Validate` type class instances for `ByteVector`. */
 object byteVector extends ByteVectorValidate
 
 private[refined] trait ByteVectorValidate {

--- a/modules/scodec/shared/src/test/scala/eu/timepit/refined/scodec/predicates/ByteVectorValidateSpec.scala
+++ b/modules/scodec/shared/src/test/scala/eu/timepit/refined/scodec/predicates/ByteVectorValidateSpec.scala
@@ -1,0 +1,29 @@
+package eu.timepit.refined.scodec.predicates
+
+import eu.timepit.refined.TestUtils._
+import eu.timepit.refined.W
+import eu.timepit.refined.collection.Size
+import eu.timepit.refined.generic.Equal
+import eu.timepit.refined.numeric.Greater
+import eu.timepit.refined.scodec.predicates.byteVector._
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+import scodec.bits.ByteVector
+
+class ByteVectorValidateSpec extends Properties("ByteVectorValidate") {
+
+  property("Size.isValid") = forAll { bytes: Array[Byte] =>
+    val bv = ByteVector(bytes)
+    isValid[Size[Greater[W.`5L`.T]]](bv) ?= (bv.size > 5L)
+  }
+
+  property("Size.showExpr") = secure {
+    showExpr[Size[Equal[W.`5L`.T]]](ByteVector.fromValidHex("0xdeadbeef")) ?= "(4 == 5)"
+  }
+
+  property("Size.showResult") = secure {
+    showResult[Size[Equal[W.`5L`.T]]](ByteVector.fromValidHex("0xdeadbeef")) ?=
+      "Predicate taking size(ByteVector(4 bytes, 0xdeadbeef)) = 4 failed: Predicate failed: (4 == 5)."
+  }
+
+}

--- a/notes/0.8.5.markdown
+++ b/notes/0.8.5.markdown
@@ -18,6 +18,14 @@
 * Add `IPv4` predicate for `String`s and refined types for private IPv4
   addresses. Thanks to [Tim Steinbach](https://github.com/NeQuissimus)!
   ([#356][#356])
+* Add `Validate[ByteVector, Size[P]]` instance to the `refined-scodec`
+  module. This allows to refine `ByteVector`s with the `Size` predicate,
+  for example:
+  ```scala
+  scala> refineV[Size[Equal[W.`2L`.T]]](ByteVector.fromValidHex("0xabcd"))
+  res0: Either[String, ByteVector Refined Size[Equal[Long(2L)]]] = Right(ByteVector(2 bytes, 0xabcd))
+  ```
+  ([#365][#365])
 
 ### Changes
 
@@ -38,3 +46,4 @@
 [#351]: https://github.com/fthomas/refined/pull/351
 [#356]: https://github.com/fthomas/refined/pull/356
 [#360]: https://github.com/fthomas/refined/pull/360
+[#365]: https://github.com/fthomas/refined/pull/365


### PR DESCRIPTION
This is still WIP and for now only contains an instance for `Size`.

Example usage:
```scala
scala> refineV[Size[Equal[W.`2L`.T]]](ByteVector.fromValidHex("0xabcd"))
res0: Either[String, Refined[ByteVector, Size[Equal[Long(2L)]]]] = Right(ByteVector(2 bytes, 0xabcd))

scala> refineV[Size[Equal[W.`2L`.T]]](ByteVector.fromValidHex("0xabcdef"))
res1: Either[String, Refined[ByteVector, Size[Equal[Long(2L)]]]] = Left(Predicate taking size(ByteVector(3 bytes, 0xabcdef)) = 3 failed: Predicate failed: (3 == 2).)
```

This implements #363. /cc @coltfred