### PR TITLE
Added subtypes for Inference

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Inference.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Inference.scala
@@ -4,27 +4,67 @@ package eu.timepit.refined.api
  * Evidence that states if the conclusion `C` can be inferred from the
  * premise `P` or not.
  *
- * This type class is used to implement refinement subtyping. If a valid
- * `Inference[P, C]` exists, the type `F[T, P]` is considered a subtype
- * of `F[T, C]`.
+ * This trait is used to implement refinement subtyping.
  */
-case class Inference[P, C](isValid: Boolean, show: String) {
-
-  final def adapt[P2, C2](adaptedShow: String): Inference[P2, C2] =
-    copy(show = adaptedShow.format(show))
-
+sealed trait Inference[P, C] {
+  def isValid: Boolean
+  def show: String
+  def adapt[P2, C2](adaptedShow: String): Inference[P2, C2]
   final def notValid: Boolean =
     !isValid
 }
 
 object Inference {
 
+  /**
+   * This type class is used to implement refinement subtyping. If a
+   * `ValidInference[P, C]` exists, the type `F[T, P]` is considered a subtype
+   * of `F[T, C]`.
+   */
+  final case class InferAlways[P, C](show: String) extends Inference[P, C] {
+
+    override def adapt[P2, C2](adaptedShow: String): Inference[P2, C2] =
+      copy(show = adaptedShow.format(show))
+
+    override def isValid: Boolean = true
+  }
+
+  /**
+   * This type class is used to implement refinement subtyping. If an inference
+   * `InferWhen[P, C]` with an ''isValid'' field set to true exists,
+   * the type `F[T, P]` is considered a subtype of `F[T, C]`.
+   */
+  final case class InferWhen[P, C](isValid: Boolean, show: String) extends Inference[P, C] {
+
+    override def adapt[P2, C2](adaptedShow: String): Inference[P2, C2] =
+      copy(show = adaptedShow.format(show))
+  }
+
+  /**
+   * This type class is used to define an invalid refinement subtyping. If an inference
+   * `ValidNever[P, C]`  exists, the type `F[T, P]` is NOT considered a subtype of `F[T, C]`.
+   */
+  final case class InferNever[P, C](show: String) extends Inference[P, C] {
+
+    override def adapt[P2, C2](adaptedShow: String): Inference[P2, C2] =
+      copy(show = adaptedShow.format(show))
+
+    override def isValid: Boolean = false
+
+  }
+
   type ==>[P, C] = Inference[P, C]
+
+  type ===>[P, C] = InferAlways[P, C]
 
   def apply[P, C](implicit i: Inference[P, C]): Inference[P, C] = i
 
-  def alwaysValid[P, C](show: String): Inference[P, C] =
-    Inference(isValid = true, show)
+  def apply[P, C](isValid: Boolean, show: String): Inference[P, C] =
+    if (isValid) InferAlways(show)
+    else InferNever(show)
+
+  def alwaysValid[P, C](show: String): InferAlways[P, C] =
+    InferAlways(show)
 
   def combine[P1, P2, P, C1, C2, C](i1: Inference[P1, C1],
                                     i2: Inference[P2, C2],

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
@@ -1,6 +1,6 @@
 package eu.timepit.refined
 
-import eu.timepit.refined.api.{RefType, Refined, Validate}
+import eu.timepit.refined.api.{Refined, RefType, Validate}
 import eu.timepit.refined.api.Inference.{===>, ==>}
 import eu.timepit.refined.macros.{InferMacro, RefineMacro}
 import shapeless.tag.@@

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined
 
-import eu.timepit.refined.api.{Refined, RefType, Validate}
-import eu.timepit.refined.api.Inference.==>
+import eu.timepit.refined.api.{RefType, Refined, Validate}
+import eu.timepit.refined.api.Inference.{===>, ==>}
 import eu.timepit.refined.macros.{InferMacro, RefineMacro}
 import shapeless.tag.@@
 
@@ -9,28 +9,16 @@ import shapeless.tag.@@
  * Module that provides automatic refinements and automatic conversions
  * between refined types (refinement subtyping) at compile-time.
  */
-object auto {
+object auto extends LowPriorityInferece {
 
   /**
    * Implicitly converts (at compile-time) a value of type `F[T, A]` to
-   * `F[T, B]` if there is a valid inference `A ==> B`. If the
-   * inference is invalid, compilation fails.
-   *
-   * Example: {{{
-   * scala> import eu.timepit.refined.api.Refined
-   *      | import eu.timepit.refined.auto.{ autoInfer, autoRefineV }
-   *      | import eu.timepit.refined.numeric.Greater
-   *
-   * scala> val x: Int Refined Greater[W.`5`.T] = 100
-   *
-   * scala> x: Int Refined Greater[W.`0`.T]
-   * res0: Int Refined Greater[W.`0`.T] = 100
-   * }}}
+   * `F[T, B]` if there is an implicit inference `A ===> B`.
    */
-  implicit def autoInfer[F[_, _], T, A, B](ta: F[T, A])(
+  implicit def autoInferOnAlways[F[_, _], T, A, B](ta: F[T, A])(
       implicit rt: RefType[F],
-      ir: A ==> B
-  ): F[T, B] = macro InferMacro.impl[F, T, A, B]
+      ir: A ===> B
+  ): F[T, B] = macro InferMacro.implAlways[F, T, A, B]
 
   /**
    * Implicitly unwraps the `T` from a value of type `F[T, P]` using the
@@ -79,4 +67,29 @@ object auto {
       implicit rt: RefType[@@],
       v: Validate[T, P]
   ): T @@ P = macro RefineMacro.impl[@@, T, P]
+}
+
+trait LowPriorityInferece {
+
+  /**
+   * Implicitly converts (at compile-time) a value of type `F[T, A]` to
+   * `F[T, B]` if there is a valid inference `A ==> B`. If the
+   * inference is invalid, compilation fails.
+   * This implicit has lower priority than the ''autoInferOnAlways''.
+   *
+   * Example: {{{
+   * scala> import eu.timepit.refined.api.Refined
+   *      | import eu.timepit.refined.auto.{ autoInfer, autoRefineV }
+   *      | import eu.timepit.refined.numeric.Greater
+   *
+   * scala> val x: Int Refined Greater[W.`5`.T] = 100
+   *
+   * scala> x: Int Refined Greater[W.`0`.T]
+   * res0: Int Refined Greater[W.`0`.T] = 100
+   * }}}
+   */
+  implicit def autoInfer[F[_, _], T, A, B](ta: F[T, A])(
+      implicit rt: RefType[F],
+      ir: A ==> B
+  ): F[T, B] = macro InferMacro.impl[F, T, A, B]
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/boolean.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined
 
 import eu.timepit.refined.api._
-import eu.timepit.refined.api.Inference.==>
+import eu.timepit.refined.api.Inference.{===>, ==>}
 import eu.timepit.refined.boolean._
 import eu.timepit.refined.internal.Resources
 import shapeless.{::, HList, HNil}
@@ -258,7 +258,7 @@ object boolean extends BooleanInference0 {
 
 private[refined] trait BooleanInference0 extends BooleanInference1 {
 
-  implicit def minimalTautology[A]: A ==> A =
+  implicit def minimalTautology[A]: A ===> A =
     Inference.alwaysValid("minimalTautology")
 
   implicit def doubleNegationElimination[A, B](implicit p1: A ==> B): Not[Not[A]] ==> B =
@@ -267,40 +267,40 @@ private[refined] trait BooleanInference0 extends BooleanInference1 {
   implicit def doubleNegationIntroduction[A, B](implicit p1: A ==> B): A ==> Not[Not[B]] =
     p1.adapt("doubleNegationIntroduction(%s)")
 
-  implicit def conjunctionAssociativity[A, B, C]: ((A And B) And C) ==> (A And (B And C)) =
+  implicit def conjunctionAssociativity[A, B, C]: ((A And B) And C) ===> (A And (B And C)) =
     Inference.alwaysValid("conjunctionAssociativity")
 
-  implicit def conjunctionCommutativity[A, B]: (A And B) ==> (B And A) =
+  implicit def conjunctionCommutativity[A, B]: (A And B) ===> (B And A) =
     Inference.alwaysValid("conjunctionCommutativity")
 
   implicit def conjunctionEliminationR[A, B, C](implicit p1: B ==> C): (A And B) ==> C =
     p1.adapt("conjunctionEliminationR(%s)")
 
-  implicit def disjunctionAssociativity[A, B, C]: ((A Or B) Or C) ==> (A Or (B Or C)) =
+  implicit def disjunctionAssociativity[A, B, C]: ((A Or B) Or C) ===> (A Or (B Or C)) =
     Inference.alwaysValid("disjunctionAssociativity")
 
-  implicit def disjunctionCommutativity[A, B]: (A Or B) ==> (B Or A) =
+  implicit def disjunctionCommutativity[A, B]: (A Or B) ===> (B Or A) =
     Inference.alwaysValid("disjunctionCommutativity")
 
-  implicit def disjunctionIntroductionL[A, B]: A ==> (A Or B) =
+  implicit def disjunctionIntroductionL[A, B]: A ===> (A Or B) =
     Inference.alwaysValid("disjunctionIntroductionL")
 
-  implicit def disjunctionIntroductionR[A, B]: B ==> (A Or B) =
+  implicit def disjunctionIntroductionR[A, B]: B ===> (A Or B) =
     Inference.alwaysValid("disjunctionIntroductionR")
 
-  implicit def deMorgansLaw1[A, B]: Not[A And B] ==> (Not[A] Or Not[B]) =
+  implicit def deMorgansLaw1[A, B]: Not[A And B] ===> (Not[A] Or Not[B]) =
     Inference.alwaysValid("deMorgansLaw1")
 
-  implicit def deMorgansLaw2[A, B]: Not[A Or B] ==> (Not[A] And Not[B]) =
+  implicit def deMorgansLaw2[A, B]: Not[A Or B] ===> (Not[A] And Not[B]) =
     Inference.alwaysValid("deMorgansLaw2")
 
-  implicit def xorCommutativity[A, B]: (A Xor B) ==> (B Xor A) =
+  implicit def xorCommutativity[A, B]: (A Xor B) ===> (B Xor A) =
     Inference.alwaysValid("xorCommutativity")
 
-  implicit def nandCommutativity[A, B]: (A Nand B) ==> (B Nand A) =
+  implicit def nandCommutativity[A, B]: (A Nand B) ===> (B Nand A) =
     Inference.alwaysValid("nandCommutativity")
 
-  implicit def norCommutativity[A, B]: (A Nor B) ==> (B Nor A) =
+  implicit def norCommutativity[A, B]: (A Nor B) ===> (B Nor A) =
     Inference.alwaysValid("norCommutativity")
 }
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined
 
 import eu.timepit.refined.api.{Inference, Result, Validate}
-import eu.timepit.refined.api.Inference.==>
+import eu.timepit.refined.api.Inference.{===>, ==>}
 import eu.timepit.refined.boolean.Not
 import eu.timepit.refined.collection._
 import eu.timepit.refined.generic.Equal
@@ -314,25 +314,25 @@ private[refined] trait CollectionInference {
   implicit def existsInference[A, B](implicit p1: A ==> B): Exists[A] ==> Exists[B] =
     p1.adapt("existsInference(%s)")
 
-  implicit def existsNonEmptyInference[P]: Exists[P] ==> NonEmpty =
+  implicit def existsNonEmptyInference[P]: Exists[P] ===> NonEmpty =
     Inference.alwaysValid("existsNonEmptyInference")
 
   implicit def headInference[A, B](implicit p1: A ==> B): Head[A] ==> Head[B] =
     p1.adapt("headInference(%s)")
 
-  implicit def headExistsInference[P]: Head[P] ==> Exists[P] =
+  implicit def headExistsInference[P]: Head[P] ===> Exists[P] =
     Inference.alwaysValid("headExistsInference")
 
   implicit def indexInference[N, A, B](implicit p1: A ==> B): Index[N, A] ==> Index[N, B] =
     p1.adapt("indexInference(%s)")
 
-  implicit def indexExistsInference[N, P]: Index[N, P] ==> Exists[P] =
+  implicit def indexExistsInference[N, P]: Index[N, P] ===> Exists[P] =
     Inference.alwaysValid("indexExistsInference")
 
   implicit def lastInference[A, B](implicit p1: A ==> B): Last[A] ==> Last[B] =
     p1.adapt("lastInference(%s)")
 
-  implicit def lastExistsInference[P]: Last[P] ==> Exists[P] =
+  implicit def lastExistsInference[P]: Last[P] ===> Exists[P] =
     Inference.alwaysValid("lastExistsInference")
 
   implicit def sizeInference[A, B](implicit p1: A ==> B): Size[A] ==> Size[B] =

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
@@ -1,5 +1,6 @@
 package eu.timepit.refined.macros
 
+import eu.timepit.refined.api.Inference.===>
 import eu.timepit.refined.api.Inference.==>
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.internal.Resources
@@ -22,4 +23,11 @@ class InferMacro(val c: blackbox.Context) extends MacroUtils {
 
     refTypeInstance(rt).unsafeRewrapM(c)(ta)
   }
+
+  def implAlways[F[_, _], T: c.WeakTypeTag, A: c.WeakTypeTag, B: c.WeakTypeTag](
+      ta: c.Expr[F[T, A]])(
+      rt: c.Expr[RefType[F]],
+      ir: c.Expr[A ===> B]
+  ): c.Expr[F[T, B]] =
+    refTypeInstance(rt).unsafeRewrapM(c)(ta)
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/ImplicitInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/ImplicitInferenceSpec.scala
@@ -1,0 +1,33 @@
+package eu.timepit.refined
+
+import eu.timepit.refined.api._
+import eu.timepit.refined.api.Inference.===>
+import eu.timepit.refined.api.RefType.applyRef
+import eu.timepit.refined.auto._
+import eu.timepit.refined.boolean._
+import eu.timepit.refined.numeric.{Greater, Positive}
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class ImplicitInferenceSpec extends Properties("ImplicitInference") {
+
+  private def convert[B, A]: PartiallyApplied[B, A] = new PartiallyApplied[B, A]
+
+  private class PartiallyApplied[B, A] {
+    final def apply[T](value: T)(implicit I: B ===> A,
+                                 V: Validate[T, B]): Either[String, T Refined A] = {
+      val res = applyRef[T Refined B](value)
+      applyRef[T Refined B](value).map(v => v: T Refined A)
+    }
+  }
+
+  property("Convert with AlwaysValid Inference") = secure {
+    type RefT1 = Positive And Greater[W.`10`.T]
+    type RefT1Inverse = Greater[W.`10`.T] And Positive
+    type T1 = Int Refined RefT1
+    type T1Inverse = Int Refined RefT1Inverse
+    val expected: T1Inverse = 12
+
+    convert[RefT1, RefT1Inverse](12) == Right(expected)
+  }
+}


### PR DESCRIPTION
Fixes #454

Here I've tried to have `Inference` as a trait and added 3 subtypes

- InferAlways
- InferWhen
- InferNever

With that I can directly have a safe conversion whenever an `InferAlways` is present.

Probably you still want to change something on the implicit inferences on `boolean.scala` and `collections.scala`...