### PR TITLE
Add `Order` instance to cats module

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ The library comes with these predefined predicates:
 * [Dale Wijnand](https://github.com/dwijnand) ([@dwijnand](https://twitter.com/dwijnand))
 * [Derek Morr](https://github.com/derekmorr) ([@derekmorr](https://twitter.com/derekmorr))
 * [Frank S. Thomas](https://github.com/fthomas) ([@fst9000](https://twitter.com/fst9000))
+* [Howard Perrin](https://github.com/howyp)
 * [Iurii Susuk](https://github.com/ysusuk) ([@IuriiSusuk](https://twitter.com/IuriiSusuk))
 * [Jean-Rémi Desjardins](https://github.com/jedesah) ([@jrdesjardins](https://twitter.com/jrdesjardins))
 * [Joe Greene](https://github.com/ClydeMachine)

--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/package.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/package.scala
@@ -2,7 +2,9 @@ package eu.timepit.refined
 
 import _root_.cats.Show
 import _root_.cats.instances.eq._
+import _root_.cats.instances.order._
 import _root_.cats.kernel.Eq
+import _root_.cats.kernel.Order
 import _root_.cats.syntax.contravariant._
 import eu.timepit.refined.api.RefType
 
@@ -21,4 +23,11 @@ package object cats {
    */
   implicit def refTypeShow[F[_, _], T: Show, P](implicit rt: RefType[F]): Show[F[T, P]] =
     Show[T].contramap(rt.unwrap)
+
+  /**
+   * `Order` instance for refined types that delegates to the `Order`
+   * instance of the base type.
+   */
+  implicit def refTypeOrder[F[_, _], T: Order, P](implicit rt: RefType[F]): Order[F[T, P]] =
+    Order[T].contramap(rt.unwrap)
 }

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/CatsSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/CatsSpec.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined.cats
 
 import cats.instances.int._
-import cats.syntax.eq._
+import cats.syntax.order._
 import cats.syntax.show._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.PosInt
@@ -19,5 +19,11 @@ class CatsSpec extends Properties("cats") {
   property("Show") = secure {
     val x: PosInt = 5
     x.show ?= "5"
+  }
+
+  property("Order") = secure {
+    val x: PosInt = 5
+    val y: PosInt = 6
+    x min y ?= x
   }
 }

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/CatsSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/CatsSpec.scala
@@ -22,8 +22,8 @@ class CatsSpec extends Properties("cats") {
   }
 
   property("Order") = secure {
-    val x: PosInt = 5
-    val y: PosInt = 6
+    val x: PosInt = PosInt(5)
+    val y: PosInt = PosInt(6)
     x min y ?= x
   }
 }


### PR DESCRIPTION
Delegates to the `Order` instance for the wrapped type, in the same way as the `Eq`/`Show` instances