### PR TITLE
Add FiniteString[N]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -381,7 +381,9 @@ lazy val moduleJvmSettings = Def.settings(
         "eu.timepit.refined.scalacheck.NumericInstances.*"),
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("eu.timepit.refined.types.*"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "eu.timepit.refined.api.RefinedType.dealias")
+        "eu.timepit.refined.api.RefinedType.dealias"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "eu.timepit.refined.scalacheck.RefTypeInstances.checkArbitraryRefinedType")
     )
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -379,7 +379,9 @@ lazy val moduleJvmSettings = Def.settings(
         "eu.timepit.refined.scalacheck.NumericInstances.*"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "eu.timepit.refined.scalacheck.NumericInstances.*"),
-      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("eu.timepit.refined.types.*")
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("eu.timepit.refined.types.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "eu.timepit.refined.api.RefinedType.dealias")
     )
   }
 )

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
@@ -18,6 +18,8 @@ trait RefinedType[FTP] extends Serializable {
 
   val alias: F[T, P] =:= FTP
 
+  val dealias: FTP =:= F[T, P]
+
   final def refine(t: T): Either[String, FTP] = {
     val res = validate.validate(t)
     if (res.isPassed) Right(alias(refType.unsafeWrap(t)))
@@ -55,5 +57,6 @@ object RefinedType {
       override val refType: RefType[F] = rt
       override val validate: Validate[T, P] = v
       override val alias: F[T, P] =:= F0[T0, P0] = implicitly
+      override val dealias: F0[T0, P0] =:= F[T, P] = implicitly
     }
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -1,12 +1,24 @@
 package eu.timepit.refined.types
 
 import eu.timepit.refined.W
-import eu.timepit.refined.api.{Refined, RefinedTypeOps}
-import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.api.{Refined, RefinedType, RefinedTypeOps}
+import eu.timepit.refined.collection.{MaxSize, NonEmpty}
 import eu.timepit.refined.string.MatchesRegex
 
 /** Module for `String` refined types. */
 object string {
+
+  /** A `String` with length less than or equal to `N`. */
+  type FiniteString[N] = String Refined MaxSize[N]
+
+  object FiniteString {
+
+    /** Creates a companion object for `FiniteString[N]` with a fixed `N`. */
+    def apply[N](
+        implicit rt: RefinedType.AuxT[FiniteString[N], String]
+    ): RefinedTypeOps[FiniteString[N], String] =
+      new RefinedTypeOps[FiniteString[N], String]
+  }
 
   /** A `String` that is not empty. */
   type NonEmptyString = String Refined NonEmpty
@@ -20,6 +32,9 @@ object string {
 }
 
 trait StringTypes {
+  final type FiniteString[N] = string.FiniteString[N]
+  final val FiniteString = string.FiniteString
+
   final type NonEmptyString = string.NonEmptyString
   final val NonEmptyString = string.NonEmptyString
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -4,6 +4,7 @@ import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedType, RefinedTypeOps}
 import eu.timepit.refined.collection.{MaxSize, NonEmpty}
 import eu.timepit.refined.string.MatchesRegex
+import shapeless.Witness
 
 /** Module for `String` refined types. */
 object string {
@@ -12,12 +13,30 @@ object string {
   type FiniteString[N] = String Refined MaxSize[N]
 
   object FiniteString {
+    class FiniteStringOps[N <: Int](
+        implicit
+        rt: RefinedType.AuxT[FiniteString[N], String],
+        wn: Witness.Aux[N]
+    ) extends RefinedTypeOps[FiniteString[N], String] {
 
-    /** Creates a companion object for `FiniteString[N]` with a fixed `N`. */
-    def apply[N](
-        implicit rt: RefinedType.AuxT[FiniteString[N], String]
-    ): RefinedTypeOps[FiniteString[N], String] =
-      new RefinedTypeOps[FiniteString[N], String]
+      /** The maximum length of a `FiniteString[N]`. */
+      final val maxLength: N =
+        wn.value
+
+      /**
+       * Creates a `FiniteString[N]` from `t` by truncating it
+       * if it is longer than `N`.
+       */
+      def truncate(t: String): FiniteString[N] =
+        Refined.unsafeApply(t.substring(0, math.min(t.length, maxLength)))
+    }
+
+    /** Creates a "companion object" for `FiniteString[N]` with a fixed `N`. */
+    def apply[N <: Int](
+        implicit
+        rt: RefinedType.AuxT[FiniteString[N], String],
+        wn: Witness.Aux[N]
+    ): FiniteStringOps[N] = new FiniteStringOps[N]
   }
 
   /** A `String` that is not empty. */

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -10,7 +10,7 @@ class StringTypesSpec extends Properties("StringTypes") {
   final val FString3 = FiniteString[W.`3`.T]
 
   property("FString3.from(str)") = forAll { (str: String) =>
-    FString3.from(str).isRight ?= (str.length <= 3)
+    FString3.from(str).isRight ?= (str.length <= FString3.maxLength)
   }
 
   property("""FString3.from("")""") = secure {
@@ -27,6 +27,12 @@ class StringTypesSpec extends Properties("StringTypes") {
     val str = "abcd"
     FString3.from(str) ?= Left(
       "Predicate taking size(abcd) = 4 failed: Predicate (4 > 3) did not fail.")
+  }
+
+  property("""FString3.truncate(str)""") = forAll { (str: String) =>
+    val truncated = FString3.truncate(str)
+    truncated.value.length <= FString3.maxLength &&
+    (truncated.value ?= str.take(FString3.maxLength))
   }
 
   // Hashes for ""

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -8,6 +8,10 @@ import org.scalacheck.Properties
 class StringTypesSpec extends Properties("StringTypes") {
   final val FString3 = FiniteString[W.`3`.T]
 
+  property("FString3.from(str)") = forAll { (str: String) =>
+    FString3.from(str).isRight ?= (str.length <= 3)
+  }
+
   property("""FString3.from("")""") = secure {
     val str = ""
     FString3.from(str).right.map(_.value) ?= Right(str)

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -1,0 +1,26 @@
+package eu.timepit.refined.types
+
+import eu.timepit.refined.W
+import eu.timepit.refined.types.string.FiniteString
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class StringTypesSpec extends Properties("StringTypes") {
+  final val FString3 = FiniteString[W.`3`.T]
+
+  property("""FString3.from("")""") = secure {
+    val str = ""
+    FString3.from(str).right.map(_.value) ?= Right(str)
+  }
+
+  property("""FString3.from("abc")""") = secure {
+    val str = "abc"
+    FString3.from(str).right.map(_.value) ?= Right(str)
+  }
+
+  property("""FString3.from("abcd")""") = secure {
+    val str = "abcd"
+    FString3.from(str) ?= Left(
+      "Predicate taking size(abcd) = 4 failed: Predicate (4 > 3) did not fail.")
+  }
+}

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/reftype.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/reftype.scala
@@ -1,6 +1,6 @@
 package eu.timepit.refined.scalacheck
 
-import eu.timepit.refined.api.{RefType, Validate}
+import eu.timepit.refined.api.{RefinedType, RefType, Validate}
 import org.scalacheck.{Arbitrary, Cogen, Gen, Prop}
 
 object reftype extends RefTypeInstances
@@ -14,6 +14,9 @@ trait RefTypeInstances {
                                            rt: RefType[F],
                                            v: Validate[T, P]): Prop =
     Prop.forAll((tp: F[T, P]) => v.isValid(rt.unwrap(tp)))
+
+  def checkArbitraryRefinedType[FTP](implicit arb: Arbitrary[FTP], rt: RefinedType[FTP]): Prop =
+    Prop.forAll((tp: FTP) => rt.validate.isValid(rt.refType.unwrap(rt.dealias(tp))))
 
   implicit def refTypeCogen[F[_, _], T: Cogen, P](implicit rt: RefType[F]): Cogen[F[T, P]] =
     Cogen[T].contramap(tp => rt.unwrap(tp))

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -8,6 +8,7 @@ import eu.timepit.refined.scalacheck.generic._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.string._
+import eu.timepit.refined.types.string.FiniteString
 import org.scalacheck.Properties
 
 class StringArbitrarySpec extends Properties("StringArbitrary") {
@@ -19,6 +20,8 @@ class StringArbitrarySpec extends Properties("StringArbitrary") {
   property("NonEmpty") = checkArbitraryRefType[Refined, String, NonEmpty]
 
   property("MaxSize") = checkArbitraryRefType[Refined, String, MaxSize[W.`16`.T]]
+
+  property("FiniteString[N]") = checkArbitraryRefinedType[FiniteString[W.`10`.T]]
 
   property("Size[Equal]") = checkArbitraryRefType[Refined, String, Size[Equal[W.`8`.T]]]
 }

--- a/notes/0.9.0.markdown
+++ b/notes/0.9.0.markdown
@@ -24,6 +24,8 @@
   ([#457][#457] by [@nrinaudo][@nrinaudo])
 * Add `HexString`, `MD5`, `SHA1`, `SHA224`, `SHA256`, `SHA384`,
   and `SHA512` types ([#453][#453] by [@NeQuissimus][@NeQuissimus])
+* Add `FiniteString[N]` type for `String`s with length less than or
+  equal to `N`. ([#437][#437], [#479][#479])
 
 ### Changes
 
@@ -71,6 +73,7 @@
 [#433]: https://github.com/fthomas/refined/pull/433
 [#434]: https://github.com/fthomas/refined/pull/434
 [#435]: https://github.com/fthomas/refined/pull/435
+[#437]: https://github.com/fthomas/refined/issues/437
 [#438]: https://github.com/fthomas/refined/pull/438
 [#447]: https://github.com/fthomas/refined/pull/447
 [#449]: https://github.com/fthomas/refined/pull/449
@@ -86,6 +89,7 @@
 [#471]: https://github.com/fthomas/refined/pull/471
 [#475]: https://github.com/fthomas/refined/pull/475
 [#478]: https://github.com/fthomas/refined/pull/478
+[#479]: https://github.com/fthomas/refined/pull/479
 [scala-dev/#446]: https://github.com/scala/scala-dev/issues/446
 
 [@densh]: https://github.com/densh


### PR DESCRIPTION
A `String` with length less than or equal to `N`.

This adds the type alias `FiniteString[N]` and a function to create
"companion objects" for `FiniteString`s of the given max length.

closes #437