### PR TITLE
Valid number string predicates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -268,8 +268,7 @@ lazy val moduleJvmSettings = Def.settings(
         "eu.timepit.refined.NumericValidate.moduloValidateNat"),
       ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.scalacheck.util.OurMath"),
       ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.scalacheck.util.OurMath$"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "eu.timepit.refined.StringValidate.ipv4Validate"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.StringValidate.*"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.types.*")
     )
   }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -56,6 +56,21 @@ object string extends StringValidate with StringInference {
 
   /** Predicate that checks if a `String` is a valid XPath expression. */
   final case class XPath()
+
+  /** Predicate that checks if a `String` can be a valid `Int`. */
+  final case class ValidInt()
+
+  /** Predicate that checks if a `String` can be a valid `Long`. */
+  final case class ValidLong()
+
+  /** Predicate that checks if a `String` can be a valid `Double`. */
+  final case class ValidDouble()
+
+  /** Predicate that checks if a `String` can be a valid `BigInt`. */
+  final case class ValidBigInt()
+
+  /** Predicate that checks if a `String` can be a valid `BigDecimal`. */
+  final case class ValidBigDecimal()
 }
 
 private[refined] trait StringValidate {
@@ -100,6 +115,21 @@ private[refined] trait StringValidate {
   implicit def xpathValidate: Validate.Plain[String, XPath] =
     Validate
       .fromPartial(javax.xml.xpath.XPathFactory.newInstance().newXPath().compile, "XPath", XPath())
+
+  implicit def validIntValidate: Validate.Plain[String, ValidInt] =
+    Validate.fromPartial(_.toInt, "Int", ValidInt())
+
+  implicit def validLongValidate: Validate.Plain[String, ValidLong] =
+    Validate.fromPartial(_.toLong, "Long", ValidLong())
+
+  implicit def validDoubleValidate: Validate.Plain[String, ValidDouble] =
+    Validate.fromPartial(_.toDouble, "Double", ValidDouble())
+
+  implicit def validBigIntValidate: Validate.Plain[String, ValidBigInt] =
+    Validate.fromPartial(BigInt(_), "BigInt", ValidBigInt())
+
+  implicit def validBigDecimalValidate: Validate.Plain[String, ValidBigDecimal] =
+    Validate.fromPartial(BigDecimal(_), "BigDecimal", ValidBigDecimal())
 }
 
 private[refined] trait StringInference {

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -117,19 +117,19 @@ private[refined] trait StringValidate {
       .fromPartial(javax.xml.xpath.XPathFactory.newInstance().newXPath().compile, "XPath", XPath())
 
   implicit def validIntValidate: Validate.Plain[String, ValidInt] =
-    Validate.fromPartial(_.toInt, "Int", ValidInt())
+    Validate.fromPartial(_.toInt, "ValidInt", ValidInt())
 
   implicit def validLongValidate: Validate.Plain[String, ValidLong] =
-    Validate.fromPartial(_.toLong, "Long", ValidLong())
+    Validate.fromPartial(_.toLong, "ValidLong", ValidLong())
 
   implicit def validDoubleValidate: Validate.Plain[String, ValidDouble] =
-    Validate.fromPartial(_.toDouble, "Double", ValidDouble())
+    Validate.fromPartial(_.toDouble, "ValidDouble", ValidDouble())
 
   implicit def validBigIntValidate: Validate.Plain[String, ValidBigInt] =
-    Validate.fromPartial(BigInt(_), "BigInt", ValidBigInt())
+    Validate.fromPartial(BigInt(_), "ValidBigInt", ValidBigInt())
 
   implicit def validBigDecimalValidate: Validate.Plain[String, ValidBigDecimal] =
-    Validate.fromPartial(BigDecimal(_), "BigDecimal", ValidBigDecimal())
+    Validate.fromPartial(BigDecimal(_), "ValidBigDecimal", ValidBigDecimal())
 }
 
 private[refined] trait StringInference {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
@@ -84,20 +84,20 @@ class StringValidateSpec extends Properties("StringValidate") {
   }
 
   private def validNumber[N: Arbitrary, P](name: String, invalidValue: String)(implicit v: Validate[String, P]) = {
-    property(s"Valid$name") = secure {
+    property(name) = secure {
       forAll { (n: N) =>
         isValid[P](n.toString) &&
           (showResult[P](n.toString) ?= s"$name predicate passed.")
       }
     }
-    property(s"Valid$name.showResult.Failed") = secure {
-      showResult[P](invalidValue) ?= s"Predicate failed: $name"
+    property(s"$name.showResult.Failed") = secure {
+      showResult[P](invalidValue).startsWith(s"$name predicate failed")
     }
   }
 
-  validNumber[Int, ValidInt]("Int", Long.MaxValue.toString)
-  validNumber[Long, ValidLong]("Long", "1.0")
-  validNumber[Double, ValidDouble]("Double", "a")
-  validNumber[BigInt, ValidBigInt]("BigInt", "1.0")
-  validNumber[BigDecimal, ValidBigDecimal]("BigDecimal", "a")
+  validNumber[Int, ValidInt]("ValidInt", Long.MaxValue.toString)
+  validNumber[Long, ValidLong]("ValidLong", "1.0")
+  validNumber[Double, ValidDouble]("ValidDouble", "a")
+  validNumber[BigInt, ValidBigInt]("ValidBigInt", "1.0")
+  validNumber[BigDecimal, ValidBigDecimal]("ValidBigDecimal", "a")
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
@@ -83,11 +83,12 @@ class StringValidateSpec extends Properties("StringValidate") {
     showResult[IPv4]("::1") ?= "Predicate failed: ::1 is a valid IPv4."
   }
 
-  private def validNumber[N: Arbitrary, P](name: String, invalidValue: String)(implicit v: Validate[String, P]) = {
+  private def validNumber[N: Arbitrary, P](name: String, invalidValue: String)(
+      implicit v: Validate[String, P]) = {
     property(name) = secure {
       forAll { (n: N) =>
         isValid[P](n.toString) &&
-          (showResult[P](n.toString) ?= s"$name predicate passed.")
+        (showResult[P](n.toString) ?= s"$name predicate passed.")
       }
     }
     property(s"$name.showResult.Failed") = secure {


### PR DESCRIPTION
Adds the following string predicates: `ValidInt`, `ValidLong`, `ValidDouble`, `ValidBigInt`, and `ValidBigDecimal`.

I initially implemented this with a typeclass-based approach, e.g. `ParsableString[N]`, which the `Validate` instance would use, but it seemed to be double the work than just creating new predicates and the corresponding `Validate` instances. Both seem extensible enough, though I surmise that a typeclass-based approach would be a little less verbose, since supplying the typeclass instances would be enough to get started. @fthomas, if you think that that's a more sensible approach, then I can always update this PR.

I'm also thinking of adding inference instances for these, but I'll hold off for now until I can find a good way of doing it without copious amounts of copy and paste.