### PR TITLE
Reduce compilation times of RefineMacro.implApplyRef

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -262,6 +262,8 @@ lazy val moduleJvmSettings = Def.settings(
     Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "eu.timepit.refined.macros.MacroUtils.refTypeInstance"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "eu.timepit.refined.macros.RefineMacro.implApplyRef"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "eu.timepit.refined.NumericValidate.moduloValidateWit"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -39,7 +39,7 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils with LiteralMatche
       rt: c.Expr[RefType[F]],
       v: c.Expr[Validate[T, P]]
   ): c.Expr[FTP] =
-    c.Expr(impl(t)(rt, v).tree)
+    c.Expr[FTP](impl(t)(rt, v).tree)
 
   private def validateInstance[T, P](v: c.Expr[Validate[T, P]])(
       implicit

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -34,7 +34,7 @@ class RefineMacro(val c: blackbox.Context) extends MacroUtils with LiteralMatche
     refTypeInstance(rt).unsafeWrapM(c)(t)
   }
 
-  def implApplyRef[FTP, F[_, _], T, P](t: c.Expr[T])(
+  def implApplyRef[FTP, F[_, _], T: c.WeakTypeTag, P: c.WeakTypeTag](t: c.Expr[T])(
       ev: c.Expr[F[T, P] =:= FTP],
       rt: c.Expr[RefType[F]],
       v: c.Expr[Validate[T, P]]

--- a/notes/0.8.6.markdown
+++ b/notes/0.8.6.markdown
@@ -28,7 +28,17 @@
 
 Thanks to [kusamakura](https://github.com/kusamakura)! ([#379][#379])
 
+### Performance improvements
+
+* Apply the optimization done in [#334][#334] also to macro calls that
+  use `RefineMacro.implApplyRef`. Before this change, compilation time
+  of e.g. `PosInt(1)` was one order of magnitude slower than `1: PosInt`.
+  With this change there is no difference in compilation times between
+  these two calls. ([#338][#338])
+
+[#334]: https://github.com/fthomas/refined/pull/334
 [#379]: https://github.com/fthomas/refined/pull/379
 [#382]: https://github.com/fthomas/refined/pull/382
 [#384]: https://github.com/fthomas/refined/pull/384
 [#385]: https://github.com/fthomas/refined/pull/385
+[#338]: https://github.com/fthomas/refined/pull/388


### PR DESCRIPTION
Adding `WeakTypeTag` context bounds on the `T` and `P` type parameters
allows to retrieve `Validate` instances for some types instead of
`eval`uating them. This optimization was implemented in #334 but did
not work here because of the missing `WeakTypeTag`s.

The big difference in compilation times of `impl` and `implApplyRef`
is gone now:
```scala
scala>
shapeless.test.compileTime("RefType[Refined].refineM[Positive](1)").toMillis
res20: Long = 66

scala>
shapeless.test.compileTime("RefType.applyRefM[PosInt](1)").toMillis
res21: Long = 62
```

Closes #387.