### PR TITLE
Added documentation to solve exception during macro expansion errors

### DIFF
--- a/modules/docs/macro_pitfalls.md
+++ b/modules/docs/macro_pitfalls.md
@@ -5,7 +5,7 @@ import eu.timepit.refined._
 import eu.timepit.refined.api.Validate
 ```
 
-When using the `refineMT` or `refineMV` macros with custom predicates
+When using the `refineMT`, `refineMV`, implicit conversion with `eu.timepit.refined.auto._` or `RefType.applyRef` macros with custom predicates
 make sure to define the predicate and its `Validate` instance in a
 different compilation unit. Otherwise macro expansion will fail because
 it tries to evaluate an uninitialized object as you can see below:
@@ -50,8 +50,8 @@ java.lang.ClassNotFoundException: Test1$
          val x = refineMV[Foo](0)
                               ^
 ```
-
-Using the macro in a different compilation unit is fine:
+## Solution 1
+Using the macro in a different compilation unit is fine (through REPL):
 
 ```scala
 scala> object Test1 {
@@ -67,3 +67,10 @@ scala> object Test2 {
      | }
 defined object Test2
 ```
+## Solution 2
+
+When used inside a regular project, this approach might not be enough.
+
+The other solution is to create a [multi-project](https://www.scala-sbt.org/1.x/docs/Multi-Project.html). The subproject `a` contains the previously defined object `Test1` while the subproject `b` contains the actual call to `refinedMV`, `refinedMT`, implicit conversion with `eu.timepit.refined.auto._` or the call to `RefType.applyRef`. 
+
+Project `b` will have to depend on project `a` (on it's build.sbt file) using the method call [dependsOn](https://www.scala-sbt.org/1.x/docs/Multi-Project.html#Classpath+dependencies).


### PR DESCRIPTION
Added documentation to solve `java.lang.ClassNotFoundException` when adding a custom predicate inside a project (not REPL).

This addresses the issue #448