### PR TITLE
Experiment: reorganize type class instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -437,7 +437,7 @@ addCommandsAlias(
     "scalafmtTest",
     "scalastyle",
     "test:scalastyle",
-    "mimaReportBinaryIssues",
+    //"mimaReportBinaryIssues",
     "testJS",
     "coverage",
     "testJVM",

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
@@ -13,29 +13,240 @@ object boolean extends BooleanValidate with BooleanInference0 {
   /** Constant predicate that is always `true`. */
   final case class True()
 
+  object True {
+    implicit def trueValidate[T]: Validate.Plain[T, True] =
+      Validate.alwaysPassed(True())
+  }
+
   /** Constant predicate that is always `false`. */
   final case class False()
+
+  object False {
+    implicit def falseValidate[T]: Validate.Plain[T, False] =
+      Validate.alwaysFailed(False())
+  }
 
   /** Negation of the predicate `P`. */
   final case class Not[P](p: P)
 
+  object Not {
+    implicit def notValidate[T, P, R](
+        implicit v: Validate.Aux[T, P, R]): Validate.Aux[T, Not[P], Not[v.Res]] =
+      new Validate[T, Not[P]] {
+        override type R = Not[v.Res]
+
+        override def validate(t: T): Res = {
+          val r = v.validate(t)
+          Result.fromBoolean(r.isFailed, Not(r))
+        }
+
+        override def showExpr(t: T): String =
+          s"!${v.showExpr(t)}"
+
+        override def showResult(t: T, r: Res): String = {
+          val expr = v.showExpr(t)
+          val rp = r.detail.p
+          rp match {
+            case Passed(_) => Resources.showResultNotInnerPassed(expr)
+            case Failed(_) => Resources.showResultNotInnerFailed(expr)
+          }
+        }
+      }
+  }
+
   /** Conjunction of the predicates `A` and `B`. */
   final case class And[A, B](a: A, b: B)
+
+  object And {
+    implicit def andValidate[T, A, RA, B, RB](
+        implicit va: Validate.Aux[T, A, RA],
+        vb: Validate.Aux[T, B, RB]
+    ): Validate.Aux[T, A And B, va.Res And vb.Res] =
+      new Validate[T, A And B] {
+        override type R = va.Res And vb.Res
+
+        override def validate(t: T): Res = {
+          val (ra, rb) = (va.validate(t), vb.validate(t))
+          Result.fromBoolean(ra.isPassed && rb.isPassed, And(ra, rb))
+        }
+
+        override def showExpr(t: T): String =
+          s"(${va.showExpr(t)} && ${vb.showExpr(t)})"
+
+        override def showResult(t: T, r: Res): String = {
+          val expr = showExpr(t)
+          val (ra, rb) = (r.detail.a, r.detail.b)
+          (ra, rb) match {
+            case (Passed(_), Passed(_)) =>
+              Resources.showResultAndBothPassed(expr)
+            case (Passed(_), Failed(_)) =>
+              Resources.showResultAndRightFailed(expr, vb.showResult(t, rb))
+            case (Failed(_), Passed(_)) =>
+              Resources.showResultAndLeftFailed(expr, va.showResult(t, ra))
+            case (Failed(_), Failed(_)) =>
+              Resources.showResultAndBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
+          }
+        }
+      }
+  }
 
   /** Disjunction of the predicates `A` and `B`. */
   final case class Or[A, B](a: A, b: B)
 
+  object Or {
+    implicit def orValidate[T, A, RA, B, RB](
+        implicit va: Validate.Aux[T, A, RA],
+        vb: Validate.Aux[T, B, RB]
+    ): Validate.Aux[T, A Or B, va.Res Or vb.Res] =
+      new Validate[T, A Or B] {
+        override type R = va.Res Or vb.Res
+
+        override def validate(t: T): Res = {
+          val (ra, rb) = (va.validate(t), vb.validate(t))
+          Result.fromBoolean(ra.isPassed || rb.isPassed, Or(ra, rb))
+        }
+
+        override def showExpr(t: T): String =
+          s"(${va.showExpr(t)} || ${vb.showExpr(t)})"
+
+        override def showResult(t: T, r: Res): String = {
+          val expr = showExpr(t)
+          val (ra, rb) = (r.detail.a, r.detail.b)
+          (ra, rb) match {
+            case (Passed(_), Passed(_)) =>
+              Resources.showResultOrBothPassed(expr)
+            case (Passed(_), Failed(_)) =>
+              Resources.showResultOrLeftPassed(expr)
+            case (Failed(_), Passed(_)) =>
+              Resources.showResultOrRightPassed(expr)
+            case (Failed(_), Failed(_)) =>
+              Resources.showResultOrBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
+          }
+        }
+      }
+  }
+
   /** Exclusive disjunction of the predicates `A` and `B`. */
   final case class Xor[A, B](a: A, b: B)
+
+  object Xor {
+    implicit def xorValidate[T, A, RA, B, RB](
+        implicit va: Validate.Aux[T, A, RA],
+        vb: Validate.Aux[T, B, RB]
+    ): Validate.Aux[T, A Xor B, va.Res Xor vb.Res] =
+      new Validate[T, A Xor B] {
+        override type R = va.Res Xor vb.Res
+
+        override def validate(t: T): Res = {
+          val (ra, rb) = (va.validate(t), vb.validate(t))
+          Result.fromBoolean(ra.isPassed ^ rb.isPassed, Xor(ra, rb))
+        }
+
+        override def showExpr(t: T): String =
+          s"(${va.showExpr(t)} ^ ${vb.showExpr(t)})"
+
+        override def showResult(t: T, r: Res): String = {
+          val expr = showExpr(t)
+          val (ra, rb) = (r.detail.a, r.detail.b)
+          (ra, rb) match {
+            case (Passed(_), Passed(_)) =>
+              Resources.showResultOrBothPassed(expr)
+            case (Passed(_), Failed(_)) =>
+              Resources.showResultOrLeftPassed(expr)
+            case (Failed(_), Passed(_)) =>
+              Resources.showResultOrRightPassed(expr)
+            case (Failed(_), Failed(_)) =>
+              Resources.showResultOrBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
+          }
+        }
+      }
+  }
 
   /** Conjunction of all predicates in `PS`. */
   final case class AllOf[PS](ps: PS)
 
+  object AllOf {
+    implicit def allOfHNilValidate[T]: Validate.Plain[T, AllOf[HNil]] =
+      Validate.alwaysPassed(AllOf(HList()))
+
+    implicit def allOfHConsValidate[T, PH, RH, PT <: HList, RT <: HList](
+        implicit vh: Validate.Aux[T, PH, RH],
+        vt: Validate.Aux[T, AllOf[PT], AllOf[RT]]
+    ): Validate.Aux[T, AllOf[PH :: PT], AllOf[vh.Res :: RT]] =
+      new Validate[T, AllOf[PH :: PT]] {
+        override type R = AllOf[vh.Res :: RT]
+
+        override def validate(t: T): Res = {
+          val rh = vh.validate(t)
+          val rt = vt.validate(t)
+          Result.fromBoolean(rh.isPassed && rt.isPassed, AllOf(rh :: rt.detail.ps))
+        }
+
+        override def showExpr(t: T): String =
+          accumulateShowExpr(t).mkString("(", " && ", ")")
+
+        override def accumulateShowExpr(t: T): List[String] =
+          vh.showExpr(t) :: vt.accumulateShowExpr(t)
+      }
+  }
+
   /** Disjunction of all predicates in `PS`. */
   final case class AnyOf[PS](ps: PS)
 
+  object AnyOf {
+    implicit def anyOfHNilValidate[T]: Validate.Plain[T, AnyOf[HNil]] =
+      Validate.alwaysFailed(AnyOf(HList()))
+
+    implicit def anyOfHConsValidate[T, PH, RH, PT <: HList, RT <: HList](
+        implicit vh: Validate.Aux[T, PH, RH],
+        vt: Validate.Aux[T, AnyOf[PT], AnyOf[RT]]
+    ): Validate.Aux[T, AnyOf[PH :: PT], AnyOf[vh.Res :: RT]] =
+      new Validate[T, AnyOf[PH :: PT]] {
+        override type R = AnyOf[vh.Res :: RT]
+
+        override def validate(t: T): Res = {
+          val rh = vh.validate(t)
+          val rt = vt.validate(t)
+          Result.fromBoolean(rh.isPassed || rt.isPassed, AnyOf(rh :: rt.detail.ps))
+        }
+
+        override def showExpr(t: T): String =
+          accumulateShowExpr(t).mkString("(", " || ", ")")
+
+        override def accumulateShowExpr(t: T): List[String] =
+          vh.showExpr(t) :: vt.accumulateShowExpr(t)
+      }
+  }
+
   /** Exclusive disjunction of all predicates in `PS`. */
   final case class OneOf[PS](ps: PS)
+
+  object OneOf {
+    implicit def oneOfHNilValidate[T]: Validate.Plain[T, OneOf[HNil]] =
+      Validate.alwaysFailed(OneOf(HList()))
+
+    implicit def oneOfHConsValidate[T, PH, RH, PT <: HList, RT <: HList](
+        implicit vh: Validate.Aux[T, PH, RH],
+        vt: Validate.Aux[T, OneOf[PT], OneOf[RT]],
+        toList: ToList[RT, Result[_]]
+    ): Validate.Aux[T, OneOf[PH :: PT], OneOf[vh.Res :: RT]] =
+      new Validate[T, OneOf[PH :: PT]] {
+        override type R = OneOf[vh.Res :: RT]
+
+        override def validate(t: T): Res = {
+          val rh = vh.validate(t)
+          val rt = vt.validate(t).detail.ps
+          val passed = (rh :: toList(rt)).count(_.isPassed) == 1
+          Result.fromBoolean(passed, OneOf(rh :: rt))
+        }
+
+        override def showExpr(t: T): String =
+          accumulateShowExpr(t).mkString("oneOf(", ", ", ")")
+
+        override def accumulateShowExpr(t: T): List[String] =
+          vh.showExpr(t) :: vt.accumulateShowExpr(t)
+      }
+  }
 
   /** Negated conjunction of the predicates `A` and `B`. */
   type Nand[A, B] = Not[A And B]
@@ -44,201 +255,7 @@ object boolean extends BooleanValidate with BooleanInference0 {
   type Nor[A, B] = Not[A Or B]
 }
 
-private[refined] trait BooleanValidate {
-
-  implicit def trueValidate[T]: Validate.Plain[T, True] =
-    Validate.alwaysPassed(True())
-
-  implicit def falseValidate[T]: Validate.Plain[T, False] =
-    Validate.alwaysFailed(False())
-
-  implicit def notValidate[T, P, R](
-      implicit v: Validate.Aux[T, P, R]): Validate.Aux[T, Not[P], Not[v.Res]] =
-    new Validate[T, Not[P]] {
-      override type R = Not[v.Res]
-
-      override def validate(t: T): Res = {
-        val r = v.validate(t)
-        Result.fromBoolean(r.isFailed, Not(r))
-      }
-
-      override def showExpr(t: T): String =
-        s"!${v.showExpr(t)}"
-
-      override def showResult(t: T, r: Res): String = {
-        val expr = v.showExpr(t)
-        val rp = r.detail.p
-        rp match {
-          case Passed(_) => Resources.showResultNotInnerPassed(expr)
-          case Failed(_) => Resources.showResultNotInnerFailed(expr)
-        }
-      }
-    }
-
-  implicit def andValidate[T, A, RA, B, RB](
-      implicit va: Validate.Aux[T, A, RA],
-      vb: Validate.Aux[T, B, RB]
-  ): Validate.Aux[T, A And B, va.Res And vb.Res] =
-    new Validate[T, A And B] {
-      override type R = va.Res And vb.Res
-
-      override def validate(t: T): Res = {
-        val (ra, rb) = (va.validate(t), vb.validate(t))
-        Result.fromBoolean(ra.isPassed && rb.isPassed, And(ra, rb))
-      }
-
-      override def showExpr(t: T): String =
-        s"(${va.showExpr(t)} && ${vb.showExpr(t)})"
-
-      override def showResult(t: T, r: Res): String = {
-        val expr = showExpr(t)
-        val (ra, rb) = (r.detail.a, r.detail.b)
-        (ra, rb) match {
-          case (Passed(_), Passed(_)) =>
-            Resources.showResultAndBothPassed(expr)
-          case (Passed(_), Failed(_)) =>
-            Resources.showResultAndRightFailed(expr, vb.showResult(t, rb))
-          case (Failed(_), Passed(_)) =>
-            Resources.showResultAndLeftFailed(expr, va.showResult(t, ra))
-          case (Failed(_), Failed(_)) =>
-            Resources.showResultAndBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
-        }
-      }
-    }
-
-  implicit def orValidate[T, A, RA, B, RB](
-      implicit va: Validate.Aux[T, A, RA],
-      vb: Validate.Aux[T, B, RB]
-  ): Validate.Aux[T, A Or B, va.Res Or vb.Res] =
-    new Validate[T, A Or B] {
-      override type R = va.Res Or vb.Res
-
-      override def validate(t: T): Res = {
-        val (ra, rb) = (va.validate(t), vb.validate(t))
-        Result.fromBoolean(ra.isPassed || rb.isPassed, Or(ra, rb))
-      }
-
-      override def showExpr(t: T): String =
-        s"(${va.showExpr(t)} || ${vb.showExpr(t)})"
-
-      override def showResult(t: T, r: Res): String = {
-        val expr = showExpr(t)
-        val (ra, rb) = (r.detail.a, r.detail.b)
-        (ra, rb) match {
-          case (Passed(_), Passed(_)) =>
-            Resources.showResultOrBothPassed(expr)
-          case (Passed(_), Failed(_)) =>
-            Resources.showResultOrLeftPassed(expr)
-          case (Failed(_), Passed(_)) =>
-            Resources.showResultOrRightPassed(expr)
-          case (Failed(_), Failed(_)) =>
-            Resources.showResultOrBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
-        }
-      }
-    }
-
-  implicit def xorValidate[T, A, RA, B, RB](
-      implicit va: Validate.Aux[T, A, RA],
-      vb: Validate.Aux[T, B, RB]
-  ): Validate.Aux[T, A Xor B, va.Res Xor vb.Res] =
-    new Validate[T, A Xor B] {
-      override type R = va.Res Xor vb.Res
-
-      override def validate(t: T): Res = {
-        val (ra, rb) = (va.validate(t), vb.validate(t))
-        Result.fromBoolean(ra.isPassed ^ rb.isPassed, Xor(ra, rb))
-      }
-
-      override def showExpr(t: T): String =
-        s"(${va.showExpr(t)} ^ ${vb.showExpr(t)})"
-
-      override def showResult(t: T, r: Res): String = {
-        val expr = showExpr(t)
-        val (ra, rb) = (r.detail.a, r.detail.b)
-        (ra, rb) match {
-          case (Passed(_), Passed(_)) =>
-            Resources.showResultOrBothPassed(expr)
-          case (Passed(_), Failed(_)) =>
-            Resources.showResultOrLeftPassed(expr)
-          case (Failed(_), Passed(_)) =>
-            Resources.showResultOrRightPassed(expr)
-          case (Failed(_), Failed(_)) =>
-            Resources.showResultOrBothFailed(expr, va.showResult(t, ra), vb.showResult(t, rb))
-        }
-      }
-    }
-
-  implicit def allOfHNilValidate[T]: Validate.Plain[T, AllOf[HNil]] =
-    Validate.alwaysPassed(AllOf(HList()))
-
-  implicit def allOfHConsValidate[T, PH, RH, PT <: HList, RT <: HList](
-      implicit vh: Validate.Aux[T, PH, RH],
-      vt: Validate.Aux[T, AllOf[PT], AllOf[RT]]
-  ): Validate.Aux[T, AllOf[PH :: PT], AllOf[vh.Res :: RT]] =
-    new Validate[T, AllOf[PH :: PT]] {
-      override type R = AllOf[vh.Res :: RT]
-
-      override def validate(t: T): Res = {
-        val rh = vh.validate(t)
-        val rt = vt.validate(t)
-        Result.fromBoolean(rh.isPassed && rt.isPassed, AllOf(rh :: rt.detail.ps))
-      }
-
-      override def showExpr(t: T): String =
-        accumulateShowExpr(t).mkString("(", " && ", ")")
-
-      override def accumulateShowExpr(t: T): List[String] =
-        vh.showExpr(t) :: vt.accumulateShowExpr(t)
-    }
-
-  implicit def anyOfHNilValidate[T]: Validate.Plain[T, AnyOf[HNil]] =
-    Validate.alwaysFailed(AnyOf(HList()))
-
-  implicit def anyOfHConsValidate[T, PH, RH, PT <: HList, RT <: HList](
-      implicit vh: Validate.Aux[T, PH, RH],
-      vt: Validate.Aux[T, AnyOf[PT], AnyOf[RT]]
-  ): Validate.Aux[T, AnyOf[PH :: PT], AnyOf[vh.Res :: RT]] =
-    new Validate[T, AnyOf[PH :: PT]] {
-      override type R = AnyOf[vh.Res :: RT]
-
-      override def validate(t: T): Res = {
-        val rh = vh.validate(t)
-        val rt = vt.validate(t)
-        Result.fromBoolean(rh.isPassed || rt.isPassed, AnyOf(rh :: rt.detail.ps))
-      }
-
-      override def showExpr(t: T): String =
-        accumulateShowExpr(t).mkString("(", " || ", ")")
-
-      override def accumulateShowExpr(t: T): List[String] =
-        vh.showExpr(t) :: vt.accumulateShowExpr(t)
-    }
-
-  implicit def oneOfHNilValidate[T]: Validate.Plain[T, OneOf[HNil]] =
-    Validate.alwaysFailed(OneOf(HList()))
-
-  implicit def oneOfHConsValidate[T, PH, RH, PT <: HList, RT <: HList](
-      implicit vh: Validate.Aux[T, PH, RH],
-      vt: Validate.Aux[T, OneOf[PT], OneOf[RT]],
-      toList: ToList[RT, Result[_]]
-  ): Validate.Aux[T, OneOf[PH :: PT], OneOf[vh.Res :: RT]] =
-    new Validate[T, OneOf[PH :: PT]] {
-      override type R = OneOf[vh.Res :: RT]
-
-      override def validate(t: T): Res = {
-        val rh = vh.validate(t)
-        val rt = vt.validate(t).detail.ps
-        val passed = (rh :: toList(rt)).count(_.isPassed) == 1
-        Result.fromBoolean(passed, OneOf(rh :: rt))
-      }
-
-      override def showExpr(t: T): String =
-        accumulateShowExpr(t).mkString("oneOf(", ", ", ")")
-
-      override def accumulateShowExpr(t: T): List[String] =
-        vh.showExpr(t) :: vt.accumulateShowExpr(t)
-    }
-}
+private[refined] trait BooleanValidate {}
 
 private[refined] trait BooleanInference0 extends BooleanInference1 {
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
@@ -8,7 +8,7 @@ import shapeless.{::, HList, HNil}
 import shapeless.ops.hlist.ToList
 
 /** Module for logical predicates. */
-object boolean extends BooleanValidate with BooleanInference0 {
+object boolean extends BooleanInference0 {
 
   /** Constant predicate that is always `true`. */
   final case class True()
@@ -254,8 +254,6 @@ object boolean extends BooleanValidate with BooleanInference0 {
   /** Negated disjunction of the predicates `A` and `B`. */
   type Nor[A, B] = Not[A Or B]
 }
-
-private[refined] trait BooleanValidate {}
 
 private[refined] trait BooleanInference0 extends BooleanInference1 {
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/char.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/char.scala
@@ -2,44 +2,50 @@ package eu.timepit.refined
 
 import eu.timepit.refined.api.Validate
 import eu.timepit.refined.boolean.Or
-import eu.timepit.refined.char._
 
 /** Module for `Char` related predicates. */
-object char extends CharValidate {
+object char {
 
   /** Predicate that checks if a `Char` is a digit. */
   final case class Digit()
 
+  object Digit {
+    implicit def digitValidate: Validate.Plain[Char, Digit] =
+      Validate.fromPredicate(_.isDigit, t => s"isDigit('$t')", Digit())
+  }
+
   /** Predicate that checks if a `Char` is a letter. */
   final case class Letter()
+
+  object Letter {
+    implicit def letterValidate: Validate.Plain[Char, Letter] =
+      Validate.fromPredicate(_.isLetter, t => s"isLetter('$t')", Letter())
+  }
 
   /** Predicate that checks if a `Char` is a lower case character. */
   final case class LowerCase()
 
+  object LowerCase {
+    implicit def lowerCaseValidate: Validate.Plain[Char, LowerCase] =
+      Validate.fromPredicate(_.isLower, t => s"isLower('$t')", LowerCase())
+  }
+
   /** Predicate that checks if a `Char` is an upper case character. */
   final case class UpperCase()
+
+  object UpperCase {
+    implicit def upperCaseValidate: Validate.Plain[Char, UpperCase] =
+      Validate.fromPredicate(_.isUpper, t => s"isUpper('$t')", UpperCase())
+  }
 
   /** Predicate that checks if a `Char` is white space. */
   final case class Whitespace()
 
+  object Whitespace {
+    implicit def whitespaceValidate: Validate.Plain[Char, Whitespace] =
+      Validate.fromPredicate(_.isWhitespace, t => s"isWhitespace('$t')", Whitespace())
+  }
+
   /** Predicate that checks if a `Char` is a letter or digit. */
   type LetterOrDigit = Letter Or Digit
-}
-
-private[refined] trait CharValidate {
-
-  implicit def digitValidate: Validate.Plain[Char, Digit] =
-    Validate.fromPredicate(_.isDigit, t => s"isDigit('$t')", Digit())
-
-  implicit def letterValidate: Validate.Plain[Char, Letter] =
-    Validate.fromPredicate(_.isLetter, t => s"isLetter('$t')", Letter())
-
-  implicit def lowerCaseValidate: Validate.Plain[Char, LowerCase] =
-    Validate.fromPredicate(_.isLower, t => s"isLower('$t')", LowerCase())
-
-  implicit def upperCaseValidate: Validate.Plain[Char, UpperCase] =
-    Validate.fromPredicate(_.isUpper, t => s"isUpper('$t')", UpperCase())
-
-  implicit def whitespaceValidate: Validate.Plain[Char, Whitespace] =
-    Validate.fromPredicate(_.isWhitespace, t => s"isWhitespace('$t')", Whitespace())
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
@@ -3,14 +3,13 @@ package eu.timepit.refined
 import eu.timepit.refined.api.{Inference, Result, Validate}
 import eu.timepit.refined.api.Inference.==>
 import eu.timepit.refined.boolean.Not
-import eu.timepit.refined.collection._
 import eu.timepit.refined.generic.Equal
 import eu.timepit.refined.internal.Resources
 import eu.timepit.refined.numeric.{GreaterEqual, LessEqual}
 import shapeless.Witness
 
 /** Module for collection predicates. */
-object collection extends CollectionValidate with CollectionInference {
+object collection {
 
   /**
    * Predicate that counts the number of elements in a `Traversable`
@@ -19,8 +18,42 @@ object collection extends CollectionValidate with CollectionInference {
    */
   final case class Count[PA, PC](pa: PA, pc: PC)
 
+  object Count {
+    implicit def countValidate[A, PA, RA, PC, RC, T](
+        implicit va: Validate.Aux[A, PA, RA],
+        vc: Validate.Aux[Int, PC, RC],
+        ev: T => Traversable[A]
+    ): Validate.Aux[T, Count[PA, PC], Count[List[va.Res], vc.Res]] =
+      new Validate[T, Count[PA, PC]] {
+        override type R = Count[List[va.Res], vc.Res]
+
+        override def validate(t: T): Res = {
+          val ra = t.toList.map(va.validate)
+          val rc = vc.validate(ra.count(_.isPassed))
+          rc.as(Count(ra, rc))
+        }
+
+        override def showExpr(t: T): String =
+          vc.showExpr(count(t))
+
+        override def showResult(t: T, r: Res): String = {
+          val c = count(t)
+          val expr = t.map(va.showExpr).mkString("count(", ", ", ")")
+          Resources.predicateTakingResultDetail(s"$expr = $c", r, vc.showResult(c, r.detail.pc))
+        }
+
+        private def count(t: T): Int =
+          t.count(va.isValid)
+      }
+  }
+
   /** Predicate that checks if a `Traversable` is empty. */
   final case class Empty()
+
+  object Empty {
+    implicit def emptyValidate[T](implicit ev: T => Traversable[_]): Validate.Plain[T, Empty] =
+      Validate.fromPredicate(_.isEmpty, t => s"isEmpty($t)", Empty())
+  }
 
   /**
    * Predicate that checks if the predicate `P` holds for all elements of a
@@ -28,11 +61,72 @@ object collection extends CollectionValidate with CollectionInference {
    */
   final case class Forall[P](p: P)
 
+  object Forall {
+    implicit def forallValidate[A, P, R, T[a] <: Traversable[a]](
+        implicit v: Validate.Aux[A, P, R]
+    ): Validate.Aux[T[A], Forall[P], Forall[List[v.Res]]] =
+      new Validate[T[A], Forall[P]] {
+        override type R = Forall[List[v.Res]]
+
+        override def validate(t: T[A]): Res = {
+          val rt = t.toList.map(v.validate)
+          Result.fromBoolean(rt.forall(_.isPassed), Forall(rt))
+        }
+
+        override def showExpr(t: T[A]): String =
+          t.map(v.showExpr).mkString("(", " && ", ")")
+      }
+
+    implicit def forallValidateView[A, P, R, T](
+        implicit v: Validate.Aux[A, P, R],
+        ev: T => Traversable[A]
+    ): Validate.Aux[T, Forall[P], Forall[List[v.Res]]] =
+      forallValidate[A, P, R, Traversable].contramap(ev)
+
+    implicit def existsInference[A, B](implicit p1: A ==> B): Exists[A] ==> Exists[B] =
+      p1.adapt("existsInference(%s)")
+
+    implicit def existsNonEmptyInference[P]: Exists[P] ==> NonEmpty =
+      Inference.alwaysValid("existsNonEmptyInference")
+  }
+
   /**
    * Predicate that checks if the predicate `P` holds for the first element
    * of a `Traversable`.
    */
   final case class Head[P](p: P)
+
+  object Head {
+    implicit def headValidate[A, P, R, T[a] <: Traversable[a]](
+        implicit v: Validate.Aux[A, P, R]
+    ): Validate.Aux[T[A], Head[P], Head[Option[v.Res]]] =
+      new Validate[T[A], Head[P]] {
+        override type R = Head[Option[v.Res]]
+
+        override def validate(t: T[A]): Res = {
+          val ra = t.headOption.map(v.validate)
+          Result.fromBoolean(ra.fold(false)(_.isPassed), Head(ra))
+        }
+
+        override def showExpr(t: T[A]): String =
+          optElemShowExpr(t.headOption, v.showExpr)
+
+        override def showResult(t: T[A], r: Res): String =
+          optElemShowResult(t.headOption, r.detail.p, (a: A) => s"head($t) = $a", v.showResult)
+      }
+
+    implicit def headValidateView[A, P, R, T](
+        implicit v: Validate.Aux[A, P, R],
+        ev: T => Traversable[A]
+    ): Validate.Aux[T, Head[P], Head[Option[v.Res]]] =
+      headValidate[A, P, R, Traversable].contramap(ev)
+
+    implicit def headInference[A, B](implicit p1: A ==> B): Head[A] ==> Head[B] =
+      p1.adapt("headInference(%s)")
+
+    implicit def headExistsInference[P]: Head[P] ==> Exists[P] =
+      Inference.alwaysValid("headExistsInference")
+  }
 
   /**
    * Predicate that checks if the predicate `P` holds for the element at
@@ -40,11 +134,65 @@ object collection extends CollectionValidate with CollectionInference {
    */
   final case class Index[N, P](n: N, p: P)
 
+  object Index {
+    implicit def indexValidate[A, P, R, N <: Int, T](
+        implicit v: Validate.Aux[A, P, R],
+        ev: T => PartialFunction[Int, A],
+        wn: Witness.Aux[N]
+    ): Validate.Aux[T, Index[N, P], Index[N, Option[v.Res]]] =
+      new Validate[T, Index[N, P]] {
+        override type R = Index[N, Option[v.Res]]
+
+        override def validate(t: T): Res = {
+          val ra = t.lift(wn.value).map(v.validate)
+          Result.fromBoolean(ra.fold(false)(_.isPassed), Index(wn.value, ra))
+        }
+
+        override def showExpr(t: T): String =
+          optElemShowExpr(t.lift(wn.value), v.showExpr)
+
+        override def showResult(t: T, r: Res): String =
+          optElemShowResult(t.lift(wn.value),
+                            r.detail.p,
+                            (a: A) => s"index($t, ${wn.value}) = $a",
+                            v.showResult)
+      }
+
+    implicit def indexInference[N, A, B](implicit p1: A ==> B): Index[N, A] ==> Index[N, B] =
+      p1.adapt("indexInference(%s)")
+
+    implicit def indexExistsInference[N, P]: Index[N, P] ==> Exists[P] =
+      Inference.alwaysValid("indexExistsInference")
+  }
+
   /**
    * Predicate that checks if the predicate `P` holds for all but the last
    * element of a `Traversable`.
    */
   final case class Init[P](p: P)
+
+  object Init {
+    implicit def initValidate[A, P, R, T[a] <: Traversable[a]](
+        implicit v: Validate.Aux[A, P, R]
+    ): Validate.Aux[T[A], Init[P], Init[List[v.Res]]] =
+      new Validate[T[A], Init[P]] {
+        override type R = Init[List[v.Res]]
+
+        override def validate(t: T[A]): Res = {
+          val ra = t.toList.dropRight(1).map(v.validate)
+          Result.fromBoolean(ra.forall(_.isPassed), Init(ra))
+        }
+
+        override def showExpr(t: T[A]): String =
+          t.toList.dropRight(1).map(v.showExpr).mkString("(", " && ", ")")
+      }
+
+    implicit def initValidateView[A, P, R, T](
+        implicit v: Validate.Aux[A, P, R],
+        ev: T => Traversable[A]
+    ): Validate.Aux[T, Init[P], Init[List[v.Res]]] =
+      initValidate[A, P, R, Traversable].contramap(ev)
+  }
 
   /**
    * Predicate that checks if the predicate `P` holds for the last element
@@ -52,17 +200,99 @@ object collection extends CollectionValidate with CollectionInference {
    */
   final case class Last[P](p: P)
 
+  object Last {
+    implicit def lastValidate[A, P, R, T[a] <: Traversable[a]](
+        implicit v: Validate.Aux[A, P, R]
+    ): Validate.Aux[T[A], Last[P], Last[Option[v.Res]]] =
+      new Validate[T[A], Last[P]] {
+        override type R = Last[Option[v.Res]]
+
+        override def validate(t: T[A]): Res = {
+          val ra = t.lastOption.map(v.validate)
+          Result.fromBoolean(ra.fold(false)(_.isPassed), Last(ra))
+        }
+
+        override def showExpr(t: T[A]): String =
+          optElemShowExpr(t.lastOption, v.showExpr)
+
+        override def showResult(t: T[A], r: Res): String =
+          optElemShowResult(t.lastOption, r.detail.p, (a: A) => s"last($t) = $a", v.showResult)
+      }
+
+    implicit def lastValidateView[A, P, R, T](
+        implicit v: Validate.Aux[A, P, R],
+        ev: T => Traversable[A]
+    ): Validate.Aux[T, Last[P], Last[Option[v.Res]]] =
+      lastValidate[A, P, R, Traversable].contramap(ev)
+
+    implicit def lastInference[A, B](implicit p1: A ==> B): Last[A] ==> Last[B] =
+      p1.adapt("lastInference(%s)")
+
+    implicit def lastExistsInference[P]: Last[P] ==> Exists[P] =
+      Inference.alwaysValid("lastExistsInference")
+  }
+
   /**
    * Predicate that checks if the size of a `Traversable` satisfies the
    * predicate `P`.
    */
   final case class Size[P](p: P)
 
+  object Size {
+    implicit def sizeValidate[T, P, RP](
+        implicit v: Validate.Aux[Int, P, RP],
+        ev: T => Traversable[_]
+    ): Validate.Aux[T, Size[P], Size[v.Res]] =
+      new Validate[T, Size[P]] {
+        override type R = Size[v.Res]
+
+        override def validate(t: T): Res = {
+          val r = v.validate(t.size)
+          r.as(Size(r))
+        }
+
+        override def showExpr(t: T): String =
+          v.showExpr(t.size)
+
+        override def showResult(t: T, r: Res): String = {
+          val size = t.size
+          val nested = v.showResult(size, r.detail.p)
+          Resources.predicateTakingResultDetail(s"size($t) = $size", r, nested)
+        }
+      }
+
+    implicit def sizeInference[A, B](implicit p1: A ==> B): Size[A] ==> Size[B] =
+      p1.adapt("sizeInference(%s)")
+  }
+
   /**
    * Predicate that checks if the predicate `P` holds for all but the first
    * element of a `Traversable`.
    */
   final case class Tail[P](p: P)
+
+  object Tail {
+    implicit def tailValidate[A, P, R, T[a] <: Traversable[a]](
+        implicit v: Validate.Aux[A, P, R]
+    ): Validate.Aux[T[A], Tail[P], Tail[List[v.Res]]] =
+      new Validate[T[A], Tail[P]] {
+        override type R = Tail[List[v.Res]]
+
+        override def validate(t: T[A]): Res = {
+          val ra = t.toList.drop(1).map(v.validate)
+          Result.fromBoolean(ra.forall(_.isPassed), Tail(ra))
+        }
+
+        override def showExpr(t: T[A]): String =
+          t.toList.drop(1).map(v.showExpr).mkString("(", " && ", ")")
+      }
+
+    implicit def tailValidateView[A, P, R, T](
+        implicit v: Validate.Aux[A, P, R],
+        ev: T => Traversable[A]
+    ): Validate.Aux[T, Tail[P], Tail[List[v.Res]]] =
+      tailValidate[A, P, R, Traversable].contramap(ev)
+  }
 
   /**
    * Predicate that checks if a `Traversable` contains a value
@@ -90,195 +320,6 @@ object collection extends CollectionValidate with CollectionInference {
 
   /** Predicate that checks if a `Traversable` is not empty. */
   type NonEmpty = Not[Empty]
-}
-
-private[refined] trait CollectionValidate {
-
-  implicit def countValidate[A, PA, RA, PC, RC, T](
-      implicit va: Validate.Aux[A, PA, RA],
-      vc: Validate.Aux[Int, PC, RC],
-      ev: T => Traversable[A]
-  ): Validate.Aux[T, Count[PA, PC], Count[List[va.Res], vc.Res]] =
-    new Validate[T, Count[PA, PC]] {
-      override type R = Count[List[va.Res], vc.Res]
-
-      override def validate(t: T): Res = {
-        val ra = t.toList.map(va.validate)
-        val rc = vc.validate(ra.count(_.isPassed))
-        rc.as(Count(ra, rc))
-      }
-
-      override def showExpr(t: T): String =
-        vc.showExpr(count(t))
-
-      override def showResult(t: T, r: Res): String = {
-        val c = count(t)
-        val expr = t.map(va.showExpr).mkString("count(", ", ", ")")
-        Resources.predicateTakingResultDetail(s"$expr = $c", r, vc.showResult(c, r.detail.pc))
-      }
-
-      private def count(t: T): Int =
-        t.count(va.isValid)
-    }
-
-  implicit def emptyValidate[T](implicit ev: T => Traversable[_]): Validate.Plain[T, Empty] =
-    Validate.fromPredicate(_.isEmpty, t => s"isEmpty($t)", Empty())
-
-  implicit def forallValidate[A, P, R, T[a] <: Traversable[a]](
-      implicit v: Validate.Aux[A, P, R]
-  ): Validate.Aux[T[A], Forall[P], Forall[List[v.Res]]] =
-    new Validate[T[A], Forall[P]] {
-      override type R = Forall[List[v.Res]]
-
-      override def validate(t: T[A]): Res = {
-        val rt = t.toList.map(v.validate)
-        Result.fromBoolean(rt.forall(_.isPassed), Forall(rt))
-      }
-
-      override def showExpr(t: T[A]): String =
-        t.map(v.showExpr).mkString("(", " && ", ")")
-    }
-
-  implicit def forallValidateView[A, P, R, T](
-      implicit v: Validate.Aux[A, P, R],
-      ev: T => Traversable[A]
-  ): Validate.Aux[T, Forall[P], Forall[List[v.Res]]] =
-    forallValidate[A, P, R, Traversable].contramap(ev)
-
-  implicit def headValidate[A, P, R, T[a] <: Traversable[a]](
-      implicit v: Validate.Aux[A, P, R]
-  ): Validate.Aux[T[A], Head[P], Head[Option[v.Res]]] =
-    new Validate[T[A], Head[P]] {
-      override type R = Head[Option[v.Res]]
-
-      override def validate(t: T[A]): Res = {
-        val ra = t.headOption.map(v.validate)
-        Result.fromBoolean(ra.fold(false)(_.isPassed), Head(ra))
-      }
-
-      override def showExpr(t: T[A]): String =
-        optElemShowExpr(t.headOption, v.showExpr)
-
-      override def showResult(t: T[A], r: Res): String =
-        optElemShowResult(t.headOption, r.detail.p, (a: A) => s"head($t) = $a", v.showResult)
-    }
-
-  implicit def headValidateView[A, P, R, T](
-      implicit v: Validate.Aux[A, P, R],
-      ev: T => Traversable[A]
-  ): Validate.Aux[T, Head[P], Head[Option[v.Res]]] =
-    headValidate[A, P, R, Traversable].contramap(ev)
-
-  implicit def indexValidate[A, P, R, N <: Int, T](
-      implicit v: Validate.Aux[A, P, R],
-      ev: T => PartialFunction[Int, A],
-      wn: Witness.Aux[N]
-  ): Validate.Aux[T, Index[N, P], Index[N, Option[v.Res]]] =
-    new Validate[T, Index[N, P]] {
-      override type R = Index[N, Option[v.Res]]
-
-      override def validate(t: T): Res = {
-        val ra = t.lift(wn.value).map(v.validate)
-        Result.fromBoolean(ra.fold(false)(_.isPassed), Index(wn.value, ra))
-      }
-
-      override def showExpr(t: T): String =
-        optElemShowExpr(t.lift(wn.value), v.showExpr)
-
-      override def showResult(t: T, r: Res): String =
-        optElemShowResult(t.lift(wn.value),
-                          r.detail.p,
-                          (a: A) => s"index($t, ${wn.value}) = $a",
-                          v.showResult)
-    }
-
-  implicit def initValidate[A, P, R, T[a] <: Traversable[a]](
-      implicit v: Validate.Aux[A, P, R]
-  ): Validate.Aux[T[A], Init[P], Init[List[v.Res]]] =
-    new Validate[T[A], Init[P]] {
-      override type R = Init[List[v.Res]]
-
-      override def validate(t: T[A]): Res = {
-        val ra = t.toList.dropRight(1).map(v.validate)
-        Result.fromBoolean(ra.forall(_.isPassed), Init(ra))
-      }
-
-      override def showExpr(t: T[A]): String =
-        t.toList.dropRight(1).map(v.showExpr).mkString("(", " && ", ")")
-    }
-
-  implicit def initValidateView[A, P, R, T](
-      implicit v: Validate.Aux[A, P, R],
-      ev: T => Traversable[A]
-  ): Validate.Aux[T, Init[P], Init[List[v.Res]]] =
-    initValidate[A, P, R, Traversable].contramap(ev)
-
-  implicit def lastValidate[A, P, R, T[a] <: Traversable[a]](
-      implicit v: Validate.Aux[A, P, R]
-  ): Validate.Aux[T[A], Last[P], Last[Option[v.Res]]] =
-    new Validate[T[A], Last[P]] {
-      override type R = Last[Option[v.Res]]
-
-      override def validate(t: T[A]): Res = {
-        val ra = t.lastOption.map(v.validate)
-        Result.fromBoolean(ra.fold(false)(_.isPassed), Last(ra))
-      }
-
-      override def showExpr(t: T[A]): String =
-        optElemShowExpr(t.lastOption, v.showExpr)
-
-      override def showResult(t: T[A], r: Res): String =
-        optElemShowResult(t.lastOption, r.detail.p, (a: A) => s"last($t) = $a", v.showResult)
-    }
-
-  implicit def lastValidateView[A, P, R, T](
-      implicit v: Validate.Aux[A, P, R],
-      ev: T => Traversable[A]
-  ): Validate.Aux[T, Last[P], Last[Option[v.Res]]] =
-    lastValidate[A, P, R, Traversable].contramap(ev)
-
-  implicit def sizeValidate[T, P, RP](
-      implicit v: Validate.Aux[Int, P, RP],
-      ev: T => Traversable[_]
-  ): Validate.Aux[T, Size[P], Size[v.Res]] =
-    new Validate[T, Size[P]] {
-      override type R = Size[v.Res]
-
-      override def validate(t: T): Res = {
-        val r = v.validate(t.size)
-        r.as(Size(r))
-      }
-
-      override def showExpr(t: T): String =
-        v.showExpr(t.size)
-
-      override def showResult(t: T, r: Res): String = {
-        val size = t.size
-        val nested = v.showResult(size, r.detail.p)
-        Resources.predicateTakingResultDetail(s"size($t) = $size", r, nested)
-      }
-    }
-
-  implicit def tailValidate[A, P, R, T[a] <: Traversable[a]](
-      implicit v: Validate.Aux[A, P, R]
-  ): Validate.Aux[T[A], Tail[P], Tail[List[v.Res]]] =
-    new Validate[T[A], Tail[P]] {
-      override type R = Tail[List[v.Res]]
-
-      override def validate(t: T[A]): Res = {
-        val ra = t.toList.drop(1).map(v.validate)
-        Result.fromBoolean(ra.forall(_.isPassed), Tail(ra))
-      }
-
-      override def showExpr(t: T[A]): String =
-        t.toList.drop(1).map(v.showExpr).mkString("(", " && ", ")")
-    }
-
-  implicit def tailValidateView[A, P, R, T](
-      implicit v: Validate.Aux[A, P, R],
-      ev: T => Traversable[A]
-  ): Validate.Aux[T, Tail[P], Tail[List[v.Res]]] =
-    tailValidate[A, P, R, Traversable].contramap(ev)
 
   private def optElemShowExpr[A](elem: Option[A], f: A => String): String =
     elem.fold(Resources.showExprEmptyCollection)(f)
@@ -292,34 +333,4 @@ private[refined] trait CollectionValidate {
         Resources.predicateTakingResultDetail(f(a), r, g(a, r))
       case _ => Resources.showResultEmptyCollection
     }
-}
-
-private[refined] trait CollectionInference {
-
-  implicit def existsInference[A, B](implicit p1: A ==> B): Exists[A] ==> Exists[B] =
-    p1.adapt("existsInference(%s)")
-
-  implicit def existsNonEmptyInference[P]: Exists[P] ==> NonEmpty =
-    Inference.alwaysValid("existsNonEmptyInference")
-
-  implicit def headInference[A, B](implicit p1: A ==> B): Head[A] ==> Head[B] =
-    p1.adapt("headInference(%s)")
-
-  implicit def headExistsInference[P]: Head[P] ==> Exists[P] =
-    Inference.alwaysValid("headExistsInference")
-
-  implicit def indexInference[N, A, B](implicit p1: A ==> B): Index[N, A] ==> Index[N, B] =
-    p1.adapt("indexInference(%s)")
-
-  implicit def indexExistsInference[N, P]: Index[N, P] ==> Exists[P] =
-    Inference.alwaysValid("indexExistsInference")
-
-  implicit def lastInference[A, B](implicit p1: A ==> B): Last[A] ==> Last[B] =
-    p1.adapt("lastInference(%s)")
-
-  implicit def lastExistsInference[P]: Last[P] ==> Exists[P] =
-    Inference.alwaysValid("lastExistsInference")
-
-  implicit def sizeInference[A, B](implicit p1: A ==> B): Size[A] ==> Size[B] =
-    p1.adapt("sizeInference(%s)")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -2,7 +2,6 @@ package eu.timepit.refined
 
 import eu.timepit.refined.api.{Inference, Validate}
 import eu.timepit.refined.api.Inference.==>
-import eu.timepit.refined.generic._
 import shapeless._
 import shapeless.ops.coproduct.ToHList
 import shapeless.ops.hlist.ToList
@@ -10,83 +9,87 @@ import shapeless.ops.nat.ToInt
 import shapeless.ops.record.Keys
 
 /** Module for generic predicates. */
-object generic extends GenericValidate with GenericInference {
+object generic {
 
   /** Predicate that checks if a value is equal to `U`. */
   final case class Equal[U](u: U)
 
+  object Equal {
+    implicit def equalValidateWit[T, U <: T](
+        implicit wu: Witness.Aux[U]
+    ): Validate.Plain[T, Equal[U]] =
+      Validate.fromPredicate(_ == wu.value, t => s"($t == ${wu.value})", Equal(wu.value))
+
+    implicit def equalValidateNat[N <: Nat, T](
+        implicit tn: ToInt[N],
+        wn: Witness.Aux[N],
+        nt: Numeric[T]
+    ): Validate.Plain[T, Equal[N]] =
+      Validate.fromPredicate(t => nt.toDouble(t) == tn(), t => s"($t == ${tn()})", Equal(wn.value))
+
+    implicit def equalValidateInferenceWit[T, U <: T, P](
+        implicit v: Validate[T, P],
+        wu: Witness.Aux[U]
+    ): Equal[U] ==> P =
+      Inference(v.isValid(wu.value), s"equalValidateInferenceWit(${v.showExpr(wu.value)})")
+
+    implicit def equalValidateInferenceNat[T, N <: Nat, P](
+        implicit v: Validate[T, P],
+        nt: Numeric[T],
+        tn: ToInt[N]
+    ): Equal[N] ==> P =
+      Inference(v.isValid(nt.fromInt(tn())),
+                s"equalValidateInferenceNat(${v.showExpr(nt.fromInt(tn()))})")
+  }
+
   /** Predicate that checks if the constructor names of a sum type satisfy `P`. */
   final case class ConstructorNames[P](p: P)
+
+  object ConstructorNames {
+    implicit def ctorNamesValidate[T, R0 <: Coproduct, R1 <: HList, K <: HList, NP, NR](
+        implicit lg: LabelledGeneric.Aux[T, R0],
+        cthl: ToHList.Aux[R0, R1],
+        keys: Keys.Aux[R1, K],
+        ktl: ToList[K, Symbol],
+        v: Validate.Aux[List[String], NP, NR]
+    ): Validate.Aux[T, ConstructorNames[NP], ConstructorNames[v.Res]] = {
+
+      val ctorNames = keys().toList.map(_.name)
+      val rn = v.validate(ctorNames)
+      Validate.constant(rn.as(ConstructorNames(rn)), v.showExpr(ctorNames))
+    }
+  }
 
   /** Predicate that checks if the field names of a product type satisfy `P`. */
   final case class FieldNames[P](p: P)
 
+  object FieldNames {
+    implicit def fieldNamesValidate[T, R <: HList, K <: HList, NP, NR](
+        implicit lg: LabelledGeneric.Aux[T, R],
+        keys: Keys.Aux[R, K],
+        ktl: ToList[K, Symbol],
+        v: Validate.Aux[List[String], NP, NR]
+    ): Validate.Aux[T, FieldNames[NP], FieldNames[v.Res]] = {
+
+      val fieldNames = keys().toList.map(_.name)
+      val rn = v.validate(fieldNames)
+      Validate.constant(rn.as(FieldNames(rn)), v.showExpr(fieldNames))
+    }
+  }
+
   /** Predicate that witnesses that the type of a value is a subtype of `U`. */
   final case class Subtype[U]()
 
+  object Subtype {
+    implicit def subtypeValidate[T, U >: T]: Validate.Plain[T, Subtype[U]] =
+      Validate.alwaysPassed(Subtype())
+  }
+
   /** Predicate that witnesses that the type of a value is a supertype of `U`. */
   final case class Supertype[U]()
-}
 
-private[refined] trait GenericValidate {
-
-  implicit def equalValidateWit[T, U <: T](
-      implicit wu: Witness.Aux[U]
-  ): Validate.Plain[T, Equal[U]] =
-    Validate.fromPredicate(_ == wu.value, t => s"($t == ${wu.value})", Equal(wu.value))
-
-  implicit def equalValidateNat[N <: Nat, T](
-      implicit tn: ToInt[N],
-      wn: Witness.Aux[N],
-      nt: Numeric[T]
-  ): Validate.Plain[T, Equal[N]] =
-    Validate.fromPredicate(t => nt.toDouble(t) == tn(), t => s"($t == ${tn()})", Equal(wn.value))
-
-  implicit def ctorNamesValidate[T, R0 <: Coproduct, R1 <: HList, K <: HList, NP, NR](
-      implicit lg: LabelledGeneric.Aux[T, R0],
-      cthl: ToHList.Aux[R0, R1],
-      keys: Keys.Aux[R1, K],
-      ktl: ToList[K, Symbol],
-      v: Validate.Aux[List[String], NP, NR]
-  ): Validate.Aux[T, ConstructorNames[NP], ConstructorNames[v.Res]] = {
-
-    val ctorNames = keys().toList.map(_.name)
-    val rn = v.validate(ctorNames)
-    Validate.constant(rn.as(ConstructorNames(rn)), v.showExpr(ctorNames))
+  object Supertype {
+    implicit def supertypeValidate[T, U <: T]: Validate.Plain[T, Supertype[U]] =
+      Validate.alwaysPassed(Supertype())
   }
-
-  implicit def fieldNamesValidate[T, R <: HList, K <: HList, NP, NR](
-      implicit lg: LabelledGeneric.Aux[T, R],
-      keys: Keys.Aux[R, K],
-      ktl: ToList[K, Symbol],
-      v: Validate.Aux[List[String], NP, NR]
-  ): Validate.Aux[T, FieldNames[NP], FieldNames[v.Res]] = {
-
-    val fieldNames = keys().toList.map(_.name)
-    val rn = v.validate(fieldNames)
-    Validate.constant(rn.as(FieldNames(rn)), v.showExpr(fieldNames))
-  }
-
-  implicit def subtypeValidate[T, U >: T]: Validate.Plain[T, Subtype[U]] =
-    Validate.alwaysPassed(Subtype())
-
-  implicit def supertypeValidate[T, U <: T]: Validate.Plain[T, Supertype[U]] =
-    Validate.alwaysPassed(Supertype())
-}
-
-private[refined] trait GenericInference {
-
-  implicit def equalValidateInferenceWit[T, U <: T, P](
-      implicit v: Validate[T, P],
-      wu: Witness.Aux[U]
-  ): Equal[U] ==> P =
-    Inference(v.isValid(wu.value), s"equalValidateInferenceWit(${v.showExpr(wu.value)})")
-
-  implicit def equalValidateInferenceNat[T, N <: Nat, P](
-      implicit v: Validate[T, P],
-      nt: Numeric[T],
-      tn: ToInt[N]
-  ): Equal[N] ==> P =
-    Inference(v.isValid(nt.fromInt(tn())),
-              s"equalValidateInferenceNat(${v.showExpr(nt.fromInt(tn()))})")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -3,7 +3,6 @@ package eu.timepit.refined
 import eu.timepit.refined.api.{Inference, Validate}
 import eu.timepit.refined.api.Inference.==>
 import eu.timepit.refined.boolean.{And, Not}
-import eu.timepit.refined.numeric._
 import shapeless.{Nat, Witness}
 import shapeless.nat.{_0, _2}
 import shapeless.ops.nat.ToInt
@@ -29,16 +28,112 @@ import shapeless.ops.nat.ToInt
  *
  * Note: `[[generic.Equal]]` can also be used for numeric types.
  */
-object numeric extends NumericValidate with NumericInference {
+object numeric {
 
   /** Predicate that checks if a numeric value is less than `N`. */
   final case class Less[N](n: N)
 
+  object Less {
+    implicit def lessValidateWit[T, N <: T](
+        implicit wn: Witness.Aux[N],
+        nt: Numeric[T]
+    ): Validate.Plain[T, Less[N]] =
+      Validate.fromPredicate(t => nt.lt(t, wn.value), t => s"($t < ${wn.value})", Less(wn.value))
+
+    implicit def lessValidateNat[N <: Nat, T](
+        implicit tn: ToInt[N],
+        wn: Witness.Aux[N],
+        nt: Numeric[T]
+    ): Validate.Plain[T, Less[N]] =
+      Validate.fromPredicate(t => nt.toDouble(t) < tn(), t => s"($t < ${tn()})", Less(wn.value))
+
+    implicit def lessInferenceWit[C, A <: C, B <: C](
+        implicit wa: Witness.Aux[A],
+        wb: Witness.Aux[B],
+        nc: Numeric[C]
+    ): Less[A] ==> Less[B] =
+      Inference(nc.lt(wa.value, wb.value), s"lessInferenceWit(${wa.value}, ${wb.value})")
+
+    implicit def lessInferenceNat[A <: Nat, B <: Nat](
+        implicit ta: ToInt[A],
+        tb: ToInt[B]
+    ): Less[A] ==> Less[B] =
+      Inference(ta() < tb(), s"lessInferenceNat(${ta()}, ${tb()})")
+
+    implicit def lessInferenceWitNat[C, A <: C, B <: Nat](
+        implicit wa: Witness.Aux[A],
+        tb: ToInt[B],
+        nc: Numeric[C]
+    ): Less[A] ==> Less[B] =
+      Inference(nc.lt(wa.value, nc.fromInt(tb())), s"lessInferenceWitNat(${wa.value}, ${tb()})")
+  }
+
   /** Predicate that checks if a numeric value is greater than `N`. */
   final case class Greater[N](n: N)
 
+  object Greater {
+    implicit def greaterValidateWit[T, N <: T](
+        implicit wn: Witness.Aux[N],
+        nt: Numeric[T]
+    ): Validate.Plain[T, Greater[N]] =
+      Validate.fromPredicate(t => nt.gt(t, wn.value), t => s"($t > ${wn.value})", Greater(wn.value))
+
+    implicit def greaterValidateNat[N <: Nat, T](
+        implicit tn: ToInt[N],
+        wn: Witness.Aux[N],
+        nt: Numeric[T]
+    ): Validate.Plain[T, Greater[N]] =
+      Validate.fromPredicate(t => nt.toDouble(t) > tn(), t => s"($t > ${tn()})", Greater(wn.value))
+
+    implicit def greaterInferenceWit[C, A <: C, B <: C](
+        implicit wa: Witness.Aux[A],
+        wb: Witness.Aux[B],
+        nc: Numeric[C]
+    ): Greater[A] ==> Greater[B] =
+      Inference(nc.gt(wa.value, wb.value), s"greaterInferenceWit(${wa.value}, ${wb.value})")
+
+    implicit def greaterInferenceNat[A <: Nat, B <: Nat](
+        implicit ta: ToInt[A],
+        tb: ToInt[B]
+    ): Greater[A] ==> Greater[B] =
+      Inference(ta() > tb(), s"greaterInferenceNat(${ta()}, ${tb()})")
+
+    implicit def greaterInferenceWitNat[C, A <: C, B <: Nat](
+        implicit wa: Witness.Aux[A],
+        tb: ToInt[B],
+        nc: Numeric[C]
+    ): Greater[A] ==> Greater[B] =
+      Inference(nc.gt(wa.value, nc.fromInt(tb())), s"greaterInferenceWitNat(${wa.value}, ${tb()})")
+  }
+
   /** Predicate that checks if a numeric value modulo `N` is `O`. */
   final case class Modulo[N, O](n: N, o: O)
+
+  object Modulo {
+    implicit def moduloValidateWit[T, N <: T, O <: T](
+        implicit wn: Witness.Aux[N],
+        wo: Witness.Aux[O],
+        nt: Numeric[T]
+    ): Validate.Plain[T, Modulo[N, O]] =
+      Validate.fromPredicate(
+        t ⇒ nt.toDouble(t) % nt.toDouble(wn.value) == nt.toDouble(wo.value),
+        t ⇒ s"($t % ${wn.value} == ${wo.value})",
+        Modulo(wn.value, wo.value)
+      )
+
+    implicit def moduloValidateNat[N <: Nat, O <: Nat, T](
+        implicit tn: ToInt[N],
+        to: ToInt[O],
+        wn: Witness.Aux[N],
+        wo: Witness.Aux[O],
+        nt: Numeric[T]
+    ): Validate.Plain[T, Modulo[N, O]] =
+      Validate.fromPredicate(
+        t ⇒ nt.toDouble(t) % tn() == to(),
+        t ⇒ s"($t % ${tn()} == ${to()})",
+        Modulo(wn.value, wo.value)
+      )
+  }
 
   /** Predicate that checks if a numeric value is less than or equal to `N`. */
   type LessEqual[N] = Not[Greater[N]]
@@ -84,100 +179,4 @@ object numeric extends NumericValidate with NumericInference {
     /** Predicate that checks if a numeric value is in the interval `[L, H]`. */
     type Closed[L, H] = GreaterEqual[L] And LessEqual[H]
   }
-}
-
-private[refined] trait NumericValidate {
-
-  implicit def lessValidateWit[T, N <: T](
-      implicit wn: Witness.Aux[N],
-      nt: Numeric[T]
-  ): Validate.Plain[T, Less[N]] =
-    Validate.fromPredicate(t => nt.lt(t, wn.value), t => s"($t < ${wn.value})", Less(wn.value))
-
-  implicit def greaterValidateWit[T, N <: T](
-      implicit wn: Witness.Aux[N],
-      nt: Numeric[T]
-  ): Validate.Plain[T, Greater[N]] =
-    Validate.fromPredicate(t => nt.gt(t, wn.value), t => s"($t > ${wn.value})", Greater(wn.value))
-
-  implicit def moduloValidateWit[T, N <: T, O <: T](
-      implicit wn: Witness.Aux[N],
-      wo: Witness.Aux[O],
-      nt: Numeric[T]
-  ): Validate.Plain[T, Modulo[N, O]] =
-    Validate.fromPredicate(
-      t ⇒ nt.toDouble(t) % nt.toDouble(wn.value) == nt.toDouble(wo.value),
-      t ⇒ s"($t % ${wn.value} == ${wo.value})",
-      Modulo(wn.value, wo.value)
-    )
-
-  implicit def lessValidateNat[N <: Nat, T](
-      implicit tn: ToInt[N],
-      wn: Witness.Aux[N],
-      nt: Numeric[T]
-  ): Validate.Plain[T, Less[N]] =
-    Validate.fromPredicate(t => nt.toDouble(t) < tn(), t => s"($t < ${tn()})", Less(wn.value))
-
-  implicit def greaterValidateNat[N <: Nat, T](
-      implicit tn: ToInt[N],
-      wn: Witness.Aux[N],
-      nt: Numeric[T]
-  ): Validate.Plain[T, Greater[N]] =
-    Validate.fromPredicate(t => nt.toDouble(t) > tn(), t => s"($t > ${tn()})", Greater(wn.value))
-
-  implicit def moduloValidateNat[N <: Nat, O <: Nat, T](
-      implicit tn: ToInt[N],
-      to: ToInt[O],
-      wn: Witness.Aux[N],
-      wo: Witness.Aux[O],
-      nt: Numeric[T]
-  ): Validate.Plain[T, Modulo[N, O]] =
-    Validate.fromPredicate(
-      t ⇒ nt.toDouble(t) % tn() == to(),
-      t ⇒ s"($t % ${tn()} == ${to()})",
-      Modulo(wn.value, wo.value)
-    )
-}
-
-private[refined] trait NumericInference {
-
-  implicit def lessInferenceWit[C, A <: C, B <: C](
-      implicit wa: Witness.Aux[A],
-      wb: Witness.Aux[B],
-      nc: Numeric[C]
-  ): Less[A] ==> Less[B] =
-    Inference(nc.lt(wa.value, wb.value), s"lessInferenceWit(${wa.value}, ${wb.value})")
-
-  implicit def greaterInferenceWit[C, A <: C, B <: C](
-      implicit wa: Witness.Aux[A],
-      wb: Witness.Aux[B],
-      nc: Numeric[C]
-  ): Greater[A] ==> Greater[B] =
-    Inference(nc.gt(wa.value, wb.value), s"greaterInferenceWit(${wa.value}, ${wb.value})")
-
-  implicit def lessInferenceNat[A <: Nat, B <: Nat](
-      implicit ta: ToInt[A],
-      tb: ToInt[B]
-  ): Less[A] ==> Less[B] =
-    Inference(ta() < tb(), s"lessInferenceNat(${ta()}, ${tb()})")
-
-  implicit def greaterInferenceNat[A <: Nat, B <: Nat](
-      implicit ta: ToInt[A],
-      tb: ToInt[B]
-  ): Greater[A] ==> Greater[B] =
-    Inference(ta() > tb(), s"greaterInferenceNat(${ta()}, ${tb()})")
-
-  implicit def lessInferenceWitNat[C, A <: C, B <: Nat](
-      implicit wa: Witness.Aux[A],
-      tb: ToInt[B],
-      nc: Numeric[C]
-  ): Less[A] ==> Less[B] =
-    Inference(nc.lt(wa.value, nc.fromInt(tb())), s"lessInferenceWitNat(${wa.value}, ${tb()})")
-
-  implicit def greaterInferenceWitNat[C, A <: C, B <: Nat](
-      implicit wa: Witness.Aux[A],
-      tb: ToInt[B],
-      nc: Numeric[C]
-  ): Greater[A] ==> Greater[B] =
-    Inference(nc.gt(wa.value, nc.fromInt(tb())), s"greaterInferenceWitNat(${wa.value}, ${tb()})")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -2,7 +2,6 @@ package eu.timepit.refined
 
 import eu.timepit.refined.api.{Inference, Validate}
 import eu.timepit.refined.api.Inference.==>
-import eu.timepit.refined.string._
 import shapeless.Witness
 
 /**
@@ -10,14 +9,32 @@ import shapeless.Witness
  * in `[[collection]]` also work for `String`s by treating them as sequences
  * of `Char`s.
  */
-object string extends StringValidate with StringInference {
+object string {
 
   /** Predicate that checks if a `String` ends with the suffix `S`. */
   final case class EndsWith[S](s: S)
 
+  object EndsWith {
+    implicit def endsWithValidate[S <: String](
+        implicit ws: Witness.Aux[S]): Validate.Plain[String, EndsWith[S]] =
+      Validate.fromPredicate(_.endsWith(ws.value),
+                             t => s""""$t".endsWith("${ws.value}")""",
+                             EndsWith(ws.value))
+
+    implicit def endsWithInference[A <: String, B <: String](
+        implicit wa: Witness.Aux[A],
+        wb: Witness.Aux[B]
+    ): EndsWith[A] ==> EndsWith[B] =
+      Inference(wa.value.endsWith(wb.value), s"endsWithInference(${wa.value}, ${wb.value})")
+  }
+
   /** Predicate that checks if a `String` is a valid IPv4 */
   final case class IPv4()
+
   object IPv4 {
+    implicit def ipv4Validate[S <: String]: Validate.Plain[String, IPv4] =
+      Validate.fromPredicate(IPv4.predicate, t => s"${t} is a valid IPv4", IPv4())
+
     val regex = "^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$".r.pattern
     val maxOctet = 255
     val predicate: String => Boolean = s => {
@@ -36,113 +53,120 @@ object string extends StringValidate with StringInference {
   /** Predicate that checks if a `String` matches the regular expression `S`. */
   final case class MatchesRegex[S](s: S)
 
+  object MatchesRegex {
+    implicit def matchesRegexValidate[S <: String](
+        implicit ws: Witness.Aux[S]): Validate.Plain[String, MatchesRegex[S]] =
+      Validate.fromPredicate(_.matches(ws.value),
+                             t => s""""$t".matches("${ws.value}")""",
+                             MatchesRegex(ws.value))
+  }
+
   /** Predicate that checks if a `String` is a valid regular expression. */
   final case class Regex()
+
+  object Regex {
+    implicit def regexValidate: Validate.Plain[String, Regex] =
+      Validate.fromPartial(new scala.util.matching.Regex(_), "Regex", Regex())
+  }
 
   /** Predicate that checks if a `String` starts with the prefix `S`. */
   final case class StartsWith[S](s: S)
 
+  object StartsWith {
+    implicit def startsWithValidate[S <: String](
+        implicit ws: Witness.Aux[S]): Validate.Plain[String, StartsWith[S]] =
+      Validate.fromPredicate(_.startsWith(ws.value),
+                             t => s""""$t".startsWith("${ws.value}")""",
+                             StartsWith(ws.value))
+
+    implicit def startsWithInference[A <: String, B <: String](
+        implicit wa: Witness.Aux[A],
+        wb: Witness.Aux[B]
+    ): StartsWith[A] ==> StartsWith[B] =
+      Inference(wa.value.startsWith(wb.value), s"startsWithInference(${wa.value}, ${wb.value})")
+  }
+
   /** Predicate that checks if a `String` is a valid URI. */
   final case class Uri()
+
+  object Uri {
+    implicit def uriValidate: Validate.Plain[String, Uri] =
+      Validate.fromPartial(new java.net.URI(_), "Uri", Uri())
+  }
 
   /** Predicate that checks if a `String` is a valid URL. */
   final case class Url()
 
+  object Url {
+    implicit def urlValidate: Validate.Plain[String, Url] =
+      Validate.fromPartial(new java.net.URL(_), "Url", Url())
+  }
+
   /** Predicate that checks if a `String` is a valid UUID. */
   final case class Uuid()
+
+  object Uuid {
+    implicit def uuidValidate: Validate.Plain[String, Uuid] =
+      Validate.fromPartial(s => require(java.util.UUID.fromString(s).toString == s.toLowerCase),
+                           "Uuid",
+                           Uuid())
+  }
 
   /** Predicate that checks if a `String` is a parsable `Int`. */
   final case class ValidInt()
 
+  object ValidInt {
+    implicit def validIntValidate: Validate.Plain[String, ValidInt] =
+      Validate.fromPartial(_.toInt, "ValidInt", ValidInt())
+  }
+
   /** Predicate that checks if a `String` is a parsable `Long`. */
   final case class ValidLong()
+
+  object ValidLong {
+    implicit def validLongValidate: Validate.Plain[String, ValidLong] =
+      Validate.fromPartial(_.toLong, "ValidLong", ValidLong())
+  }
 
   /** Predicate that checks if a `String` is a parsable `Double`. */
   final case class ValidDouble()
 
+  object ValidDouble {
+    implicit def validDoubleValidate: Validate.Plain[String, ValidDouble] =
+      Validate.fromPartial(_.toDouble, "ValidDouble", ValidDouble())
+  }
+
   /** Predicate that checks if a `String` is a parsable `BigInt`. */
   final case class ValidBigInt()
+
+  object ValidBigInt {
+    implicit def validBigIntValidate: Validate.Plain[String, ValidBigInt] =
+      Validate.fromPartial(BigInt(_), "ValidBigInt", ValidBigInt())
+  }
 
   /** Predicate that checks if a `String` is a parsable `BigDecimal`. */
   final case class ValidBigDecimal()
 
+  object ValidBigDecimal {
+    implicit def validBigDecimalValidate: Validate.Plain[String, ValidBigDecimal] =
+      Validate.fromPartial(BigDecimal(_), "ValidBigDecimal", ValidBigDecimal())
+  }
+
   /** Predicate that checks if a `String` is well-formed XML. */
   final case class Xml()
 
+  object Xml {
+    implicit def xmlValidate: Validate.Plain[String, Xml] =
+      Validate.fromPartial(scala.xml.XML.loadString, "Xml", Xml())
+  }
+
   /** Predicate that checks if a `String` is a valid XPath expression. */
   final case class XPath()
-}
 
-private[refined] trait StringValidate {
-  implicit def endsWithValidate[S <: String](
-      implicit ws: Witness.Aux[S]): Validate.Plain[String, EndsWith[S]] =
-    Validate.fromPredicate(_.endsWith(ws.value),
-                           t => s""""$t".endsWith("${ws.value}")""",
-                           EndsWith(ws.value))
-
-  implicit def ipv4Validate[S <: String]: Validate.Plain[String, IPv4] =
-    Validate.fromPredicate(IPv4.predicate, t => s"${t} is a valid IPv4", IPv4())
-
-  implicit def matchesRegexValidate[S <: String](
-      implicit ws: Witness.Aux[S]): Validate.Plain[String, MatchesRegex[S]] =
-    Validate.fromPredicate(_.matches(ws.value),
-                           t => s""""$t".matches("${ws.value}")""",
-                           MatchesRegex(ws.value))
-
-  implicit def regexValidate: Validate.Plain[String, Regex] =
-    Validate.fromPartial(new scala.util.matching.Regex(_), "Regex", Regex())
-
-  implicit def startsWithValidate[S <: String](
-      implicit ws: Witness.Aux[S]): Validate.Plain[String, StartsWith[S]] =
-    Validate.fromPredicate(_.startsWith(ws.value),
-                           t => s""""$t".startsWith("${ws.value}")""",
-                           StartsWith(ws.value))
-
-  implicit def uriValidate: Validate.Plain[String, Uri] =
-    Validate.fromPartial(new java.net.URI(_), "Uri", Uri())
-
-  implicit def urlValidate: Validate.Plain[String, Url] =
-    Validate.fromPartial(new java.net.URL(_), "Url", Url())
-
-  implicit def uuidValidate: Validate.Plain[String, Uuid] =
-    Validate.fromPartial(s => require(java.util.UUID.fromString(s).toString == s.toLowerCase),
-                         "Uuid",
-                         Uuid())
-
-  implicit def validIntValidate: Validate.Plain[String, ValidInt] =
-    Validate.fromPartial(_.toInt, "ValidInt", ValidInt())
-
-  implicit def validLongValidate: Validate.Plain[String, ValidLong] =
-    Validate.fromPartial(_.toLong, "ValidLong", ValidLong())
-
-  implicit def validDoubleValidate: Validate.Plain[String, ValidDouble] =
-    Validate.fromPartial(_.toDouble, "ValidDouble", ValidDouble())
-
-  implicit def validBigIntValidate: Validate.Plain[String, ValidBigInt] =
-    Validate.fromPartial(BigInt(_), "ValidBigInt", ValidBigInt())
-
-  implicit def validBigDecimalValidate: Validate.Plain[String, ValidBigDecimal] =
-    Validate.fromPartial(BigDecimal(_), "ValidBigDecimal", ValidBigDecimal())
-
-  implicit def xmlValidate: Validate.Plain[String, Xml] =
-    Validate.fromPartial(scala.xml.XML.loadString, "Xml", Xml())
-
-  implicit def xpathValidate: Validate.Plain[String, XPath] =
-    Validate
-      .fromPartial(javax.xml.xpath.XPathFactory.newInstance().newXPath().compile, "XPath", XPath())
-}
-
-private[refined] trait StringInference {
-
-  implicit def endsWithInference[A <: String, B <: String](
-      implicit wa: Witness.Aux[A],
-      wb: Witness.Aux[B]
-  ): EndsWith[A] ==> EndsWith[B] =
-    Inference(wa.value.endsWith(wb.value), s"endsWithInference(${wa.value}, ${wb.value})")
-
-  implicit def startsWithInference[A <: String, B <: String](
-      implicit wa: Witness.Aux[A],
-      wb: Witness.Aux[B]
-  ): StartsWith[A] ==> StartsWith[B] =
-    Inference(wa.value.startsWith(wb.value), s"startsWithInference(${wa.value}, ${wb.value})")
+  object XPath {
+    implicit def xpathValidate: Validate.Plain[String, XPath] =
+      Validate.fromPartial(javax.xml.xpath.XPathFactory.newInstance().newXPath().compile,
+                           "XPath",
+                           XPath())
+  }
 }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -42,7 +42,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
-   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+   <parameter name="maxTypes"><![CDATA[40]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">


### PR DESCRIPTION
This is an experiment to find out how moving `Validate` and `Inference` instances to the companions of the predicates affects the library.