### PR TITLE
Fix #396 by avoiding .toDouble in Modulo Validate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -271,7 +271,8 @@ lazy val moduleJvmSettings = Def.settings(
       ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.scalacheck.util.OurMath"),
       ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.scalacheck.util.OurMath$"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.StringValidate.*"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.types.*")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.types.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("eu.timepit.refined.NumericValidate.*")
     )
   }
 )

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -122,26 +122,6 @@ private[refined] trait NumericValidate {
       Modulo(wn.value, wo.value)
     )
 
-  implicit def moduloValidateWitDouble[N <: Double, O <: Double](
-      implicit wn: Witness.Aux[N],
-      wo: Witness.Aux[O]
-  ): Validate.Plain[Double, Modulo[N, O]] =
-    Validate.fromPredicate(
-      t ⇒ t % wn.value == wo.value,
-      t ⇒ s"($t % ${wn.value} == ${wo.value})",
-      Modulo(wn.value, wo.value)
-    )
-
-  implicit def moduloValidateWitFloat[N <: Float, O <: Float](
-      implicit wn: Witness.Aux[N],
-      wo: Witness.Aux[O]
-  ): Validate.Plain[Float, Modulo[N, O]] =
-    Validate.fromPredicate(
-      t ⇒ t % wn.value == wo.value,
-      t ⇒ s"($t % ${wn.value} == ${wo.value})",
-      Modulo(wn.value, wo.value)
-    )
-
   implicit def lessValidateNat[N <: Nat, T](
       implicit tn: ToInt[N],
       wn: Witness.Aux[N],
@@ -178,30 +158,6 @@ private[refined] trait NumericValidate {
   ): Validate.Plain[T, Modulo[N, O]] =
     Validate.fromPredicate(
       t ⇒ i.rem(t, i.fromInt(tn())) == i.fromInt(to()),
-      t ⇒ s"($t % ${tn()} == ${to()})",
-      Modulo(wn.value, wo.value)
-    )
-
-  implicit def moduloValidateNatFloat[N <: Nat, O <: Nat](
-      implicit tn: ToInt[N],
-      to: ToInt[O],
-      wn: Witness.Aux[N],
-      wo: Witness.Aux[O]
-  ): Validate.Plain[Float, Modulo[N, O]] =
-    Validate.fromPredicate(
-      t ⇒ t % tn() == to(),
-      t ⇒ s"($t % ${tn()} == ${to()})",
-      Modulo(wn.value, wo.value)
-    )
-
-  implicit def moduloValidateNatDouble[N <: Nat, O <: Nat](
-      implicit tn: ToInt[N],
-      to: ToInt[O],
-      wn: Witness.Aux[N],
-      wo: Witness.Aux[O]
-  ): Validate.Plain[Double, Modulo[N, O]] =
-    Validate.fromPredicate(
-      t ⇒ t % tn() == to(),
       t ⇒ s"($t % ${tn()} == ${to()})",
       Modulo(wn.value, wo.value)
     )

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -130,10 +130,10 @@ private[refined] trait NumericValidate {
       to: ToInt[O],
       wn: Witness.Aux[N],
       wo: Witness.Aux[O],
-      nt: Numeric[T]
+      i: Integral[T]
   ): Validate.Plain[T, Modulo[N, O]] =
     Validate.fromPredicate(
-      t ⇒ nt.toDouble(t) % tn() == to(),
+      t ⇒ i.rem(t, i.fromInt(tn())) == to(),
       t ⇒ s"($t % ${tn()} == ${to()})",
       Modulo(wn.value, wo.value)
     )

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -177,10 +177,11 @@ private[refined] trait NumericValidate {
       i: Integral[T]
   ): Validate.Plain[T, Modulo[N, O]] =
     Validate.fromPredicate(
-      t ⇒ i.rem(t, i.fromInt(tn())) == to(),
+      t ⇒ i.rem(t, i.fromInt(tn())) == i.fromInt(to()),
       t ⇒ s"($t % ${tn()} == ${to()})",
       Modulo(wn.value, wo.value)
     )
+
   implicit def moduloValidateNatFloat[N <: Nat, O <: Nat](
       implicit tn: ToInt[N],
       to: ToInt[O],
@@ -192,6 +193,7 @@ private[refined] trait NumericValidate {
       t ⇒ s"($t % ${tn()} == ${to()})",
       Modulo(wn.value, wo.value)
     )
+
   implicit def moduloValidateNatDouble[N <: Nat, O <: Nat](
       implicit tn: ToInt[N],
       to: ToInt[O],

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -100,13 +100,33 @@ private[refined] trait NumericValidate {
   ): Validate.Plain[T, Greater[N]] =
     Validate.fromPredicate(t => nt.gt(t, wn.value), t => s"($t > ${wn.value})", Greater(wn.value))
 
-  implicit def moduloValidateWit[T, N <: T, O <: T](
+  implicit def moduloValidateWitIntegral[T, N <: T, O <: T](
       implicit wn: Witness.Aux[N],
       wo: Witness.Aux[O],
-      nt: Numeric[T]
+      nt: Integral[T]
   ): Validate.Plain[T, Modulo[N, O]] =
     Validate.fromPredicate(
-      t ⇒ nt.toDouble(t) % nt.toDouble(wn.value) == nt.toDouble(wo.value),
+      t ⇒ nt.rem(t, wn.value) == wo.value,
+      t ⇒ s"($t % ${wn.value} == ${wo.value})",
+      Modulo(wn.value, wo.value)
+    )
+
+  implicit def moduloValidateWitDouble[N <: Double, O <: Double](
+      implicit wn: Witness.Aux[N],
+      wo: Witness.Aux[O],
+  ): Validate.Plain[Double, Modulo[N, O]] =
+    Validate.fromPredicate(
+      t ⇒ t % wn.value == wo.value,
+      t ⇒ s"($t % ${wn.value} == ${wo.value})",
+      Modulo(wn.value, wo.value)
+    )
+
+  implicit def moduloValidateWitFloat[N <: Float, O <: Float](
+      implicit wn: Witness.Aux[N],
+      wo: Witness.Aux[O],
+  ): Validate.Plain[Float, Modulo[N, O]] =
+    Validate.fromPredicate(
+      t ⇒ t % wn.value == wo.value,
       t ⇒ s"($t % ${wn.value} == ${wo.value})",
       Modulo(wn.value, wo.value)
     )
@@ -125,7 +145,7 @@ private[refined] trait NumericValidate {
   ): Validate.Plain[T, Greater[N]] =
     Validate.fromPredicate(t => nt.toDouble(t) > tn(), t => s"($t > ${tn()})", Greater(wn.value))
 
-  implicit def moduloValidateNat[N <: Nat, O <: Nat, T](
+  implicit def moduloValidateNatIntegral[N <: Nat, O <: Nat, T](
       implicit tn: ToInt[N],
       to: ToInt[O],
       wn: Witness.Aux[N],
@@ -134,6 +154,28 @@ private[refined] trait NumericValidate {
   ): Validate.Plain[T, Modulo[N, O]] =
     Validate.fromPredicate(
       t ⇒ i.rem(t, i.fromInt(tn())) == to(),
+      t ⇒ s"($t % ${tn()} == ${to()})",
+      Modulo(wn.value, wo.value)
+    )
+  implicit def moduloValidateNatFloat[N <: Nat, O <: Nat](
+      implicit tn: ToInt[N],
+      to: ToInt[O],
+      wn: Witness.Aux[N],
+      wo: Witness.Aux[O]
+  ): Validate.Plain[Float, Modulo[N, O]] =
+    Validate.fromPredicate(
+      t ⇒ t % tn() == to(),
+      t ⇒ s"($t % ${tn()} == ${to()})",
+      Modulo(wn.value, wo.value)
+    )
+  implicit def moduloValidateNatDouble[N <: Nat, O <: Nat](
+      implicit tn: ToInt[N],
+      to: ToInt[O],
+      wn: Witness.Aux[N],
+      wo: Witness.Aux[O]
+  ): Validate.Plain[Double, Modulo[N, O]] =
+    Validate.fromPredicate(
+      t ⇒ t % tn() == to(),
       t ⇒ s"($t % ${tn()} == ${to()})",
       Modulo(wn.value, wo.value)
     )

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -100,6 +100,17 @@ private[refined] trait NumericValidate {
   ): Validate.Plain[T, Greater[N]] =
     Validate.fromPredicate(t => nt.gt(t, wn.value), t => s"($t > ${wn.value})", Greater(wn.value))
 
+  def moduloValidateWit[T, N <: T, O <: T](
+      implicit wn: Witness.Aux[N],
+      wo: Witness.Aux[O],
+      nt: Numeric[T]
+  ): Validate.Plain[T, Modulo[N, O]] =
+    Validate.fromPredicate(
+      t ⇒ nt.toDouble(t) % nt.toDouble(wn.value) == nt.toDouble(wo.value),
+      t ⇒ s"($t % ${wn.value} == ${wo.value})",
+      Modulo(wn.value, wo.value)
+    )
+
   implicit def moduloValidateWitIntegral[T, N <: T, O <: T](
       implicit wn: Witness.Aux[N],
       wo: Witness.Aux[O],
@@ -113,7 +124,7 @@ private[refined] trait NumericValidate {
 
   implicit def moduloValidateWitDouble[N <: Double, O <: Double](
       implicit wn: Witness.Aux[N],
-      wo: Witness.Aux[O],
+      wo: Witness.Aux[O]
   ): Validate.Plain[Double, Modulo[N, O]] =
     Validate.fromPredicate(
       t ⇒ t % wn.value == wo.value,
@@ -123,7 +134,7 @@ private[refined] trait NumericValidate {
 
   implicit def moduloValidateWitFloat[N <: Float, O <: Float](
       implicit wn: Witness.Aux[N],
-      wo: Witness.Aux[O],
+      wo: Witness.Aux[O]
   ): Validate.Plain[Float, Modulo[N, O]] =
     Validate.fromPredicate(
       t ⇒ t % wn.value == wo.value,
@@ -144,6 +155,19 @@ private[refined] trait NumericValidate {
       nt: Numeric[T]
   ): Validate.Plain[T, Greater[N]] =
     Validate.fromPredicate(t => nt.toDouble(t) > tn(), t => s"($t > ${tn()})", Greater(wn.value))
+
+  def moduloValidateNat[N <: Nat, O <: Nat, T](
+      implicit tn: ToInt[N],
+      to: ToInt[O],
+      wn: Witness.Aux[N],
+      wo: Witness.Aux[O],
+      nt: Numeric[T]
+  ): Validate.Plain[T, Modulo[N, O]] =
+    Validate.fromPredicate(
+      t ⇒ nt.toDouble(t) % tn() == to(),
+      t ⇒ s"($t % ${tn()} == ${to()})",
+      Modulo(wn.value, wo.value)
+    )
 
   implicit def moduloValidateNatIntegral[N <: Nat, O <: Nat, T](
       implicit tn: ToInt[N],

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
@@ -64,10 +64,6 @@ class NumericValidateSpec extends Properties("NumericValidate") {
     showResult[Greater[_5]](i) ?= showResult[Greater[W.`5`.T]](i)
   }
 
-  property("Modulo.isValid") = forAll { (d: Double) =>
-    isValid[Modulo[W.`2.0`.T, W.`0.0`.T]](d) ?= (d % 2.0 == 0.0)
-  }
-
   property("Modulo.isValid - Nat - Byte") = forAll { (b: Byte) =>
     isValid[Modulo[_2, _0]](b) ?= (b % 2 == 0)
   }
@@ -92,24 +88,8 @@ class NumericValidateSpec extends Properties("NumericValidate") {
     isValid[Modulo[W.`2L`.T, W.`0L`.T]](l) ?= (l % 2 == 0)
   }
 
-  property("Modulo.isValid - Nat - Float") = forAll { (l: Float) =>
-    isValid[Modulo[_2, _0]](l) ?= (l % 2 == 0)
-  }
-
-  property("Modulo.isValid - Wit - Float") = forAll { (l: Float) =>
-    isValid[Modulo[W.`2.0f`.T, W.`0.0f`.T]](l) ?= (l % 2 == 0)
-  }
-
-  property("Modulo.isValid - Nat - Double") = forAll { (l: Double) =>
-    isValid[Modulo[_2, _0]](l) ?= (l % 2 == 0)
-  }
-
-  property("Modulo.isValid - Wit - Double") = forAll { (l: Double) =>
-    isValid[Modulo[W.`2.0d`.T, W.`0.0d`.T]](l) ?= (l % 2 == 0)
-  }
-
   property("Modulo.showExpr") = secure {
-    showExpr[Modulo[W.`2.0`.T, W.`0.0`.T]](4.0) ?= s"(${4.0} % ${2.0} == ${0.0})"
+    showExpr[Modulo[W.`2`.T, W.`0`.T]](4) ?= s"(${4} % ${2} == ${0})"
   }
 
   property("Modulo.Nat.isValid") = forAll { (i: Int) =>

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
@@ -68,20 +68,44 @@ class NumericValidateSpec extends Properties("NumericValidate") {
     isValid[Modulo[W.`2.0`.T, W.`0.0`.T]](d) ?= (d % 2.0 == 0.0)
   }
 
-  property("Modulo.isValid - Byte") = forAll { (b: Byte) =>
+  property("Modulo.isValid - Nat - Byte") = forAll { (b: Byte) =>
     isValid[Modulo[_2, _0]](b) ?= (b % 2 == 0)
   }
 
-  property("Modulo.isValid - Short") = forAll { (s: Short) =>
+  property("Modulo.isValid - Nat - Short") = forAll { (s: Short) =>
     isValid[Modulo[_2, _0]](s) ?= (s % 2 == 0)
   }
 
-  property("Modulo.isValid - Int") = forAll { (i: Int) =>
+  property("Modulo.isValid - Nat - Int") = forAll { (i: Int) =>
     isValid[Modulo[_2, _0]](i) ?= (i % 2 == 0)
   }
 
-  property("Modulo.isValid - Long") = forAll { (l: Long) =>
+  property("Modulo.isValid - Wit - Int") = forAll { (i: Int) =>
+    isValid[Modulo[W.`2`.T, W.`0`.T]](i) ?= (i % 2 == 0)
+  }
+
+  property("Modulo.isValid - Nat - Long") = forAll { (l: Long) =>
     isValid[Modulo[_2, _0]](l) ?= (l % 2 == 0)
+  }
+
+  property("Modulo.isValid - Wit - Long") = forAll { (l: Long) =>
+    isValid[Modulo[W.`2L`.T, W.`0L`.T]](l) ?= (l % 2 == 0)
+  }
+
+  property("Modulo.isValid - Nat - Float") = forAll { (l: Float) =>
+    isValid[Modulo[_2, _0]](l) ?= (l % 2 == 0)
+  }
+
+  property("Modulo.isValid - Wit - Float") = forAll { (l: Float) =>
+    isValid[Modulo[W.`2.0f`.T, W.`0.0f`.T]](l) ?= (l % 2 == 0)
+  }
+
+  property("Modulo.isValid - Nat - Double") = forAll { (l: Double) =>
+    isValid[Modulo[_2, _0]](l) ?= (l % 2 == 0)
+  }
+
+  property("Modulo.isValid - Wit - Double") = forAll { (l: Double) =>
+    isValid[Modulo[W.`2.0d`.T, W.`0.0d`.T]](l) ?= (l % 2 == 0)
   }
 
   property("Modulo.showExpr") = secure {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
@@ -68,6 +68,22 @@ class NumericValidateSpec extends Properties("NumericValidate") {
     isValid[Modulo[W.`2.0`.T, W.`0.0`.T]](d) ?= (d % 2.0 == 0.0)
   }
 
+  property("Modulo.isValid - Byte") = forAll { (b: Byte) =>
+    isValid[Modulo[_2, _0]](b) ?= (b % 2 == 0)
+  }
+
+  property("Modulo.isValid - Short") = forAll { (s: Short) =>
+    isValid[Modulo[_2, _0]](s) ?= (s % 2 == 0)
+  }
+
+  property("Modulo.isValid - Int") = forAll { (i: Int) =>
+    isValid[Modulo[_2, _0]](i) ?= (i % 2 == 0)
+  }
+
+  property("Modulo.isValid - Long") = forAll { (l: Long) =>
+    isValid[Modulo[_2, _0]](l) ?= (l % 2 == 0)
+  }
+
   property("Modulo.showExpr") = secure {
     showExpr[Modulo[W.`2.0`.T, W.`0.0`.T]](4.0) ?= s"(${4.0} % ${2.0} == ${0.0})"
   }


### PR DESCRIPTION
Fixes #396.

This switches the `Validate` instances for `Modulo` to use `Integral` rather than `Numeric`. I've also kept the support for floating point types by having specific instances for them, though I'd vote for dropping this support.

I couldn't find a way to create a witness-style singleton for `Byte` and `Short` literals - hence they are not tested.

The change is **almost** binary-compatible. I've had to add an exclude for `ReversedMissingMethodProblem` - is that ok? I see there are other exclusions of this type already.