### PR TITLE
Deprecate Subtype and Supertype predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,6 @@ The library comes with these predefined predicates:
 * `Equal[U]`: checks if a value is equal to `U`
 * `ConstructorNames[P]`: checks if the constructor names of a sum type satisfy `P`
 * `FieldNames[P]`: checks if the field names of a product type satisfy `P`
-* `Subtype[U]`: witnesses that the type of a value is a subtype of `U`
-* `Supertype[U]`: witnesses that the type of a value is a supertype of `U`
 
 [`numeric`](https://github.com/fthomas/refined/blob/master/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala)
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -21,10 +21,14 @@ object generic extends GenericValidate with GenericInference {
   /** Predicate that checks if the field names of a product type satisfy `P`. */
   final case class FieldNames[P](p: P)
 
-  /** Predicate that witnesses that the type of a value is a subtype of `U`. */
+  @deprecated(
+    "The Subtype predicate is deprecated without replacement because it is lacking practical relevance.",
+    "0.9.0")
   final case class Subtype[U]()
 
-  /** Predicate that witnesses that the type of a value is a supertype of `U`. */
+  @deprecated(
+    "The Supertype predicate is deprecated without replacement because it is lacking practical relevance.",
+    "0.9.0")
   final case class Supertype[U]()
 }
 
@@ -69,9 +73,15 @@ private[refined] trait GenericValidate {
     Validate.constant(rn.as(FieldNames(rn)), v.showExpr(fieldNames))
   }
 
+  @deprecated(
+    "The Subtype predicate is deprecated without replacement because it is lacking practical relevance.",
+    "0.9.0")
   implicit def subtypeValidate[T, U >: T]: Validate.Plain[T, Subtype[U]] =
     Validate.alwaysPassed(Subtype())
 
+  @deprecated(
+    "The Supertype predicate is deprecated without replacement because it is lacking practical relevance.",
+    "0.9.0")
   implicit def supertypeValidate[T, U <: T]: Validate.Plain[T, Supertype[U]] =
     Validate.alwaysPassed(Supertype())
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
@@ -6,7 +6,6 @@ import eu.timepit.refined.generic._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import shapeless.Nat._
-import shapeless.test.illTyped
 
 class GenericValidateSpec extends Properties("GenericValidate") {
 
@@ -86,21 +85,5 @@ class GenericValidateSpec extends Properties("GenericValidate") {
     case class A(fst: Any = 1, snd: Any = 2)
     showExpr[FieldNames[Contains[W.`"third"`.T]]](A()) ?=
       "!(!(fst == third) && !(snd == third))"
-  }
-
-  property("Subtype.isValid") = secure {
-    isValid[Subtype[AnyVal]](0)
-  }
-
-  property("Subtype.noInstance") = wellTyped {
-    illTyped("isValid[Subtype[Int]](0: AnyVal)", ".*could not find implicit value.*")
-  }
-
-  property("Supertype.isValid") = secure {
-    isValid[Supertype[List[Int]]](Seq(0))
-  }
-
-  property("Supertype.noInstance") = wellTyped {
-    illTyped("isValid[Supertype[Seq[Int]]](List(0))", ".*could not find implicit value.*")
   }
 }

--- a/notes/0.9.0.markdown
+++ b/notes/0.9.0.markdown
@@ -6,6 +6,8 @@
 
 * Change layout of the `types` package to create fewer instances and to
   support "auto import" in IntelliJ. ([#416][#416], [#431][#431])
+* Deprecate `Subtype` and `Supertype` predicates because they lack
+  practical relevance. ([#432][#432])
 * Remove deprecated `util.time` module which has been replaced by
   the `types.time` module. ([#425][#425])
 * Remove deprecated `Refined#get` method which has been replaced by
@@ -20,3 +22,4 @@
 [#425]: https://github.com/fthomas/refined/pull/425
 [#426]: https://github.com/fthomas/refined/pull/426
 [#431]: https://github.com/fthomas/refined/pull/431
+[#432]: https://github.com/fthomas/refined/pull/432


### PR DESCRIPTION
Because they are lacking practical relevance.

See also #386.