### PR TITLE
Omit type parameters in rt.unsafeWrap

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Max.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Max.scala
@@ -25,27 +25,27 @@ trait MaxInstances extends LowPriorityMaxInstances {
 
   implicit def greaterMax[F[_, _], T, N](implicit rt: RefType[F],
                                          m: Max[T]): Max[F[T, Greater[N]]] =
-    Max.instance(rt.unsafeWrap[T, Greater[N]](m.max))
+    Max.instance(rt.unsafeWrap(m.max))
 
   implicit def notLessMax[F[_, _], T, N](implicit rt: RefType[F],
                                          m: Max[T]): Max[F[T, Not[Less[N]]]] =
-    Max.instance(rt.unsafeWrap[T, Not[Less[N]]](m.max))
+    Max.instance(rt.unsafeWrap(m.max))
 
   implicit def notGreaterWit[F[_, _], T, N <: T](implicit rt: RefType[F],
                                                  w: Witness.Aux[N]): Max[F[T, Not[Greater[N]]]] =
-    Max.instance(rt.unsafeWrap[T, Not[Greater[N]]](w.value))
+    Max.instance(rt.unsafeWrap(w.value))
 
   implicit def notGreaterNat[F[_, _], T, N <: Nat](
       implicit
       rt: RefType[F],
       toInt: ToInt[N],
       numeric: Numeric[T]): Max[F[T, Not[Greater[N]]]] =
-    Max.instance(rt.unsafeWrap[T, Not[Greater[N]]](numeric.fromInt(toInt.apply())))
+    Max.instance(rt.unsafeWrap(numeric.fromInt(toInt.apply())))
 
   implicit def lessMax[F[_, _], T, N](implicit rt: RefType[F],
                                       notGreater: Max[F[T, Not[Greater[N]]]],
                                       adj: Adjacent[T]): Max[F[T, Less[N]]] =
-    Max.instance(rt.unsafeWrap[T, Less[N]](adj.nextDown(rt.unwrap(notGreater.max))))
+    Max.instance(rt.unsafeWrap(adj.nextDown(rt.unwrap(notGreater.max))))
 
   implicit def andMax[F[_, _], T, L, R](implicit rt: RefType[F],
                                         leftMax: Max[F[T, L]],
@@ -53,8 +53,7 @@ trait MaxInstances extends LowPriorityMaxInstances {
                                         validate: Validate[T, (L And R)],
                                         numeric: Numeric[T]): Max[F[T, (L And R)]] =
     Max.instance(
-      rt.unsafeWrap[T, (L And R)](
-        findValid(numeric.min(rt.unwrap(leftMax.max), rt.unwrap(rightMax.max)))))
+      rt.unsafeWrap(findValid(numeric.min(rt.unwrap(leftMax.max), rt.unwrap(rightMax.max)))))
 }
 trait LowPriorityMaxInstances {
   implicit def validateMax[F[_, _], T, P](implicit rt: RefType[F],

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Min.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Min.scala
@@ -24,25 +24,25 @@ trait MinInstances extends LowPriorityMinInstances {
   implicit val charMin: Min[Char] = Min.instance(Char.MinValue)
 
   implicit def lessMin[F[_, _], T, N](implicit rt: RefType[F], m: Min[T]): Min[F[T, Less[N]]] =
-    Min.instance(rt.unsafeWrap[T, Less[N]](m.min))
+    Min.instance(rt.unsafeWrap(m.min))
 
   implicit def notGreaterMin[F[_, _], T, N](implicit rt: RefType[F],
                                             m: Min[T]): Min[F[T, Not[Greater[N]]]] =
-    Min.instance(rt.unsafeWrap[T, Not[Greater[N]]](m.min))
+    Min.instance(rt.unsafeWrap(m.min))
 
   implicit def notLessMinWit[F[_, _], T, N <: T](implicit rt: RefType[F],
                                                  w: Witness.Aux[N]): Min[F[T, Not[Less[N]]]] =
-    Min.instance(rt.unsafeWrap[T, Not[Less[N]]](w.value))
+    Min.instance(rt.unsafeWrap(w.value))
 
   implicit def notLessMinNat[F[_, _], T, N <: Nat](implicit rt: RefType[F],
                                                    toInt: ToInt[N],
                                                    numeric: Numeric[T]): Min[F[T, Not[Less[N]]]] =
-    Min.instance(rt.unsafeWrap[T, Not[Less[N]]](numeric.fromInt(toInt.apply())))
+    Min.instance(rt.unsafeWrap(numeric.fromInt(toInt.apply())))
 
   implicit def greaterMin[F[_, _], T, N](implicit rt: RefType[F],
                                          notLessMin: Min[F[T, Not[Less[N]]]],
                                          adj: Adjacent[T]): Min[F[T, Greater[N]]] =
-    Min.instance(rt.unsafeWrap[T, Greater[N]](adj.nextUp(rt.unwrap(notLessMin.min))))
+    Min.instance(rt.unsafeWrap(adj.nextUp(rt.unwrap(notLessMin.min))))
 
   implicit def andMin[F[_, _], T, L, R](implicit rt: RefType[F],
                                         leftMin: Min[F[T, L]],
@@ -50,8 +50,7 @@ trait MinInstances extends LowPriorityMinInstances {
                                         validate: Validate[T, (L And R)],
                                         numeric: Numeric[T]): Min[F[T, (L And R)]] =
     Min.instance(
-      rt.unsafeWrap[T, (L And R)](
-        findValid(numeric.max(rt.unwrap(leftMin.min), rt.unwrap(rightMin.min)))))
+      rt.unsafeWrap(findValid(numeric.max(rt.unwrap(leftMin.min), rt.unwrap(rightMin.min)))))
 }
 trait LowPriorityMinInstances {
   implicit def validateMin[F[_, _], T, P](implicit rt: RefType[F],


### PR DESCRIPTION
This avoids repetition and is a little bit easier on the eyes.
Type inference will do the correct thing in these cases.