### PR TITLE
Use checkArbitraryRefinedType

### DIFF
--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/AnyArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/AnyArbitrarySpec.scala
@@ -9,7 +9,8 @@ import org.scalacheck.Properties
 
 class AnyArbitrarySpec extends Properties("AnyArbitrary") {
 
-  property("MatchesRegex") = checkArbitraryRefType[Refined, String, MatchesRegex[W.`".{2,}"`.T]]
+  property("MatchesRegex[S]") =
+    checkArbitraryRefinedType[String Refined MatchesRegex[W.`".{2,}"`.T]]
 
-  property("NonEmpty") = checkArbitraryRefType[Refined, List[Int], NonEmpty]
+  property("NonEmpty") = checkArbitraryRefinedType[List[Int] Refined NonEmpty]
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CharArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CharArbitrarySpec.scala
@@ -8,24 +8,25 @@ import eu.timepit.refined.numeric.Interval
 import eu.timepit.refined.scalacheck.boolean._
 import eu.timepit.refined.scalacheck.char._
 import eu.timepit.refined.scalacheck.numeric._
+import eu.timepit.refined.types.char.{LowerCaseChar, UpperCaseChar}
 import org.scalacheck.Properties
 
-class CharArbitrarySpec extends Properties("CharArbitrarySpec") {
+class CharArbitrarySpec extends Properties("CharArbitrary") {
 
-  property("Digit") = checkArbitraryRefType[Refined, Char, Digit]
+  property("Digit") = checkArbitraryRefinedType[Char Refined Digit]
 
-  property("Letter") = checkArbitraryRefType[Refined, Char, Letter]
+  property("Letter") = checkArbitraryRefinedType[Char Refined Letter]
 
-  property("LowerCase") = checkArbitraryRefType[Refined, Char, LowerCase]
+  property("LowerCaseChar") = checkArbitraryRefinedType[LowerCaseChar]
 
-  property("UpperCase") = checkArbitraryRefType[Refined, Char, UpperCase]
+  property("UpperCaseChar") = checkArbitraryRefinedType[UpperCaseChar]
 
-  property("Whitespace") = checkArbitraryRefType[Refined, Char, Whitespace]
+  property("Whitespace") = checkArbitraryRefinedType[Char Refined Whitespace]
 
-  property("LetterOrDigit") = checkArbitraryRefType[Refined, Char, LetterOrDigit]
+  property("LetterOrDigit") = checkArbitraryRefinedType[Char Refined LetterOrDigit]
 
   property("HexDigit") = {
     type HexDigit = Digit Or Interval.Closed[W.`'a'`.T, W.`'f'`.T]
-    checkArbitraryRefType[Refined, Char, HexDigit]
+    checkArbitraryRefinedType[Char Refined HexDigit]
   }
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
@@ -11,14 +11,15 @@ import shapeless.nat._
 
 class CollectionArbitrarySpec extends Properties("CollectionArbitrary") {
 
-  property("List with MaxSize[42]") =
-    checkArbitraryRefType[Refined, List[String], MaxSize[W.`42`.T]]
+  property("List[String] Refined MaxSize[42]") =
+    checkArbitraryRefinedType[List[String] Refined MaxSize[W.`42`.T]]
 
-  property("Vector with MaxSize[23]") =
-    checkArbitraryRefType[Refined, Vector[Int], MaxSize[W.`23`.T]]
+  property("List[String] Refined MaxSize[_13]") =
+    checkArbitraryRefinedType[List[String] Refined MaxSize[_13]]
 
-  property("MaxSize.Nat") = checkArbitraryRefType[Refined, List[String], MaxSize[_13]]
+  property("Vector[Int] Refined MaxSize[23]") =
+    checkArbitraryRefinedType[Vector[Int] Refined MaxSize[W.`23`.T]]
 
-  property("Size.Interval.Closed") =
-    checkArbitraryRefType[Refined, List[String], Size[Interval.Closed[W.`23`.T, W.`42`.T]]]
+  property("Size[Interval.Closed[23, 42]]") =
+    checkArbitraryRefinedType[List[Char] Refined Size[Interval.Closed[W.`23`.T, W.`42`.T]]]
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/GenericArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/GenericArbitrarySpec.scala
@@ -8,5 +8,5 @@ import org.scalacheck.Properties
 
 class GenericArbitrarySpec extends Properties("GenericArbitrary") {
 
-  property("Equal") = checkArbitraryRefType[Refined, Int, Equal[W.`100`.T]]
+  property("Equal[100]") = checkArbitraryRefinedType[Int Refined Equal[W.`100`.T]]
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -2,9 +2,9 @@ package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.scalacheck.numeric._
+import eu.timepit.refined.types.numeric.{NegDouble, NonNegInt, NonNegLong, PosFloat}
 import eu.timepit.refined.types.time.Minute
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
@@ -12,69 +12,63 @@ import shapeless.nat._
 
 class NumericArbitrarySpec extends Properties("NumericArbitrary") {
 
-  property("Less.positive") = checkArbitraryRefType[Refined, Int, Less[W.`100`.T]]
+  property("Less[10]") = checkArbitraryRefinedType[Int Refined Less[W.`10`.T]]
 
-  property("Less.negative") = checkArbitraryRefType[Refined, Int, Less[W.`-100`.T]]
+  property("Less[-10]") = checkArbitraryRefinedType[Int Refined Less[W.`-10`.T]]
 
-  property("Less.Nat") = checkArbitraryRefType[Refined, Long, Less[_10]]
+  property("Less[_10]") = checkArbitraryRefinedType[Long Refined Less[_10]]
 
-  property("LessEqual.positive") = checkArbitraryRefType[Refined, Int, LessEqual[W.`42`.T]]
+  property("LessEqual[42]") = checkArbitraryRefinedType[Int Refined LessEqual[W.`42`.T]]
 
-  property("LessEqual.negative") = checkArbitraryRefType[Refined, Int, LessEqual[W.`-42`.T]]
+  property("LessEqual[-42]") = checkArbitraryRefinedType[Int Refined LessEqual[W.`-42`.T]]
 
-  property("LessEqual.Nat") = checkArbitraryRefType[Refined, Long, LessEqual[_10]]
+  property("LessEqual[_10]") = checkArbitraryRefinedType[Long Refined LessEqual[_10]]
 
-  property("Greater.positive") = checkArbitraryRefType[Refined, Int, Greater[W.`100`.T]]
+  property("Greater[10]") = checkArbitraryRefinedType[Int Refined Greater[W.`10`.T]]
 
-  property("Greater.negative") = checkArbitraryRefType[Refined, Int, Greater[W.`-100`.T]]
+  property("Greater[-10]") = checkArbitraryRefinedType[Int Refined Greater[W.`-10`.T]]
 
-  property("Greater.Nat") = checkArbitraryRefType[Refined, Long, Greater[_10]]
+  property("Greater[_10]") = checkArbitraryRefinedType[Long Refined Greater[_10]]
 
-  property("GreaterEqual.positive") =
-    checkArbitraryRefType[Refined, Int, GreaterEqual[W.`123456`.T]]
+  property("GreaterEqual[123]") = checkArbitraryRefinedType[Int Refined GreaterEqual[W.`123`.T]]
 
-  property("GreaterEqual.negative") =
-    checkArbitraryRefType[Refined, Int, GreaterEqual[W.`-123456`.T]]
+  property("GreaterEqual[123]") = checkArbitraryRefinedType[Int Refined GreaterEqual[W.`-123`.T]]
 
-  property("GreaterEqual.Nat") = checkArbitraryRefType[Refined, Int, GreaterEqual[_10]]
+  property("GreaterEqual[_10]") = checkArbitraryRefinedType[Int Refined GreaterEqual[_10]]
 
-  property("Positive") = checkArbitraryRefType[Refined, Float, Positive]
+  property("PosFloat") = checkArbitraryRefinedType[PosFloat]
 
-  property("NonPositive") = checkArbitraryRefType[Refined, Short, NonPositive]
+  property("NonPositive") = checkArbitraryRefinedType[Short Refined NonPositive]
 
-  property("Negative") = checkArbitraryRefType[Refined, Double, Negative]
+  property("NegDouble") = checkArbitraryRefinedType[NegDouble]
 
-  property("NonNegative") = checkArbitraryRefType[Refined, Long, NonNegative]
+  property("NonNegLong") = checkArbitraryRefinedType[NonNegLong]
 
-  property("Interval.Open") =
-    checkArbitraryRefType[Refined, Int, Interval.Open[W.`-23`.T, W.`42`.T]]
+  property("Interval.Open[-23, 42]") =
+    checkArbitraryRefinedType[Int Refined Interval.Open[W.`-23`.T, W.`42`.T]]
 
-  property("Interval.Open (0.554, 0.556)") =
-    checkArbitraryRefType[Refined, Double, Interval.Open[W.`0.554`.T, W.`0.556`.T]]
+  property("Interval.Open[0.554, 0.556]") =
+    checkArbitraryRefinedType[Double Refined Interval.Open[W.`0.554`.T, W.`0.556`.T]]
 
-  property("Interval.OpenClosed") =
-    checkArbitraryRefType[Refined, Double, Interval.OpenClosed[W.`2.71828`.T, W.`3.14159`.T]]
+  property("Interval.OpenClosed[2.71828, 3.14159]") =
+    checkArbitraryRefinedType[Double Refined Interval.OpenClosed[W.`2.71828`.T, W.`3.14159`.T]]
 
-  property("Interval.OpenClosed (0.54, 0.56]") =
-    checkArbitraryRefType[Refined, Float, Interval.OpenClosed[W.`0.54F`.T, W.`0.56F`.T]]
+  property("Interval.OpenClosed[0.54, 0.56]") =
+    checkArbitraryRefinedType[Float Refined Interval.OpenClosed[W.`0.54F`.T, W.`0.56F`.T]]
 
-  property("Interval.ClosedOpen") =
-    checkArbitraryRefType[Refined, Double, Interval.ClosedOpen[W.`-2.71828`.T, W.`3.14159`.T]]
+  property("Interval.ClosedOpen[-2.71828, 3.14159]") =
+    checkArbitraryRefinedType[Double Refined Interval.ClosedOpen[W.`-2.71828`.T, W.`3.14159`.T]]
 
-  property("Interval.ClosedOpen [0.4, 0.6)") =
-    checkArbitraryRefType[Refined, Float, Interval.ClosedOpen[W.`0.4F`.T, W.`0.6F`.T]]
+  property("Interval.ClosedOpen[0.4, 0.6]") =
+    checkArbitraryRefinedType[Float Refined Interval.ClosedOpen[W.`0.4F`.T, W.`0.6F`.T]]
 
-  property("Interval.Closed") =
-    checkArbitraryRefType[Refined, Int, Interval.Closed[W.`23`.T, W.`42`.T]]
+  property("Interval.Closed[23, 42]") =
+    checkArbitraryRefinedType[Int Refined Interval.Closed[W.`23`.T, W.`42`.T]]
 
-  property("Interval.alias") = forAll { m: Minute =>
-    m >= 0 && m <= 59
-  }
+  property("Minute") = checkArbitraryRefinedType[Minute]
 
-  property("chooseRefinedNum") = {
-    type Natural = Int Refined NonNegative
-    forAll(chooseRefinedNum(23: Natural, 42: Natural)) { n =>
-      n >= 23 && n <= 42
+  property("chooseRefinedNum") =
+    forAll(chooseRefinedNum(NonNegInt.unsafeFrom(23), NonNegInt.unsafeFrom(42))) { n =>
+      n.value >= 23 && n.value <= 42
     }
-  }
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/PackageSpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/PackageSpec.scala
@@ -1,14 +1,18 @@
 package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.TestUtils.wellTyped
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.all._
 import org.scalacheck.{Cogen, Properties}
 
 class PackageSpec extends Properties("Package") {
 
-  property("Cogen instances") = wellTyped {
-    val x0 = Cogen[LowerCaseChar]
-    val x1 = Cogen[NonEmptyString]
-    val x2 = Cogen[PosInt]
-  }
+  property("Cogen[Short Refined Positive]") = wellTyped(Cogen[Short Refined Positive])
+
+  property("Cogen[LowerCaseChar]") = wellTyped(Cogen[LowerCaseChar])
+
+  property("Cogen[NonEmptyString]") = wellTyped(Cogen[NonEmptyString])
+
+  property("Cogen[PosInt]") = wellTyped(Cogen[PosInt])
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -2,26 +2,26 @@ package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.{MaxSize, NonEmpty, Size}
+import eu.timepit.refined.collection.{MaxSize, Size}
 import eu.timepit.refined.generic.Equal
 import eu.timepit.refined.scalacheck.generic._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.string._
-import eu.timepit.refined.types.string.FiniteString
+import eu.timepit.refined.types.string.{FiniteString, NonEmptyString}
 import org.scalacheck.Properties
 
 class StringArbitrarySpec extends Properties("StringArbitrary") {
 
-  property("EndsWith") = checkArbitraryRefType[Refined, String, EndsWith[W.`"abc"`.T]]
+  property("EndsWith[S]") = checkArbitraryRefinedType[String Refined EndsWith[W.`"abc"`.T]]
 
-  property("StartsWith") = checkArbitraryRefType[Refined, String, StartsWith[W.`"abc"`.T]]
+  property("StartsWith[S]") = checkArbitraryRefinedType[String Refined StartsWith[W.`"abc"`.T]]
 
-  property("NonEmpty") = checkArbitraryRefType[Refined, String, NonEmpty]
+  property("NonEmptyString") = checkArbitraryRefinedType[NonEmptyString]
 
-  property("MaxSize") = checkArbitraryRefType[Refined, String, MaxSize[W.`16`.T]]
+  property("MaxSize[16]") = checkArbitraryRefinedType[String Refined MaxSize[W.`16`.T]]
 
-  property("FiniteString[N]") = checkArbitraryRefinedType[FiniteString[W.`10`.T]]
+  property("FiniteString[10]") = checkArbitraryRefinedType[FiniteString[W.`10`.T]]
 
-  property("Size[Equal]") = checkArbitraryRefType[Refined, String, Size[Equal[W.`8`.T]]]
+  property("Size[Equal[8]]") = checkArbitraryRefinedType[String Refined Size[Equal[W.`8`.T]]]
 }


### PR DESCRIPTION
... instead of `checkArbitraryRefType`. The former can also check
`Arbitrary` instances of type aliases.