### PR TITLE
Merge multiple package clauses

### DIFF
--- a/modules/core/shared/src/main/scala-2.10/eu/timepit/refined/api/Refined.scala
+++ b/modules/core/shared/src/main/scala-2.10/eu/timepit/refined/api/Refined.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 /**
  * Wraps a value of type `T` that satisfies the predicate `P`. Instances of

--- a/modules/core/shared/src/main/scala-2.11/eu/timepit/refined/api/Refined.scala
+++ b/modules/core/shared/src/main/scala-2.11/eu/timepit/refined/api/Refined.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 /**
  * Wraps a value of type `T` that satisfies the predicate `P`. Instances of

--- a/modules/core/shared/src/main/scala-2.12/eu/timepit/refined/api/Refined.scala
+++ b/modules/core/shared/src/main/scala-2.12/eu/timepit/refined/api/Refined.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 /**
  * Wraps a value of type `T` that satisfies the predicate `P`. Instances of

--- a/modules/core/shared/src/main/scala-2.13.0-M2/eu/timepit/refined/api/Refined.scala
+++ b/modules/core/shared/src/main/scala-2.13.0-M2/eu/timepit/refined/api/Refined.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 /**
  * Wraps a value of type `T` that satisfies the predicate `P`. Instances of

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Inference.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Inference.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 /**
  * Evidence that states if the conclusion `C` can be inferred from the

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 import eu.timepit.refined.internal._
 import scala.reflect.macros.blackbox

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 /**
  * Type class that combines `[[RefType]]` and `[[Validate]]` instances

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedTypeOps.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedTypeOps.scala
@@ -1,5 +1,6 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
+
+import eu.timepit.refined.macros.RefineMacro
 
 /**
  * Provides functions to create values of the refined type `FTP` from
@@ -28,7 +29,7 @@ class RefinedTypeOps[FTP, T](implicit rt: RefinedType.AuxT[FTP, T]) extends Seri
       rt: RefType[F],
       v: Validate[T, P]
   ): FTP =
-    macro macros.RefineMacro.implApplyRef[FTP, F, T, P]
+    macro RefineMacro.implApplyRef[FTP, F, T, P]
 
   def from(t: T): Either[String, FTP] =
     rt.refine(t)

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Result.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Result.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 sealed abstract class Result[A] extends Product with Serializable {
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 import eu.timepit.refined.internal.Resources
 import scala.util.Try

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefMPartiallyApplied.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefMPartiallyApplied.scala
@@ -1,7 +1,7 @@
-package eu.timepit.refined
-package internal
+package eu.timepit.refined.internal
 
 import eu.timepit.refined.api.{RefType, Validate}
+import eu.timepit.refined.macros.RefineMacro
 
 /**
  * Helper class that allows the types `F`, `T`, and `P` to be inferred
@@ -16,5 +16,5 @@ final class ApplyRefMPartiallyApplied[FTP] {
       implicit ev: F[T, P] =:= FTP,
       rt: RefType[F],
       v: Validate[T, P]
-  ): FTP = macro macros.RefineMacro.implApplyRef[FTP, F, T, P]
+  ): FTP = macro RefineMacro.implApplyRef[FTP, F, T, P]
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefPartiallyApplied.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/ApplyRefPartiallyApplied.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package internal
+package eu.timepit.refined.internal
 
 import eu.timepit.refined.api.{RefType, Validate}
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package internal
+package eu.timepit.refined.internal
 
 import eu.timepit.refined.api.{RefType, Validate}
 import eu.timepit.refined.macros.RefineMacro

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMPartiallyApplied.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMPartiallyApplied.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package internal
+package eu.timepit.refined.internal
 
 import eu.timepit.refined.api.{RefType, Validate}
 import eu.timepit.refined.macros.RefineMacro

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefinePartiallyApplied.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefinePartiallyApplied.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package internal
+package eu.timepit.refined.internal
 
 import eu.timepit.refined.api.{RefType, Validate}
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Resources.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Resources.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package internal
+package eu.timepit.refined.internal
 
 import eu.timepit.refined.api.Result
 import scala.util.{Failure, Success, Try}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package macros
+package eu.timepit.refined.macros
 
 import eu.timepit.refined.api.Inference.==>
 import eu.timepit.refined.api.RefType

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package macros
+package eu.timepit.refined.macros
 
 import eu.timepit.refined.api.{Refined, RefType}
 import macrocompat.bundle

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/RefineMacro.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package macros
+package eu.timepit.refined.macros
 
 import eu.timepit.refined.api.{RefType, Validate}
 import eu.timepit.refined.char.{Digit, Letter, LowerCase, UpperCase, Whitespace}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/util/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/util/string.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package util
+package eu.timepit.refined.util
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string._

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/util/time.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/util/time.scala
@@ -1,6 +1,6 @@
-package eu.timepit.refined
-package util
+package eu.timepit.refined.util
 
+import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Interval
 

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -1,7 +1,7 @@
-package eu.timepit.refined
-package api
+package eu.timepit.refined.api
 
 import eu.timepit.refined.TestUtils._
+import eu.timepit.refined.W
 import eu.timepit.refined.api.RefType.ops._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.char.{Digit, LowerCase}

--- a/modules/jsonpath/jvm/src/main/scala/eu/timepit/refined/jsonpath/string.scala
+++ b/modules/jsonpath/jvm/src/main/scala/eu/timepit/refined/jsonpath/string.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package jsonpath
+package eu.timepit.refined.jsonpath
 
 import eu.timepit.refined.api.Validate
 

--- a/modules/jsonpath/jvm/src/test/scala/eu/timepit/refined/jsonpath/StringValidateSpec.scala
+++ b/modules/jsonpath/jvm/src/test/scala/eu/timepit/refined/jsonpath/StringValidateSpec.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package jsonpath
+package eu.timepit.refined.jsonpath
 
 import eu.timepit.refined.TestUtils._
 import eu.timepit.refined.jsonpath.string._

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/any.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/any.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.{RefType, Validate}
 import org.scalacheck.Arbitrary

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/boolean.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/boolean.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.boolean.Or

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/char.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/char.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.char._

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/generic.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/generic.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.generic.Equal

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.{RefType, Validate}
 import eu.timepit.refined.numeric._

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.string.{EndsWith, StartsWith}

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CharArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CharArbitrarySpec.scala
@@ -1,6 +1,6 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
+import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.boolean.Or
 import eu.timepit.refined.char._

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/GenericArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/GenericArbitrarySpec.scala
@@ -1,6 +1,6 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
+import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.generic.Equal
 import eu.timepit.refined.scalacheck.generic._

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -1,6 +1,6 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
+import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/PackageSpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/PackageSpec.scala
@@ -1,5 +1,4 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.TestUtils.wellTyped
 import eu.timepit.refined.types.all._

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -1,6 +1,6 @@
-package eu.timepit.refined
-package scalacheck
+package eu.timepit.refined.scalacheck
 
+import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.scalacheck.any._


### PR DESCRIPTION
This is a stylistic change that makes the source code more consistent.

And as the diff shows, in most cases multiple package clauses were just unnecessary.