### PR TITLE
Move IPv4 and IPv6 companions to the other companions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -304,7 +304,9 @@ lazy val moduleJvmSettings = Def.settings(
       ProblemFilters.exclude[MissingTypesProblem]("eu.timepit.refined.string*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("eu.timepit.refined.collection.*"),
       ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.CollectionValidate"),
-      ProblemFilters.exclude[MissingTypesProblem]("eu.timepit.refined.collection*")
+      ProblemFilters.exclude[MissingTypesProblem]("eu.timepit.refined.collection*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("eu.timepit.refined.string#IPv4.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("eu.timepit.refined.string#IPv6.*")
     )
   }
 )


### PR DESCRIPTION
and make all their fields private now that the Validate instances
are defined inside the companions.