### PR TITLE
Deprecate ConstructorNames and FieldNames predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,6 @@ The library comes with these predefined predicates:
 [`generic`](https://github.com/fthomas/refined/blob/master/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala)
 
 * `Equal[U]`: checks if a value is equal to `U`
-* `ConstructorNames[P]`: checks if the constructor names of a sum type satisfy `P`
-* `FieldNames[P]`: checks if the field names of a product type satisfy `P`
 
 [`numeric`](https://github.com/fthomas/refined/blob/master/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala)
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/generic.scala
@@ -15,10 +15,14 @@ object generic extends GenericValidate with GenericInference {
   /** Predicate that checks if a value is equal to `U`. */
   final case class Equal[U](u: U)
 
-  /** Predicate that checks if the constructor names of a sum type satisfy `P`. */
+  @deprecated(
+    "Deprecated because ConstructorNames operates on types and not values and refined focuses on refining values.",
+    "0.9.0")
   final case class ConstructorNames[P](p: P)
 
-  /** Predicate that checks if the field names of a product type satisfy `P`. */
+  @deprecated(
+    "Deprecated because FieldNames operates on types and not values and refined focuses on refining values.",
+    "0.9.0")
   final case class FieldNames[P](p: P)
 
   @deprecated(
@@ -48,6 +52,9 @@ private[refined] trait GenericValidate {
     Validate.fromPredicate(_ == n, t => s"($t == $n)", Equal(wn.value))
   }
 
+  @deprecated(
+    "Deprecated because ConstructorNames operates on types and not values and refined focuses on refining values.",
+    "0.9.0")
   implicit def ctorNamesValidate[T, R0 <: Coproduct, R1 <: HList, K <: HList, NP, NR](
       implicit lg: LabelledGeneric.Aux[T, R0],
       cthl: ToHList.Aux[R0, R1],
@@ -61,6 +68,9 @@ private[refined] trait GenericValidate {
     Validate.constant(rn.as(ConstructorNames(rn)), v.showExpr(ctorNames))
   }
 
+  @deprecated(
+    "Deprecated because FieldNames operates on types and not values and refined focuses on refining values.",
+    "0.9.0")
   implicit def fieldNamesValidate[T, R <: HList, K <: HList, NP, NR](
       implicit lg: LabelledGeneric.Aux[T, R],
       keys: Keys.Aux[R, K],

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
@@ -1,7 +1,6 @@
 package eu.timepit.refined
 
 import eu.timepit.refined.TestUtils._
-import eu.timepit.refined.collection.Contains
 import eu.timepit.refined.generic._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
@@ -56,34 +55,5 @@ class GenericValidateSpec extends Properties("GenericValidate") {
 
   property("Equal.Nat ~= Equal.Int") = forAll { (i: Int) =>
     showResult[Equal[_1]](i) ?= showResult[Equal[W.`1`.T]](i)
-  }
-
-  property("ConstructorNames.isValid") = secure {
-    isValid[ConstructorNames[Contains[W.`"Some"`.T]]](Option(0))
-  }
-
-  property("ConstructorNames.notValid") = secure {
-    notValid[ConstructorNames[Contains[W.`"Just"`.T]]](Option(0))
-  }
-
-  property("ConstructorNames.showExpr") = secure {
-    showExpr[ConstructorNames[Contains[W.`"Just"`.T]]](Option(0)) ?=
-      "!(!(None == Just) && !(Some == Just))"
-  }
-
-  property("FieldNames.isValid") = secure {
-    case class A(fst: Any = 1, snd: Any = 2)
-    isValid[FieldNames[Contains[W.`"snd"`.T]]](A())
-  }
-
-  property("FieldNames.notValid") = secure {
-    case class A(fst: Any = 1, snd: Any = 2)
-    notValid[FieldNames[Contains[W.`"first"`.T]]](A())
-  }
-
-  property("FieldNames.showExpr") = secure {
-    case class A(fst: Any = 1, snd: Any = 2)
-    showExpr[FieldNames[Contains[W.`"third"`.T]]](A()) ?=
-      "!(!(fst == third) && !(snd == third))"
   }
 }

--- a/notes/0.9.0.markdown
+++ b/notes/0.9.0.markdown
@@ -9,14 +9,21 @@
 
 * Change layout of the `types` package to create fewer instances and to
   support "auto import" in IntelliJ. ([#416][#416], [#431][#431])
+
+### Bug fixes
+
+### Deprecations and removals
+
 * Deprecate `Subtype` and `Supertype` predicates because they lack
   practical relevance. ([#432][#432])
+* Deprecate `ConstructorNames` and `FieldNames` predicates because they
+  operate on types instead of values (i.e. the result of a validation
+  only depends on the type of a value) and the library focuses on
+  refining values.
 * Remove deprecated `util.time` module which has been replaced by
   the `types.time` module. ([#425][#425])
 * Remove deprecated `Refined#get` method which has been replaced by
   `Refined#value`. ([#426][#426])
-
-### Bug fixes
 
 ### Updates
 


### PR DESCRIPTION
because they operate on types and not values and refined focuses
on refining values.