### PR TITLE
Test that instances don't need to imported explicitly

### DIFF
--- a/modules/core/shared/src/test/scala/eu/timepit/refined/ImplicitScopeSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/ImplicitScopeSpec.scala
@@ -1,0 +1,37 @@
+package eu.timepit.refined
+
+import eu.timepit.refined.TestUtils.wellTyped
+import eu.timepit.refined.api.{Inference, Validate}
+import org.scalacheck.Properties
+
+/**
+ * Tests that ensure that `Validate` and `Inference` instances of
+ * predicates are in their implicit scope and do not need to be imported
+ * explicitly.
+ */
+class ImplicitScopeSpec extends Properties("implicit scope") {
+
+  property("Validate[Char, LetterOrDigit]") = wellTyped {
+    Validate[Char, char.LetterOrDigit]
+  }
+
+  property("Validate[Int, Positive]") = wellTyped {
+    Validate[Int, numeric.Positive]
+  }
+
+  property("Validate[Int, NonPositive]") = wellTyped {
+    Validate[Int, numeric.NonPositive]
+  }
+
+  property("Validate[Int, Interval.Closed[0, 10]]") = wellTyped {
+    Validate[Int, numeric.Interval.Closed[W.`0`.T, W.`10`.T]]
+  }
+
+  property("Inference[And[UpperCase, Letter], And[Letter, UpperCase]]") = wellTyped {
+    Inference[boolean.And[char.UpperCase, char.Letter], boolean.And[char.Letter, char.UpperCase]]
+  }
+
+  property("Inference[Greater[1], Greater[0]]") = wellTyped {
+    Inference[numeric.Greater[W.`1`.T], numeric.Greater[W.`0`.T]]
+  }
+}

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/TestUtils.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/TestUtils.scala
@@ -35,7 +35,7 @@ object TestUtils {
     def apply[T](t: T)(implicit v: Validate[T, P]): String = v.showResult(t, v.validate(t))
   }
 
-  def wellTyped(body: => Unit): Prop = Prop.secure {
+  def wellTyped[A](body: => A): Prop = Prop.secure {
     body
     true
   }


### PR DESCRIPTION
This tests that `Validate` and `Inference` instances are in the implicit
scope of their predicates and do not need to be imported explicitly.

I conducted https://github.com/fthomas/refined/pull/392 under the
premise that `Validate` and `Inference` instances were not in the implicit
scope of their predicates and using them would always require an
explicit import. For example, to refine with the `numeric.Positive`
predicate I thought a `numeric._` wildcard import was always necessary.
This tests show that this is not the case.