### PR TITLE
Remove "predicates" package from refined-scodec

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The project provides these optional extensions and library integrations:
 * `refined-scalaz` provides [Scalaz](https://github.com/scalaz/scalaz)
   type class instances for refined types and support for `scalaz.@@`
 * `refined-scodec` allows binary decoding and encoding of refined types with
-  [scodec](http://scodec.org/)
+  [scodec](http://scodec.org/) and allows refining `scodec.bits.ByteVector`
 
 ### External modules
 

--- a/modules/scodec/shared/src/main/scala/eu/timepit/refined/scodec/byteVector.scala
+++ b/modules/scodec/shared/src/main/scala/eu/timepit/refined/scodec/byteVector.scala
@@ -1,4 +1,4 @@
-package eu.timepit.refined.scodec.predicates
+package eu.timepit.refined.scodec
 
 import eu.timepit.refined.api.Validate
 import eu.timepit.refined.collection.Size

--- a/modules/scodec/shared/src/test/scala/eu/timepit/refined/scodec/ByteVectorValidateSpec.scala
+++ b/modules/scodec/shared/src/test/scala/eu/timepit/refined/scodec/ByteVectorValidateSpec.scala
@@ -1,11 +1,11 @@
-package eu.timepit.refined.scodec.predicates
+package eu.timepit.refined.scodec
 
 import eu.timepit.refined.TestUtils._
 import eu.timepit.refined.W
 import eu.timepit.refined.collection.Size
 import eu.timepit.refined.generic.Equal
 import eu.timepit.refined.numeric.Greater
-import eu.timepit.refined.scodec.predicates.byteVector._
+import eu.timepit.refined.scodec.byteVector._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import scodec.bits.ByteVector


### PR DESCRIPTION
This aligns the organization of `Validate` instances with
the core module.