### PR TITLE
Add inference rule for `Greater[A] ==> Not[Less[A]]`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,10 +316,10 @@ lazy val moduleJvmSettings = Def.settings(
         "eu.timepit.refined.jsonpath.string.jsonPathValidate"),
       ProblemFilters.exclude[MissingTypesProblem]("eu.timepit.refined.jsonpath.string$*"),
       ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.jsonpath.StringValidate"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "eu.timepit.refined.numeric.greaterEqualInference"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "eu.timepit.refined.numeric.lessEqualInference")
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "eu.timepit.refined.NumericInference.greaterEqualInference"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "eu.timepit.refined.NumericInference.lessEqualInference")
     )
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -315,7 +315,11 @@ lazy val moduleJvmSettings = Def.settings(
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "eu.timepit.refined.jsonpath.string.jsonPathValidate"),
       ProblemFilters.exclude[MissingTypesProblem]("eu.timepit.refined.jsonpath.string$*"),
-      ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.jsonpath.StringValidate")
+      ProblemFilters.exclude[MissingClassProblem]("eu.timepit.refined.jsonpath.StringValidate"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "eu.timepit.refined.numeric.greaterEqualInference"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "eu.timepit.refined.numeric.lessEqualInference")
     )
   }
 )

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -196,6 +196,9 @@ private[refined] trait NumericInference {
   ): Greater[A] ==> Greater[B] =
     Inference(nc.gt(wa.value, nc.fromInt(tb())), s"greaterInferenceWitNat(${wa.value}, ${tb()})")
 
-  implicit def greaterNotLessThanInference[A]: Greater[A] ==> Not[Less[A]] =
-    Inference(true, s"greaterNotLessThanInference")
+  implicit def greaterEqualInference[A]: Greater[A] ==> GreaterEqual[A] =
+    Inference(true, "greaterEqualInference")
+
+  implicit def lessEqualInference[A]: Less[A] ==> LessEqual[A] =
+    Inference(true, "lessEqualInference")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -195,4 +195,7 @@ private[refined] trait NumericInference {
       nc: Numeric[C]
   ): Greater[A] ==> Greater[B] =
     Inference(nc.gt(wa.value, nc.fromInt(tb())), s"greaterInferenceWitNat(${wa.value}, ${tb()})")
+
+  implicit def greaterNotLessThanInference[A]: Greater[A] ==> Not[Less[A]] =
+    Inference(true, s"greaterNotLessThanInference")
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericInferenceSpec.scala
@@ -91,6 +91,10 @@ class NumericInferenceSpec extends Properties("NumericInference") {
     Inference[Interval.Closed[_5, _10], LessEqual[_11]].isValid
   }
 
+  property("Greater[A] ==> Not[Less[A]]") = secure {
+    Inference[Greater[W.`0`.T], Not[Less[W.`0`.T]]].isValid
+  }
+
   /*
   property("Interval.Closed[Nat] ==> GreaterEqual[Nat]") = secure {
     Inference[Interval.Closed[_5, _10], GreaterEqual[_4]].isValid

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericInferenceSpec.scala
@@ -91,8 +91,12 @@ class NumericInferenceSpec extends Properties("NumericInference") {
     Inference[Interval.Closed[_5, _10], LessEqual[_11]].isValid
   }
 
-  property("Greater[A] ==> Not[Less[A]]") = secure {
-    Inference[Greater[W.`0`.T], Not[Less[W.`0`.T]]].isValid
+  property("Greater[A] ==> GreaterEqual[A]") = secure {
+    Inference[Greater[W.`0`.T], GreaterEqual[W.`0`.T]].isValid
+  }
+
+  property("Less[A] ==> LessEqual[A]") = secure {
+    Inference[Less[W.`0`.T], LessEqual[W.`0`.T]].isValid
   }
 
   /*


### PR DESCRIPTION
If a value is greater than `x`, then it also must not be less than `x`.

What do you think of introducing it as an inference rule?