### PR TITLE
Make Adjacent[BigDecimal] non-derivable

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Max.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Max.scala
@@ -51,9 +51,10 @@ trait MaxInstances extends LowPriorityMaxInstances {
                                         leftMax: Max[F[T, L]],
                                         rightMax: Max[F[T, R]],
                                         validate: Validate[T, (L And R)],
-                                        numeric: Numeric[T]): Max[F[T, (L And R)]] =
+                                        ordering: Ordering[T],
+                                        adjacent: Adjacent[T]): Max[F[T, (L And R)]] =
     Max.instance(
-      rt.unsafeWrap(findValid(numeric.min(rt.unwrap(leftMax.max), rt.unwrap(rightMax.max)))))
+      rt.unsafeWrap(findValid(ordering.min(rt.unwrap(leftMax.max), rt.unwrap(rightMax.max)))))
 }
 trait LowPriorityMaxInstances {
   implicit def validateMax[F[_, _], T, P](implicit rt: RefType[F],

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Min.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Min.scala
@@ -48,9 +48,10 @@ trait MinInstances extends LowPriorityMinInstances {
                                         leftMin: Min[F[T, L]],
                                         rightMin: Min[F[T, R]],
                                         validate: Validate[T, (L And R)],
-                                        numeric: Numeric[T]): Min[F[T, (L And R)]] =
+                                        ordering: Ordering[T],
+                                        adjacent: Adjacent[T]): Min[F[T, (L And R)]] =
     Min.instance(
-      rt.unsafeWrap(findValid(numeric.max(rt.unwrap(leftMin.min), rt.unwrap(rightMin.min)))))
+      rt.unsafeWrap(findValid(ordering.max(rt.unwrap(leftMin.min), rt.unwrap(rightMin.min)))))
 }
 trait LowPriorityMinInstances {
   implicit def validateMin[F[_, _], T, P](implicit rt: RefType[F],

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
@@ -26,9 +26,9 @@ object Adjacent {
       t => Math.nextAfter(t, Float.NegativeInfinity)
     )
 
-  implicit def numericAdjacent[T](implicit nt: Numeric[T]): Adjacent[T] =
+  implicit def integralAdjacent[T](implicit it: Integral[T]): Adjacent[T] =
     instance(
-      t => nt.plus(t, nt.one),
-      t => nt.minus(t, nt.one)
+      t => it.max(it.plus(t, it.one), t),
+      t => it.min(it.minus(t, it.one), t)
     )
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/internal/AdjacentSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/internal/AdjacentSpec.scala
@@ -1,0 +1,29 @@
+package eu.timepit.refined.internal
+
+import eu.timepit.refined.TestUtils.wellTyped
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+import shapeless.test.illTyped
+
+class AdjacentSpec extends Properties("Adjacent") {
+
+  property("nextUp.Int") = forAll { (i: Int) =>
+    Adjacent[Int].nextUp(i) >= i
+  }
+
+  property("nextDown.Int") = forAll { (i: Int) =>
+    Adjacent[Int].nextDown(i) <= i
+  }
+
+  property("nextUp.Double") = forAll { (d: Double) =>
+    Adjacent[Double].nextUp(d) >= d
+  }
+
+  property("nextDown.Double") = forAll { (d: Double) =>
+    Adjacent[Double].nextDown(d) <= d
+  }
+
+  property("BigDecimal instance is non-derivable") = wellTyped {
+    illTyped("Adjacent[BigDecimal]", "could not find implicit value.*")
+  }
+}


### PR DESCRIPTION
The `numericAdjacent` allowed to derive this
```scala
scala> internal.Adjacent[BigDecimal].nextUp(BigDecimal(1.0))
res1: BigDecimal = 2.0
```
which is invalid because there are uncountable many `BigDecimal`s
greater than 1.0 and less than 2.0.