### PR TITLE
Arbitrary instances for Vector/String with Size[P]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -364,7 +364,9 @@ lazy val moduleJvmSettings = Def.settings(
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "eu.timepit.refined.NumericInference.greaterEqualInference"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "eu.timepit.refined.NumericInference.lessEqualInference")
+        "eu.timepit.refined.NumericInference.lessEqualInference"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "eu.timepit.refined.scalacheck.StringInstances.stringSizeArbitrary")
     )
   }
 )

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
@@ -29,7 +29,7 @@ trait CollectionInstances {
   //
   // scala> buildableSizeArbitrary[Refined, Set[Boolean], Boolean, Equal[3]].arbitrary.sample
   // res0: Option[Refined[Set[Boolean], Size[Equal[3]]]] = Some(Set(false, true))
-  private def buildableSizeArbitrary[F[_, _]: RefType, C, T, P](
+  private[scalacheck] def buildableSizeArbitrary[F[_, _]: RefType, C, T, P](
       implicit
       arbT: Arbitrary[T],
       arbN: Arbitrary[Int Refined P],

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
@@ -3,19 +3,40 @@ package eu.timepit.refined.scalacheck
 import eu.timepit.refined.api.{Refined, RefType}
 import eu.timepit.refined.collection.Size
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.util.Buildable
 
 /** Module that provides `Arbitrary` instances for collection predicates. */
 object collection extends CollectionInstances
 
 trait CollectionInstances {
 
-  implicit def listSizeArbitrary[T: Arbitrary, F[_, _]: RefType, P](
-      implicit arb: Arbitrary[Int Refined P]
+  implicit def listSizeArbitrary[F[_, _]: RefType, T, P](
+      implicit
+      arbT: Arbitrary[T],
+      arbSize: Arbitrary[Int Refined P]
   ): Arbitrary[F[List[T], Size[P]]] =
-    arbitraryRefType[F, List[T], Size[P]](
-      for {
-        numElems <- arb.arbitrary
-        elems <- Gen.listOfN(numElems.value, Arbitrary.arbitrary[T])
-      } yield elems
-    )
+    buildableSizeArbitrary[F, List[T], T, P]
+
+  implicit def vectorSizeArbitrary[F[_, _]: RefType, T, P](
+      implicit
+      arbT: Arbitrary[T],
+      arbSize: Arbitrary[Int Refined P]
+  ): Arbitrary[F[Vector[T], Size[P]]] =
+    buildableSizeArbitrary[F, Vector[T], T, P]
+
+  // This is private and not implicit because it could produce invalid
+  // values for some collections:
+  //
+  // scala> buildableSizeArbitrary[Refined, Set[Boolean], Boolean, Equal[3]].arbitrary.sample
+  // res0: Option[Refined[Set[Boolean], Size[Equal[3]]]] = Some(Set(false, true))
+  private def buildableSizeArbitrary[F[_, _]: RefType, C, T, P](
+      implicit
+      arbT: Arbitrary[T],
+      arbN: Arbitrary[Int Refined P],
+      ev1: Buildable[T, C],
+      ev2: C => Traversable[T]
+  ): Arbitrary[F[C, Size[P]]] =
+    arbitraryRefType(arbN.arbitrary.flatMap { n =>
+      Gen.buildableOfN[C, T](n.value, arbT.arbitrary)
+    })
 }

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/collection.scala
@@ -10,17 +10,13 @@ object collection extends CollectionInstances
 
 trait CollectionInstances {
 
-  implicit def listSizeArbitrary[F[_, _]: RefType, T, P](
-      implicit
-      arbT: Arbitrary[T],
-      arbSize: Arbitrary[Int Refined P]
+  implicit def listSizeArbitrary[F[_, _]: RefType, T: Arbitrary, P](
+      implicit arbSize: Arbitrary[Int Refined P]
   ): Arbitrary[F[List[T], Size[P]]] =
     buildableSizeArbitrary[F, List[T], T, P]
 
-  implicit def vectorSizeArbitrary[F[_, _]: RefType, T, P](
-      implicit
-      arbT: Arbitrary[T],
-      arbSize: Arbitrary[Int Refined P]
+  implicit def vectorSizeArbitrary[F[_, _]: RefType, T: Arbitrary, P](
+      implicit arbSize: Arbitrary[Int Refined P]
   ): Arbitrary[F[Vector[T], Size[P]]] =
     buildableSizeArbitrary[F, Vector[T], T, P]
 
@@ -32,11 +28,11 @@ trait CollectionInstances {
   private[scalacheck] def buildableSizeArbitrary[F[_, _]: RefType, C, T, P](
       implicit
       arbT: Arbitrary[T],
-      arbN: Arbitrary[Int Refined P],
+      arbSize: Arbitrary[Int Refined P],
       ev1: Buildable[T, C],
       ev2: C => Traversable[T]
   ): Arbitrary[F[C, Size[P]]] =
-    arbitraryRefType(arbN.arbitrary.flatMap { n =>
+    arbitraryRefType(arbSize.arbitrary.flatMap { n =>
       Gen.buildableOfN[C, T](n.value, arbT.arbitrary)
     })
 }

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -1,6 +1,6 @@
 package eu.timepit.refined.scalacheck
 
-import eu.timepit.refined.api.{RefType, Refined}
+import eu.timepit.refined.api.{Refined, RefType}
 import eu.timepit.refined.collection.{NonEmpty, Size}
 import eu.timepit.refined.string.{EndsWith, StartsWith}
 import org.scalacheck.Arbitrary

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined.scalacheck
 
-import eu.timepit.refined.api.RefType
-import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.api.{RefType, Refined}
+import eu.timepit.refined.collection.{NonEmpty, Size}
 import eu.timepit.refined.string.{EndsWith, StartsWith}
 import org.scalacheck.Arbitrary
 import shapeless.Witness
@@ -35,4 +35,11 @@ trait StringInstances {
     } yield s + c.toString
     arbitraryRefType(nonEmptyStringGen)
   }
+
+  implicit def stringSizeArbitrary[F[_, _]: RefType, P](
+      implicit
+      arbChar: Arbitrary[Char],
+      arbSize: Arbitrary[Int Refined P]
+  ): Arbitrary[F[String, Size[P]]] =
+    collection.buildableSizeArbitrary[F, String, Char, P]
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
@@ -11,7 +11,11 @@ import shapeless.nat._
 
 class CollectionArbitrarySpec extends Properties("CollectionArbitrary") {
 
-  property("MaxSize.positive") = checkArbitraryRefType[Refined, List[String], MaxSize[W.`42`.T]]
+  property("List with MaxSize[42]") =
+    checkArbitraryRefType[Refined, List[String], MaxSize[W.`42`.T]]
+
+  property("Vector with MaxSize[23]") =
+    checkArbitraryRefType[Refined, Vector[Int], MaxSize[W.`23`.T]]
 
   property("MaxSize.Nat") = checkArbitraryRefType[Refined, List[String], MaxSize[_13]]
 

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -2,7 +2,9 @@ package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.{MaxSize, NonEmpty}
+import eu.timepit.refined.collection.{MaxSize, NonEmpty, Size}
+import eu.timepit.refined.generic.Equal
+import eu.timepit.refined.scalacheck.generic._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.string._
@@ -17,4 +19,6 @@ class StringArbitrarySpec extends Properties("StringArbitrary") {
   property("NonEmpty") = checkArbitraryRefType[Refined, String, NonEmpty]
 
   property("MaxSize") = checkArbitraryRefType[Refined, String, MaxSize[W.`16`.T]]
+
+  property("Size[Equal]") = checkArbitraryRefType[Refined, String, Size[Equal[W.`8`.T]]]
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -2,7 +2,8 @@ package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.collection.{MaxSize, NonEmpty}
+import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.string._
 import org.scalacheck.Properties
@@ -14,4 +15,6 @@ class StringArbitrarySpec extends Properties("StringArbitrary") {
   property("StartsWith") = checkArbitraryRefType[Refined, String, StartsWith[W.`"abc"`.T]]
 
   property("NonEmpty") = checkArbitraryRefType[Refined, String, NonEmpty]
+
+  property("MaxSize") = checkArbitraryRefType[Refined, String, MaxSize[W.`16`.T]]
 }


### PR DESCRIPTION
This builds up on the work @matthedude did in #455 to provide `Arbitrary` instances for `Vector` and `String` with any `Size[P]` predicate.

The instance for `String` will become handy if we add something like `FiniteString[N]` (#437) to the library.