### PR TITLE
Try stabilizing 2.10 build by running tests in a forked JVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,8 +150,7 @@ lazy val docs = project
   .settings(
     scalacOptions in Tut := scalacOptions.value.diff(Seq("-Ywarn-unused:imports")),
     tutSourceDirectory := baseDirectory.value / "src",
-    tutTargetDirectory := baseDirectory.value,
-    fork in (Tut, run) := true
+    tutTargetDirectory := baseDirectory.value
   )
 
 lazy val eval = crossProject(JSPlatform, JVMPlatform)
@@ -302,6 +301,7 @@ lazy val moduleCrossSettings = Def.settings(
 )
 
 lazy val moduleJvmSettings = Def.settings(
+  fork in Test := true,
   mimaPreviousArtifacts := {
     val hasPredecessor = !unreleasedModules.value.contains(moduleName.value)
     latestVersionInSeries.value match {


### PR DESCRIPTION
This reverts one part of #462 (running tut in a forked JVM)
which should not be necessary anymore. I hope running the
tests in a forked JVM should be enough to fix the OOME
that #462 tried to fix.