### PR TITLE
Shadow cats.Order instance in the cats.Eq test

### DIFF
--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/package.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/package.scala
@@ -1,11 +1,8 @@
 package eu.timepit.refined
 
 import _root_.cats.Show
-import _root_.cats.instances.eq._
-import _root_.cats.instances.order._
-import _root_.cats.kernel.Eq
-import _root_.cats.kernel.Order
-import _root_.cats.syntax.contravariant._
+import _root_.cats.implicits._
+import _root_.cats.kernel.{Eq, Order}
 import eu.timepit.refined.api.RefType
 
 package object cats {
@@ -18,16 +15,16 @@ package object cats {
     Eq[T].contramap(rt.unwrap)
 
   /**
-   * `Show` instance for refined types that delegates to the `Show`
-   * instance of the base type.
-   */
-  implicit def refTypeShow[F[_, _], T: Show, P](implicit rt: RefType[F]): Show[F[T, P]] =
-    Show[T].contramap(rt.unwrap)
-
-  /**
    * `Order` instance for refined types that delegates to the `Order`
    * instance of the base type.
    */
   implicit def refTypeOrder[F[_, _], T: Order, P](implicit rt: RefType[F]): Order[F[T, P]] =
     Order[T].contramap(rt.unwrap)
+
+  /**
+   * `Show` instance for refined types that delegates to the `Show`
+   * instance of the base type.
+   */
+  implicit def refTypeShow[F[_, _], T: Show, P](implicit rt: RefType[F]): Show[F[T, P]] =
+    Show[T].contramap(rt.unwrap)
 }

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/CatsSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/CatsSpec.scala
@@ -1,25 +1,26 @@
 package eu.timepit.refined.cats
 
-import cats.instances.int._
-import cats.syntax.order._
-import cats.syntax.show._
+import cats.implicits._
 import eu.timepit.refined.types.numeric.PosInt
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 
 class CatsSpec extends Properties("cats") {
 
-  property("Equal") = secure {
+  property("Eq") = secure {
+    val refTypeOrder: Unit = () // shadow the `Order` instance so the `Eq` instance is tested
+    locally(refTypeOrder) // prevent a "unused" warning
+
     PosInt.unsafeFrom(5) === PosInt.unsafeFrom(5)
+  }
+
+  property("Order") = secure {
+    val x = PosInt.unsafeFrom(5)
+    val y = PosInt.unsafeFrom(6)
+    x min y ?= x
   }
 
   property("Show") = secure {
     PosInt.unsafeFrom(5).show ?= "5"
-  }
-
-  property("Order") = secure {
-    val x: PosInt = PosInt.unsafeFrom(5)
-    val y: PosInt = PosInt.unsafeFrom(6)
-    x min y ?= x
   }
 }


### PR DESCRIPTION
Without shadowing, the `Order` instance is used in this test
because `Order` is a subtype of `Eq`.