### PR TITLE
Do not use Numeric#toDouble in Equal's Validate instance

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -39,8 +39,10 @@ private[refined] trait GenericValidate {
       implicit tn: ToInt[N],
       wn: Witness.Aux[N],
       nt: Numeric[T]
-  ): Validate.Plain[T, Equal[N]] =
-    Validate.fromPredicate(t => nt.toDouble(t) == tn(), t => s"($t == ${tn()})", Equal(wn.value))
+  ): Validate.Plain[T, Equal[N]] = {
+    val n = nt.fromInt(tn())
+    Validate.fromPredicate(_ == n, t => s"($t == $n)", Equal(wn.value))
+  }
 
   implicit def ctorNamesValidate[T, R0 <: Coproduct, R1 <: HList, K <: HList, NP, NR](
       implicit lg: LabelledGeneric.Aux[T, R0],

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
@@ -51,12 +51,8 @@ class GenericValidateSpec extends Properties("GenericValidate") {
     isValid[Equal[_0]](d) ?= (d == 0.0)
   }
 
-  property("Equal.Nat.Int.showExpr") = secure {
+  property("Equal.Nat.showExpr") = secure {
     showExpr[Equal[_5]](0) ?= "(0 == 5)"
-  }
-
-  property("Equal.Nat.Double.showExpr") = secure {
-    showExpr[Equal[_5]](1.0) ?= "(1.0 == 5.0)"
   }
 
   property("Equal.Nat ~= Equal.Int") = forAll { (i: Int) =>

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
@@ -43,12 +43,20 @@ class GenericValidateSpec extends Properties("GenericValidate") {
     isValid[Equal[_0]](i) ?= (i == 0)
   }
 
+  property("Equal.Nat.Long.isValid") = forAll { (l: Long) =>
+    isValid[Equal[_0]](l) ?= (l == 0L)
+  }
+
   property("Equal.Nat.Double.isValid") = forAll { (d: Double) =>
     isValid[Equal[_0]](d) ?= (d == 0.0)
   }
 
-  property("Equal.Nat.showExpr") = secure {
+  property("Equal.Nat.Int.showExpr") = secure {
     showExpr[Equal[_5]](0) ?= "(0 == 5)"
+  }
+
+  property("Equal.Nat.Double.showExpr") = secure {
+    showExpr[Equal[_5]](1.0) ?= "(1.0 == 5.0)"
   }
 
   property("Equal.Nat ~= Equal.Int") = forAll { (i: Int) =>


### PR DESCRIPTION
... because of https://github.com/fthomas/refined/issues/396

Using Numeric#fromInt should be safer for this instance.