### PR TITLE
Add predicates package and über-import for all predicates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -217,12 +217,7 @@ lazy val commonSettings = Def.settings(
     import $rootPkg.api.Inference.==>
     import $rootPkg.api.RefType.ops._
     import $rootPkg.auto._
-    import $rootPkg.boolean._
-    import $rootPkg.char._
-    import $rootPkg.collection._
-    import $rootPkg.generic._
-    import $rootPkg.numeric._
-    import $rootPkg.string._
+    import $rootPkg.predicates.all._
     import $rootPkg.types.all._
     import shapeless.{ ::, HList, HNil }
     import shapeless.nat._

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
@@ -1,0 +1,11 @@
+package eu.timepit.refined.predicates
+
+object all extends AllPredicates
+
+trait AllPredicates
+    extends BooleanPredicates
+    with CharPredicates
+    with CollectionPredicates
+    with GenericPredicates
+    with NumericPredicates
+    with StringPredicates

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/boolean.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/boolean.scala
@@ -1,0 +1,38 @@
+package eu.timepit.refined.predicates
+
+import eu.timepit.refined
+
+object boolean extends BooleanPredicates
+
+trait BooleanPredicates {
+  final type True = refined.boolean.True
+  final val True = refined.boolean.True
+
+  final type False = refined.boolean.False
+  final val False = refined.boolean.False
+
+  final type Not[P] = refined.boolean.Not[P]
+  final val Not = refined.boolean.Not
+
+  final type And[A, B] = refined.boolean.And[A, B]
+  final val And = refined.boolean.And
+
+  final type Or[A, B] = refined.boolean.Or[A, B]
+  final val Or = refined.boolean.Or
+
+  final type Xor[A, B] = refined.boolean.Xor[A, B]
+  final val Xor = refined.boolean.Xor
+
+  final type AllOf[PS] = refined.boolean.AllOf[PS]
+  final val AllOf = refined.boolean.AllOf
+
+  final type AnyOf[PS] = refined.boolean.AnyOf[PS]
+  final val AnyOf = refined.boolean.AnyOf
+
+  final type OneOf[PS] = refined.boolean.OneOf[PS]
+  final val OneOf = refined.boolean.OneOf
+
+  final type Nand[A, B] = refined.boolean.Nand[A, B]
+
+  final type Nor[A, B] = refined.boolean.Nor[A, B]
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/char.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/char.scala
@@ -1,0 +1,24 @@
+package eu.timepit.refined.predicates
+
+import eu.timepit.refined
+
+object char extends CharPredicates
+
+trait CharPredicates {
+  final type Digit = refined.char.Digit
+  final val Digit = refined.char.Digit
+
+  final type Letter = refined.char.Letter
+  final val Letter = refined.char.Letter
+
+  final type LowerCase = refined.char.LowerCase
+  final val LowerCase = refined.char.LowerCase
+
+  final type UpperCase = refined.char.UpperCase
+  final val UpperCase = refined.char.UpperCase
+
+  final type Whitespace = refined.char.Whitespace
+  final val Whitespace = refined.char.Whitespace
+
+  final type LetterOrDigit = refined.char.LetterOrDigit
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/collection.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/collection.scala
@@ -1,0 +1,44 @@
+package eu.timepit.refined.predicates
+
+import eu.timepit.refined
+
+object collection extends CollectionPredicates
+
+trait CollectionPredicates {
+  final type Count[PA, PC] = refined.collection.Count[PA, PC]
+  final val Count = refined.collection.Count
+
+  final type Empty = refined.collection.Empty
+  final val Empty = refined.collection.Empty
+
+  final type Forall[P] = refined.collection.Forall[P]
+  final val Forall = refined.collection.Forall
+
+  final type Head[P] = refined.collection.Head[P]
+  final val Head = refined.collection.Head
+
+  final type Index[N, P] = refined.collection.Index[N, P]
+  final val Index = refined.collection.Index
+
+  final type Init[P] = refined.collection.Init[P]
+  final val Init = refined.collection.Init
+
+  final type Last[P] = refined.collection.Last[P]
+  final val Last = refined.collection.Last
+
+  final type Size[P] = refined.collection.Size[P]
+  final val Size = refined.collection.Size
+
+  final type Tail[P] = refined.collection.Tail[P]
+  final val Tail = refined.collection.Tail
+
+  final type Contains[U] = refined.collection.Contains[U]
+
+  final type Exists[P] = refined.collection.Exists[P]
+
+  final type MinSize[N] = refined.collection.MinSize[N]
+
+  final type MaxSize[N] = refined.collection.MaxSize[N]
+
+  final type NonEmpty = refined.collection.NonEmpty
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/generic.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/generic.scala
@@ -1,0 +1,10 @@
+package eu.timepit.refined.predicates
+
+import eu.timepit.refined
+
+object generic extends GenericPredicates
+
+trait GenericPredicates {
+  final type Equal[U] = refined.generic.Equal[U]
+  final val Equal = refined.generic.Equal
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
@@ -1,0 +1,38 @@
+package eu.timepit.refined.predicates
+
+import eu.timepit.refined
+
+object numeric extends NumericPredicates
+
+trait NumericPredicates {
+  final type Less[N] = refined.numeric.Less[N]
+  final val Less = refined.numeric.Less
+
+  final type Greater[N] = refined.numeric.Greater[N]
+  final val Greater = refined.numeric.Greater
+
+  final type Modulo[N, O] = refined.numeric.Modulo[N, O]
+  final val Modulo = refined.numeric.Modulo
+
+  final type LessEqual[N] = refined.numeric.LessEqual[N]
+
+  final type GreaterEqual[N] = refined.numeric.GreaterEqual[N]
+
+  final type Positive = refined.numeric.Positive
+
+  final type NonPositive = refined.numeric.NonPositive
+
+  final type Negative = refined.numeric.Negative
+
+  final type NonNegative = refined.numeric.NonNegative
+
+  final type Divisible[N] = refined.numeric.Divisible[N]
+
+  final type NonDivisible[N] = refined.numeric.NonDivisible[N]
+
+  final type Even = refined.numeric.Even
+
+  final type Odd = refined.numeric.Odd
+
+  final val Interval = refined.numeric.Interval
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/string.scala
@@ -1,0 +1,55 @@
+package eu.timepit.refined.predicates
+
+import eu.timepit.refined
+
+object string extends StringPredicates
+
+trait StringPredicates {
+  final type EndsWith[S] = refined.string.EndsWith[S]
+  final val EndsWith = refined.string.EndsWith
+
+  final type IPv4 = refined.string.IPv4
+  final val IPv4 = refined.string.IPv4
+
+  final type IPv6 = refined.string.IPv6
+  final val IPv6 = refined.string.IPv6
+
+  final type MatchesRegex[S] = refined.string.MatchesRegex[S]
+  final val MatchesRegex = refined.string.MatchesRegex
+
+  final type Regex = refined.string.Regex
+  final val Regex = refined.string.Regex
+
+  final type StartsWith[S] = refined.string.StartsWith[S]
+  final val StartsWith = refined.string.StartsWith
+
+  final type Uri = refined.string.Uri
+  final val Uri = refined.string.Uri
+
+  final type Url = refined.string.Url
+  final val Url = refined.string.Url
+
+  final type Uuid = refined.string.Uuid
+  final val Uuid = refined.string.Uuid
+
+  final type ValidInt = refined.string.ValidInt
+  final val ValidInt = refined.string.ValidInt
+
+  final type ValidLong = refined.string.ValidLong
+  final val ValidLong = refined.string.ValidLong
+
+  final type ValidDouble = refined.string.ValidDouble
+  final val ValidDouble = refined.string.ValidDouble
+
+  final type ValidBigInt = refined.string.ValidBigInt
+  final val ValidBigInt = refined.string.ValidBigInt
+
+  final type ValidBigDecimal = refined.string.ValidBigDecimal
+  final val ValidBigDecimal = refined.string.ValidBigDecimal
+
+  final type Xml = refined.string.Xml
+  final val Xml = refined.string.Xml
+
+  final type XPath = refined.string.XPath
+  final val XPath = refined.string.XPath
+}

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/CharValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/CharValidateSpec.scala
@@ -15,6 +15,10 @@ class CharValidateSpec extends Properties("CharValidate") {
     showExpr[Digit]('c') ?= "isDigit('c')"
   }
 
+  property("Digit()") = wellTyped {
+    Digit()
+  }
+
   property("Letter.isValid") = forAll { (c: Char) =>
     isValid[Letter](c) ?= c.isLetter
   }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/CharValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/CharValidateSpec.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined
 
 import eu.timepit.refined.TestUtils._
-import eu.timepit.refined.char._
+import eu.timepit.refined.predicates.all._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 

--- a/notes/0.9.0.markdown
+++ b/notes/0.9.0.markdown
@@ -1,6 +1,9 @@
 ### New features
 
 * Add `Arbitrary` instance for `NonEmptyString`. ([#415][#415])
+* Add `predicates` package which allows to import all predicates
+  with a single `import eu.timepit.refined.predicates.all._`.
+  ([#433][#433])
 
 ### Changes
 
@@ -23,3 +26,4 @@
 [#426]: https://github.com/fthomas/refined/pull/426
 [#431]: https://github.com/fthomas/refined/pull/431
 [#432]: https://github.com/fthomas/refined/pull/432
+[#433]: https://github.com/fthomas/refined/pull/433


### PR DESCRIPTION
This allows to import all predicates with `import predicates.all._`. The `AllPredicates` trait also allow us to create an even bigger über-import. It is one step towards #184.

With a `predicates` package it also makes sense to move the actual definitions of our predicates here. But that should happen in another PR.