### PR TITLE
Add arbitrary instance for lists with a MaxSize.

### DIFF
--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
@@ -7,3 +7,4 @@ object all
     with NumericInstances
     with RefTypeInstances
     with StringInstances
+    with CollectionInstances

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
@@ -3,19 +3,21 @@ package eu.timepit.refined.scalacheck
 import eu.timepit.refined.api.{Refined, RefType}
 import eu.timepit.refined.collection.Size
 import org.scalacheck.{Arbitrary, Gen}
+import shapeless.Nat
+import shapeless.ops.nat.ToInt
 
 /** Module that provides `Arbitrary` instances for collection predicates. */
 object collection extends CollectionInstances
 
 trait CollectionInstances {
 
-  implicit def listSizeArbitrary[T: Arbitrary, F[_, _]: RefType, P](
-      implicit arb: Arbitrary[Int Refined P]
-  ): Arbitrary[F[List[T], Size[P]]] =
-    arbitraryRefType[F, List[T], Size[P]](
+  implicit def listSizeArbitrary[T: Arbitrary, F[_, _]: RefType, P[_], N <: Nat](
+      implicit arb: Arbitrary[Int Refined P[N]],
+      tn: ToInt[N]): Arbitrary[F[List[T], Size[P[N]]]] =
+    arbitraryRefType[F, List[T], Size[P[N]]](
       for {
         numElems <- arb.arbitrary
-        elems <- Gen.listOfN(Math.min(numElems.value, 999), Arbitrary.arbitrary[T])
+        elems <- Gen.listOfN(Math.min(numElems.value, tn() + 999), Arbitrary.arbitrary[T])
       } yield elems
     )
 }

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
@@ -1,0 +1,23 @@
+package eu.timepit.refined.scalacheck
+
+import eu.timepit.refined.api.RefType
+import eu.timepit.refined.collection.MaxSize
+import org.scalacheck.{Arbitrary, Gen}
+import shapeless.Nat
+import shapeless.ops.nat.ToInt
+
+/** Module that provides `Arbitrary` instances for collection predicates. */
+object collection extends CollectionInstances
+
+trait CollectionInstances {
+
+  implicit def listMaxSizeArbitraryNat[T: Arbitrary, F[_, _]: RefType, N <: Nat](
+      implicit tn: ToInt[N]
+  ): Arbitrary[F[List[T], MaxSize[N]]] =
+    arbitraryRefType[F, List[T], MaxSize[N]](
+      for {
+        numElems <- Gen.chooseNum(0, tn())
+        elems <- Gen.listOfN(numElems, Arbitrary.arbitrary[T])
+      } yield elems
+    )
+}

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
@@ -1,23 +1,21 @@
 package eu.timepit.refined.scalacheck
 
-import eu.timepit.refined.api.RefType
-import eu.timepit.refined.collection.MaxSize
+import eu.timepit.refined.api.{Refined, RefType}
+import eu.timepit.refined.collection.Size
 import org.scalacheck.{Arbitrary, Gen}
-import shapeless.Nat
-import shapeless.ops.nat.ToInt
 
 /** Module that provides `Arbitrary` instances for collection predicates. */
 object collection extends CollectionInstances
 
 trait CollectionInstances {
 
-  implicit def listMaxSizeArbitraryNat[T: Arbitrary, F[_, _]: RefType, N <: Nat](
-      implicit tn: ToInt[N]
-  ): Arbitrary[F[List[T], MaxSize[N]]] =
-    arbitraryRefType[F, List[T], MaxSize[N]](
+  implicit def listSizeArbitrary[T: Arbitrary, F[_, _]: RefType, P](
+      implicit arb: Arbitrary[Int Refined P]
+  ): Arbitrary[F[List[T], Size[P]]] =
+    arbitraryRefType[F, List[T], Size[P]](
       for {
-        numElems <- Gen.chooseNum(0, tn())
-        elems <- Gen.listOfN(numElems, Arbitrary.arbitrary[T])
+        numElems <- arb.arbitrary
+        elems <- Gen.listOfN(Math.min(numElems.value, 999), Arbitrary.arbitrary[T])
       } yield elems
     )
 }

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
@@ -3,21 +3,19 @@ package eu.timepit.refined.scalacheck
 import eu.timepit.refined.api.{Refined, RefType}
 import eu.timepit.refined.collection.Size
 import org.scalacheck.{Arbitrary, Gen}
-import shapeless.Nat
-import shapeless.ops.nat.ToInt
 
 /** Module that provides `Arbitrary` instances for collection predicates. */
 object collection extends CollectionInstances
 
 trait CollectionInstances {
 
-  implicit def listSizeArbitrary[T: Arbitrary, F[_, _]: RefType, P[_], N <: Nat](
-      implicit arb: Arbitrary[Int Refined P[N]],
-      tn: ToInt[N]): Arbitrary[F[List[T], Size[P[N]]]] =
-    arbitraryRefType[F, List[T], Size[P[N]]](
+  implicit def listSizeArbitrary[T: Arbitrary, F[_, _]: RefType, P](
+      implicit arb: Arbitrary[Int Refined P]
+  ): Arbitrary[F[List[T], Size[P]]] =
+    arbitraryRefType[F, List[T], Size[P]](
       for {
         numElems <- arb.arbitrary
-        elems <- Gen.listOfN(Math.min(numElems.value, tn() + 999), Arbitrary.arbitrary[T])
+        elems <- Gen.listOfN(numElems.value, Arbitrary.arbitrary[T])
       } yield elems
     )
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
@@ -1,13 +1,15 @@
 package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.MaxSize
+import eu.timepit.refined.collection.{MaxSize, MinSize}
+import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.collection._
 import org.scalacheck.Properties
 import shapeless.nat._
 
 class CollectionArbitrarySpec extends Properties("CollectionArbitrary") {
 
-  property("MaxSize.Nat") = checkArbitraryRefType[Refined, List[String], MaxSize[_10]]
+  property("MaxSize") = checkArbitraryRefType[Refined, List[String], MaxSize[_10]]
 
+  property("MinSize") = checkArbitraryRefType[Refined, List[String], MinSize[_10]]
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
@@ -1,7 +1,9 @@
 package eu.timepit.refined.scalacheck
 
+import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.{MaxSize, MinSize}
+import eu.timepit.refined.collection.{MaxSize, Size}
+import eu.timepit.refined.numeric.Interval
 import eu.timepit.refined.scalacheck.collection._
 import eu.timepit.refined.scalacheck.numeric._
 import org.scalacheck.Properties
@@ -9,7 +11,10 @@ import shapeless.nat._
 
 class CollectionArbitrarySpec extends Properties("CollectionArbitrary") {
 
-  property("MaxSize") = checkArbitraryRefType[Refined, List[String], MaxSize[_10]]
+  property("MaxSize.positive") = checkArbitraryRefType[Refined, List[String], MaxSize[W.`42`.T]]
 
-  property("MinSize") = checkArbitraryRefType[Refined, List[String], MinSize[_10]]
+  property("MaxSize.Nat") = checkArbitraryRefType[Refined, List[String], MaxSize[_13]]
+
+  property("Size.Interval.Closed") =
+    checkArbitraryRefType[Refined, List[String], Size[Interval.Closed[W.`23`.T, W.`42`.T]]]
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
@@ -2,8 +2,8 @@ package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.{MaxSize, MinSize}
-import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.collection._
+import eu.timepit.refined.scalacheck.numeric._
 import org.scalacheck.Properties
 import shapeless.nat._
 

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
@@ -1,0 +1,13 @@
+package eu.timepit.refined.scalacheck
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.MaxSize
+import eu.timepit.refined.scalacheck.collection._
+import org.scalacheck.Properties
+import shapeless.nat._
+
+class CollectionArbitrarySpec extends Properties("CollectionArbitrary") {
+
+  property("MaxSize.Nat") = checkArbitraryRefType[Refined, List[String], MaxSize[_10]]
+
+}


### PR DESCRIPTION
I thought I would get the ball rolling for collection arbitrary instances for ScalaCheck. I've added one instance for lists with a `MaxSize`, from here if the structure is OK I can add more as can other people.