### PR TITLE
Arbitrary instances for NonEmpty Lists and Vectors

### DIFF
--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
@@ -8,3 +8,4 @@ object all
     with RefTypeInstances
     with StringInstances
     with CollectionInstances
+    with CollectionInstancesBinCompat1

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -28,13 +28,8 @@ trait StringInstances {
 
   implicit def nonEmptyStringArbitrary[F[_, _]](
       implicit rt: RefType[F]
-  ): Arbitrary[F[String, NonEmpty]] = {
-    val nonEmptyStringGen = for {
-      s <- Arbitrary.arbString.arbitrary
-      c <- Arbitrary.arbChar.arbitrary
-    } yield s + c.toString
-    arbitraryRefType(nonEmptyStringGen)
-  }
+  ): Arbitrary[F[String, NonEmpty]] =
+    collection.buildableNonEmptyArbitrary[F, String, Char]
 
   implicit def stringSizeArbitrary[F[_, _]: RefType, P](
       implicit

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/CollectionArbitrarySpec.scala
@@ -2,7 +2,7 @@ package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.{MaxSize, Size}
+import eu.timepit.refined.collection.{MaxSize, NonEmpty, Size}
 import eu.timepit.refined.numeric.Interval
 import eu.timepit.refined.scalacheck.collection._
 import eu.timepit.refined.scalacheck.numeric._
@@ -17,8 +17,13 @@ class CollectionArbitrarySpec extends Properties("CollectionArbitrary") {
   property("List[String] Refined MaxSize[_13]") =
     checkArbitraryRefinedType[List[String] Refined MaxSize[_13]]
 
+  property("List[Int] Refined NonEmpty") = checkArbitraryRefinedType[List[Int] Refined NonEmpty]
+
   property("Vector[Int] Refined MaxSize[23]") =
     checkArbitraryRefinedType[Vector[Int] Refined MaxSize[W.`23`.T]]
+
+  property("Vector[Double] Refined NonEmpty") =
+    checkArbitraryRefinedType[Vector[Double] Refined NonEmpty]
 
   property("Size[Interval.Closed[23, 42]]") =
     checkArbitraryRefinedType[List[Char] Refined Size[Interval.Closed[W.`23`.T, W.`42`.T]]]


### PR DESCRIPTION
The instances are defined in `CollectionInstancesBinCompat1` so that this change is binary compatible with 0.9.0.