### PR TITLE
Add a TrimmedString.trim method

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -43,8 +43,16 @@ object string {
 
   object NonEmptyString extends RefinedTypeOps[NonEmptyString, String]
 
-  /** A `String` that contains no leading or trailing whitespace. */
-  type TrimmedString = String Refined MatchesRegex[W.`"""^(?!\\s).*(?<!\\s)"""`.T]
+  // scalastyle:off no.whitespace.after.left.bracket
+  /**
+   * A `String` that contains no leading or trailing whitespace.
+   *
+   * Note that a line separator (`\u2028') is not considered whitespace for the
+   * purposes of trimming.
+   */
+  type TrimmedString = String Refined MatchesRegex[
+    W.`"""^(?![\\x{0000}-\\x{0020}])(?s:.*)(?<![\\x{0000}-\\x{0020}])"""`.T]
+  // scalastyle:on no.whitespace.after.left.bracket
 
   object TrimmedString extends RefinedTypeOps[TrimmedString, String] {
 
@@ -57,15 +65,6 @@ object string {
      *
      * scala> TrimmedString.trim(" \n a b c ")
      * res0: TrimmedString = a b c
-     *
-     * Note that there are some strings can inhabit `TrimmedString` but will
-     * still be trimmed when passed into this method:
-     *
-     * scala> TrimmedString("\u0000a")
-     * res1: TrimmedString = \u000a
-     *
-     * scala> TrimmedString.trim("\u0000a")
-     * res2: TrimmedString = a
      * }}}
      */
     def trim(s: String): TrimmedString = Refined.unsafeApply(s.trim)

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -46,7 +46,30 @@ object string {
   /** A `String` that contains no leading or trailing whitespace. */
   type TrimmedString = String Refined MatchesRegex[W.`"""^(?!\\s).*(?<!\\s)"""`.T]
 
-  object TrimmedString extends RefinedTypeOps[TrimmedString, String]
+  object TrimmedString extends RefinedTypeOps[TrimmedString, String] {
+
+    /**
+     * Trim a string into a TrimmedString by removing leading and trailing
+     * whitespace.
+     *
+     * Example: {{{
+     * scala> import eu.timepit.refined.types.string._
+     *
+     * scala> TrimmedString.trim(" \n a b c ")
+     * res0: TrimmedString = a b c
+     *
+     * Note that there are some strings can inhabit `TrimmedString` but will
+     * still be trimmed when passed into this method:
+     *
+     * scala> TrimmedString("\u0000a")
+     * res1: TrimmedString = \u000a
+     *
+     * scala> TrimmedString.trim("\u0000a")
+     * res2: TrimmedString = a
+     * }}}
+     */
+    def trim(s: String): TrimmedString = Refined.unsafeApply(s.trim)
+  }
 
   /** A `String` representing a hexadecimal number */
   type HexStringSpec = MatchesRegex[W.`"""^(([0-9a-f]+)|([0-9A-F]+))$"""`.T]

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -35,6 +35,11 @@ class StringTypesSpec extends Properties("StringTypes") {
     (truncated.value ?= str.take(FString3.maxLength))
   }
 
+  property("""TrimmedString.trim(str)""") = forAll { (str: String) =>
+    val trimmed = TrimmedString.trim(str)
+    TrimmedString.from(trimmed.value) ?= Right(trimmed)
+  }
+
   // Hashes for ""
   object EmptyString {
     val md5 = "d41d8cd98f00b204e9800998ecf8427e"

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -35,6 +35,10 @@ class StringTypesSpec extends Properties("StringTypes") {
     (truncated.value ?= str.take(FString3.maxLength))
   }
 
+  property("""TrimmedString.from(str)""") = forAll { (str: String) =>
+    TrimmedString.from(str).isRight ?= (TrimmedString.trim(str).value == str)
+  }
+
   property("""TrimmedString.trim(str)""") = forAll { (str: String) =>
     val trimmed = TrimmedString.trim(str)
     TrimmedString.from(trimmed.value) ?= Right(trimmed)


### PR DESCRIPTION
This is somewhat similar to `FiniteStringOps.truncate` in that it's
guaranteed to turn any `String` into a `TrimmedString`.

There are some funny characters that get removed by `String.trim` but
don't match on `\s` in regular expressions. I've added an example to
demonstrate that these characters can lead to a `String` being "trimmed"
a bit more than would technically be necessary to match the
`TrimmedString` regex.