### PR TITLE
Replace Bounded with Min & Max

### DIFF
--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -1,9 +1,8 @@
 package eu.timepit.refined.scalacheck
 
-import eu.timepit.refined.api.{RefType, Validate}
+import eu.timepit.refined.api.{Max, Min, RefType, Validate}
 import eu.timepit.refined.internal.Adjacent
 import eu.timepit.refined.numeric._
-import eu.timepit.refined.scalacheck.util.Bounded
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Gen.Choose
 import shapeless.{Nat, Witness}
@@ -33,56 +32,56 @@ trait NumericInstances {
   ///
 
   implicit def lessArbitraryWit[F[_, _]: RefType, T: Numeric: Choose: Adjacent, N <: T](
-      implicit bounded: Bounded[T],
+      implicit min: Min[T],
       wn: Witness.Aux[N]
   ): Arbitrary[F[T, Less[N]]] =
-    rangeClosedOpenArbitrary(bounded.minValue, wn.value)
+    rangeClosedOpenArbitrary(min.min, wn.value)
 
   implicit def lessArbitraryNat[F[_, _]: RefType, T: Choose: Adjacent, N <: Nat](
-      implicit bounded: Bounded[T],
+      implicit min: Min[T],
       nt: Numeric[T],
       tn: ToInt[N]
   ): Arbitrary[F[T, Less[N]]] =
-    rangeClosedOpenArbitrary(bounded.minValue, nt.fromInt(tn()))
+    rangeClosedOpenArbitrary(min.min, nt.fromInt(tn()))
 
   implicit def lessEqualArbitraryWit[F[_, _]: RefType, T: Numeric: Choose, N <: T](
-      implicit bounded: Bounded[T],
+      implicit min: Min[T],
       wn: Witness.Aux[N]
   ): Arbitrary[F[T, LessEqual[N]]] =
-    rangeClosedArbitrary(bounded.minValue, wn.value)
+    rangeClosedArbitrary(min.min, wn.value)
 
   implicit def lessEqualArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat](
-      implicit bounded: Bounded[T],
+      implicit min: Min[T],
       nt: Numeric[T],
       tn: ToInt[N]
   ): Arbitrary[F[T, LessEqual[N]]] =
-    rangeClosedArbitrary(bounded.minValue, nt.fromInt(tn()))
+    rangeClosedArbitrary(min.min, nt.fromInt(tn()))
 
   implicit def greaterArbitraryWit[F[_, _]: RefType, T: Numeric: Choose: Adjacent, N <: T](
-      implicit bounded: Bounded[T],
+      implicit max: Max[T],
       wn: Witness.Aux[N]
   ): Arbitrary[F[T, Greater[N]]] =
-    rangeOpenClosedArbitrary(wn.value, bounded.maxValue)
+    rangeOpenClosedArbitrary(wn.value, max.max)
 
   implicit def greaterArbitraryNat[F[_, _]: RefType, T: Choose: Adjacent, N <: Nat](
-      implicit bounded: Bounded[T],
+      implicit max: Max[T],
       nt: Numeric[T],
       tn: ToInt[N]
   ): Arbitrary[F[T, Greater[N]]] =
-    rangeOpenClosedArbitrary(nt.fromInt(tn()), bounded.maxValue)
+    rangeOpenClosedArbitrary(nt.fromInt(tn()), max.max)
 
   implicit def greaterEqualArbitraryWit[F[_, _]: RefType, T: Numeric: Choose, N <: T](
-      implicit bounded: Bounded[T],
+      implicit max: Max[T],
       wn: Witness.Aux[N]
   ): Arbitrary[F[T, GreaterEqual[N]]] =
-    rangeClosedArbitrary(wn.value, bounded.maxValue)
+    rangeClosedArbitrary(wn.value, max.max)
 
   implicit def greaterEqualArbitraryNat[F[_, _]: RefType, T: Choose, N <: Nat](
-      implicit bounded: Bounded[T],
+      implicit max: Max[T],
       nt: Numeric[T],
       tn: ToInt[N]
   ): Arbitrary[F[T, GreaterEqual[N]]] =
-    rangeClosedArbitrary(nt.fromInt(tn()), bounded.maxValue)
+    rangeClosedArbitrary(nt.fromInt(tn()), max.max)
 
   ///
 

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Adjacent.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Adjacent.scala
@@ -15,6 +15,9 @@ trait Adjacent[T] {
     nextDown(t).getOrElse(t)
 }
 
+@deprecated(
+  "This type class has been replaced by eu.timepit.refined.internal.Adjacent in the core module",
+  "0.9.0")
 object Adjacent {
   def apply[T](implicit a: Adjacent[T]): Adjacent[T] = a
 

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Bounded.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/util/Bounded.scala
@@ -1,15 +1,12 @@
 package eu.timepit.refined.scalacheck.util
 
-/**
- * Auxiliary type class that provides the upper and lower bounds of a
- * type `T`. This is needed for the `Arbitrary` instances of numeric
- * refined types.
- */
+@deprecated("Bounded has been replaced by eu.timepit.refined.api.Min/Max", "0.9.0")
 trait Bounded[T] {
   def minValue: T
   def maxValue: T
 }
 
+@deprecated("Bounded has been replaced by eu.timepit.refined.api.Min/Max", "0.9.0")
 object Bounded {
   def apply[T](implicit b: Bounded[T]): Bounded[T] = b
 

--- a/notes/0.9.0.markdown
+++ b/notes/0.9.0.markdown
@@ -23,7 +23,7 @@
   with [scopt](https://github.com/scopt/scopt).
   ([#457][#457] by [@nrinaudo][@nrinaudo])
 * Add `HexString`, `MD5`, `SHA1`, `SHA224`, `SHA256`, `SHA384`,
-  and `SHA512` types ([#453][#453] by [@NeQuissimus][@NeQuissimus])
+  and `SHA512` types. ([#453][#453] by [@NeQuissimus][@NeQuissimus])
 * Add `FiniteString[N]` type for `String`s with length less than or
   equal to `N`. ([#437][#437], [#479][#479])
 
@@ -37,8 +37,6 @@
   [scala-dev/#446][scala-dev/#446]. ([#438][#438])
 * Update documentation to solve "exception during macro expansion" errors.
   ([#451][#451] by [@umbreak][@umbreak])
-
-### Bug fixes
 
 ### Deprecations and removals
 
@@ -54,6 +52,8 @@
   `Refined#value`. ([#426][#426])
 * Deprecate `scalacheck.util.Adjacent` in favor of `internal.Adjacent`
   in the core module. ([#475][#475])
+* Deprecate `scalacheck.util.Bounded` in favor of `api.{Min, Max}`
+  in the core module. ([#482][#482])
 
 ### Updates and build
 
@@ -90,13 +90,14 @@
 [#475]: https://github.com/fthomas/refined/pull/475
 [#478]: https://github.com/fthomas/refined/pull/478
 [#479]: https://github.com/fthomas/refined/pull/479
+[#482]: https://github.com/fthomas/refined/pull/482
 [scala-dev/#446]: https://github.com/scala/scala-dev/issues/446
 
 [@densh]: https://github.com/densh
 [@fommil]: https://github.com/fommil
 [@fthomas]: https://github.com/fthomas
 [@matthedude]: https://github.com/matthedude
+[@NeQuissimus]: https://github.com/NeQuissimus
 [@nrinaudo]: https://github.com/nrinaudo
 [@umbreak]: https://github.com/umbreak
 [@zainab-ali]: https://github.com/zainab-ali
-[@NeQuissimus]: https://github.com/NeQuissimus


### PR DESCRIPTION
This replaces `Bounded` in the scalacheck module with `Min` and `Max`
from the core module. This is similar to #393 but just modifies the
implicit parameters of the current instances.