### PR TITLE
Add scopt module

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ libraryDependencies ++= Seq(
   "eu.timepit" %% "refined-pureconfig" % "0.8.7", // optional, JVM-only
   "eu.timepit" %% "refined-scalacheck" % "0.8.7", // optional
   "eu.timepit" %% "refined-scalaz"     % "0.8.7", // optional
-  "eu.timepit" %% "refined-scodec"     % "0.8.7"  // optional
+  "eu.timepit" %% "refined-scodec"     % "0.8.7", // optional
+  "eu.timepit" %% "refined-scopt"      % "0.8.7"  // optional
 )
 ```
 
@@ -217,6 +218,8 @@ The project provides these optional extensions and library integrations:
   type class instances for refined types and support for `scalaz.@@`
 * `refined-scodec` allows binary decoding and encoding of refined types with
   [scodec](http://scodec.org/) and allows refining `scodec.bits.ByteVector`
+* `refined-scopt` allows to read command line options with refined types
+  using [scopt](https://github.com/scopt/scopt)
 
 ### External modules
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ val scalaCheckVersion = "1.13.5"
 val scalaXmlVersion = "1.0.6"
 val scalazVersion = "7.2.20"
 val scodecVersion = "1.10.3"
+val scoptVersion = "3.7.0"
 
 val macroParadise =
   "org.scalamacros" % "paradise" % macroParadiseVersion cross CrossVersion.patch
@@ -27,7 +28,7 @@ val scalaCheckDep =
   Def.setting("org.scalacheck" %%% "scalacheck" % scalaCheckVersion)
 
 val allSubprojects =
-  Seq("cats", "core", "eval", "jsonpath", "pureconfig", "scalacheck", "scalaz", "scodec")
+  Seq("cats", "core", "eval", "jsonpath", "pureconfig", "scalacheck", "scalaz", "scodec", "scopt")
 val allSubprojectsJVM = allSubprojects.map(_ + "JVM")
 val allSubprojectsJS = {
   val jvmOnlySubprojects = Seq("jsonpath", "pureconfig")
@@ -57,7 +58,9 @@ lazy val root = project
     scalazJVM,
     scalazJS,
     scodecJVM,
-    scodecJS
+    scodecJS,
+    scoptJVM,
+    scoptJS
   )
   .settings(commonSettings)
   .settings(noPublishSettings)
@@ -218,6 +221,22 @@ lazy val scodec = crossProject(JSPlatform, JVMPlatform)
 
 lazy val scodecJVM = scodec.jvm
 lazy val scodecJS = scodec.js
+
+lazy val scopt = crossProject(JSPlatform, JVMPlatform)
+  .configureCross(moduleCrossConfig("scopt"))
+  .dependsOn(core % "compile->compile;test->test")
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.scopt" %%% "scopt" % scoptVersion,
+      compilerPlugin(macroParadise % Test)
+    )
+  )
+  // This is required by scopt (which uses the 'os' modue), although I'm not 100% sure what other potential side effects
+  // this might have.
+  .jsSettings(scalaJSModuleKind := ModuleKind.CommonJSModule)
+
+lazy val scoptJVM = scopt.jvm
+lazy val scoptJS = scopt.js
 
 /// settings
 

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -3,6 +3,7 @@ latestVersion in ThisBuild := "0.8.7"
 latestVersionInSeries in ThisBuild := Some("0.8.7")
 
 unreleasedModules in ThisBuild := Set(
+  "refined-scopt"
   // Example:
   // "refined-eval"
 )

--- a/modules/scopt/shared/src/main/scala/eu/timepit/refined/scopt/package.scala
+++ b/modules/scopt/shared/src/main/scala/eu/timepit/refined/scopt/package.scala
@@ -1,0 +1,14 @@
+package eu.timepit.refined
+
+import _root_.scopt.Read
+import eu.timepit.refined.api.{RefType, Validate}
+
+package object scopt {
+
+  implicit def refTypeRead[F[_, _], T, P](
+      implicit read: Read[T],
+      refType: RefType[F],
+      validate: Validate[T, P]
+  ): Read[F[T, P]] = read.map(t => refType.refine[P].unsafeFrom(t))
+
+}

--- a/modules/scopt/shared/src/test/scala/eu/timepit/refined/scopt/RefTypeRedSpec.scala
+++ b/modules/scopt/shared/src/test/scala/eu/timepit/refined/scopt/RefTypeRedSpec.scala
@@ -1,0 +1,38 @@
+package eu.timepit.refined.scopt
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric.Positive
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+import scopt._
+
+class RefTypeReadSpec extends Properties("RefTypeRead") {
+
+  type PosInt = Int Refined Positive
+  case class Config(foo: PosInt)
+
+  val parser = new OptionParser[Config]("tests") {
+    opt[PosInt]('f', "foo")
+      .action((x, c) => c.copy(foo = x))
+      .text("foo is a positive integer property")
+  }
+
+  property("load success") = secure {
+    loadConfigWithValue("10") =?
+      Some(Config(10))
+  }
+
+  property("load failure (predicate)") = secure {
+    loadConfigWithValue("0") =?
+      None
+  }
+
+  property("load failure (wrong type)") = secure {
+    loadConfigWithValue("abc") =?
+      None
+  }
+
+  def loadConfigWithValue(value: String): Option[Config] =
+    parser.parse(Array("-f", value), Config(1))
+}


### PR DESCRIPTION
Fixes #326.

I've done my best to respect the project's conventions, but feel free to point out anything I might have missed.

A couple of points:
* I had to enable scalaJS modules for `scoptJS`. I'm not entirely sure what ramifications this might have
* I cannot seem to run `validate` locally, as I'm getting some test failures. This is in the `core` module however and I'm assuming, for the moment, that it's to do with my local setup rather than with anything I might have done.
