### PR TITLE
Make Adjacent a subclass of Ordering

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Max.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Max.scala
@@ -61,11 +61,10 @@ trait MaxInstances extends LowPriorityMaxInstances {
       implicit rt: RefType[F],
       ml: Max[F[T, L]],
       mr: Max[F[T, R]],
-      ot: Ordering[T],
       at: Adjacent[T],
       v: Validate[T, L And R]
   ): Max[F[T, L And R]] =
-    Max.instance(rt.unsafeWrap(findValid(ot.min(rt.unwrap(ml.max), rt.unwrap(mr.max)))))
+    Max.instance(rt.unsafeWrap(findValid(at.min(rt.unwrap(ml.max), rt.unwrap(mr.max)))))
 }
 
 trait LowPriorityMaxInstances {
@@ -79,7 +78,7 @@ trait LowPriorityMaxInstances {
 
   protected def findValid[T, P](from: T)(implicit at: Adjacent[T], v: Validate[T, P]): T = {
     var result = from
-    while (!v.isValid(result)) result = at.nextDown(result)
+    while (!v.isValid(result)) result = at.nextDownOrNone(result).get
     result
   }
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Min.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Min.scala
@@ -61,11 +61,10 @@ trait MinInstances extends LowPriorityMinInstances {
       implicit rt: RefType[F],
       ml: Min[F[T, L]],
       mr: Min[F[T, R]],
-      ot: Ordering[T],
       at: Adjacent[T],
       v: Validate[T, L And R]
   ): Min[F[T, L And R]] =
-    Min.instance(rt.unsafeWrap(findValid(ot.max(rt.unwrap(ml.min), rt.unwrap(mr.min)))))
+    Min.instance(rt.unsafeWrap(findValid(at.max(rt.unwrap(ml.min), rt.unwrap(mr.min)))))
 }
 
 trait LowPriorityMinInstances {
@@ -79,7 +78,7 @@ trait LowPriorityMinInstances {
 
   protected def findValid[T, P](from: T)(implicit at: Adjacent[T], v: Validate[T, P]): T = {
     var result = from
-    while (!v.isValid(result)) result = at.nextUp(result)
+    while (!v.isValid(result)) result = at.nextUpOrNone(result).get
     result
   }
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
@@ -58,8 +58,8 @@ object Adjacent {
   implicit def integralAdjacent[T](
       implicit it: Integral[T]
   ): Adjacent[T] =
-    instance(
+    instance[T](
       t => it.max(it.plus(t, it.one), t),
       t => it.min(it.minus(t, it.one), t)
-    )
+    )(it)
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
@@ -40,26 +40,25 @@ trait Adjacent[T] extends Ordering[T] {
 object Adjacent {
   def apply[T](implicit at: Adjacent[T]): Adjacent[T] = at
 
-  def instance[T](nextUpF: T => T, nextDownF: T => T)(
-      implicit ot: Ordering[T]
-  ): Adjacent[T] =
+  def instance[T](compareF: (T, T) => Int, nextUpF: T => T, nextDownF: T => T): Adjacent[T] =
     new Adjacent[T] {
-      override def compare(x: T, y: T): Int = ot.compare(x, y)
+      override def compare(x: T, y: T): Int = compareF(x, y)
       override def nextUp(t: T): T = nextUpF(t)
       override def nextDown(t: T): T = nextDownF(t)
     }
 
   implicit val doubleAdjacent: Adjacent[Double] =
-    instance(Math.nextUp, Math.nextDown)
+    instance(Ordering.Double.compare, Math.nextUp, Math.nextDown)
 
   implicit val floatAdjacent: Adjacent[Float] =
-    instance(Math.nextUp, Math.nextDown)
+    instance(Ordering.Float.compare, Math.nextUp, Math.nextDown)
 
   implicit def integralAdjacent[T](
       implicit it: Integral[T]
   ): Adjacent[T] =
-    instance[T](
+    instance(
+      it.compare,
       t => it.max(it.plus(t, it.one), t),
       t => it.min(it.minus(t, it.one), t)
-    )(it)
+    )
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Adjacent.scala
@@ -4,7 +4,7 @@ package eu.timepit.refined.internal
  * Type class that provides the next greater or next smaller value for
  * a given argument.
  */
-trait Adjacent[T] {
+trait Adjacent[T] extends Ordering[T] {
 
   /**
    * Returns the next greater value adjacent to `t` or `t` if there is
@@ -17,13 +17,34 @@ trait Adjacent[T] {
    * no smaller value.
    */
   def nextDown(t: T): T
+
+  /**
+   * Returns the next greater value adjacent to `t` or `None` if there is
+   * no greater value.
+   */
+  def nextUpOrNone(t: T): Option[T] = {
+    val n = nextUp(t)
+    if (gt(n, t)) Some(n) else None
+  }
+
+  /**
+   * Returns the next smaller value adjacent to `t` or `None` if there is
+   * no smaller value.
+   */
+  def nextDownOrNone(t: T): Option[T] = {
+    val n = nextDown(t)
+    if (lt(n, t)) Some(n) else None
+  }
 }
 
 object Adjacent {
-  def apply[T](implicit a: Adjacent[T]): Adjacent[T] = a
+  def apply[T](implicit at: Adjacent[T]): Adjacent[T] = at
 
-  def instance[T](nextUpF: T => T, nextDownF: T => T): Adjacent[T] =
+  def instance[T](nextUpF: T => T, nextDownF: T => T)(
+      implicit ot: Ordering[T]
+  ): Adjacent[T] =
     new Adjacent[T] {
+      override def compare(x: T, y: T): Int = ot.compare(x, y)
       override def nextUp(t: T): T = nextUpF(t)
       override def nextDown(t: T): T = nextDownF(t)
     }
@@ -34,7 +55,9 @@ object Adjacent {
   implicit val floatAdjacent: Adjacent[Float] =
     instance(Math.nextUp, Math.nextDown)
 
-  implicit def integralAdjacent[T](implicit it: Integral[T]): Adjacent[T] =
+  implicit def integralAdjacent[T](
+      implicit it: Integral[T]
+  ): Adjacent[T] =
     instance(
       t => it.max(it.plus(t, it.one), t),
       t => it.min(it.minus(t, it.one), t)


### PR DESCRIPTION
This PR

1. makes `Adjacent` a subclass of `Ordering`
2. adds `next{Up,Down}OrNone` to `Adjacent`
3. changes `{Min,Max}.findValid` to throw an exception instead of
   looping forever if it fails to find a next value satisfying the predicate

Making `Adjacent` a subclass of `Ordering` was not required technically
but is the right thing to do conceptually. The laws of `Adjacent` are
`nextUp(x) >= x` and `nextDown(x) <= x` for all `x`. To formulate these
laws we need `>=` and `<=` and hence any `Adjacent` needs to be
`Ordering`.