### PR TITLE
Experiment: replace Witness with proper literal types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ notifications:
     on_start: false
 matrix:
   include:
-  - scala: 2.10.7
-  - scala: 2.11.12 # Remember to update this in build.sbt, too.
-    sudo: required
-    before_install:
-    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
-    script:
-    - sbt ++$TRAVIS_SCALA_VERSION compileNative validateJVM &&
-      sbt ++$TRAVIS_SCALA_VERSION validateJS
+  #- scala: 2.10.7
+  #- scala: 2.11.12 # Remember to update this in build.sbt, too.
+  #  sudo: required
+  #  before_install:
+  #  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
+  #  script:
+  #  - sbt ++$TRAVIS_SCALA_VERSION compileNative validateJVM &&
+  #    sbt ++$TRAVIS_SCALA_VERSION validateJS
   - scala: 2.13.0-M3 # Remember to update this in build.sbt, too.
     script:
-    - sbt ++$TRAVIS_SCALA_VERSION coreJVM/compile
-  - scala: 2.12.4
+    - sbt ++$TRAVIS_SCALA_VERSION coreJVM/test
+  #- scala: 2.12.4

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
@@ -21,10 +21,10 @@ object auto {
    *      | import eu.timepit.refined.auto.{ autoInfer, autoRefineV }
    *      | import eu.timepit.refined.numeric.Greater
    *
-   * scala> val x: Int Refined Greater[W.`5`.T] = 100
+   * scala> val x: Int Refined Greater[5] = 100
    *
-   * scala> x: Int Refined Greater[W.`0`.T]
-   * res0: Int Refined Greater[W.`0`.T] = 100
+   * scala> x: Int Refined Greater[0]
+   * res0: Int Refined Greater[0] = 100
    * }}}
    */
   implicit def autoInfer[F[_, _], T, A, B](ta: F[T, A])(

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
@@ -7,7 +7,6 @@ import eu.timepit.refined.collection._
 import eu.timepit.refined.generic.Equal
 import eu.timepit.refined.internal.Resources
 import eu.timepit.refined.numeric.{GreaterEqual, Interval}
-import shapeless.Witness
 import shapeless.nat._0
 
 /** Module for collection predicates. */
@@ -179,7 +178,7 @@ object collection extends CollectionInference {
     implicit def indexValidate[A, P, R, N <: Int, T](
         implicit v: Validate.Aux[A, P, R],
         ev: T => PartialFunction[Int, A],
-        wn: Witness.Aux[N]
+        wn: ValueOf[N]
     ): Validate.Aux[T, Index[N, P], Index[N, Option[v.Res]]] =
       new Validate[T, Index[N, P]] {
         override type R = Index[N, Option[v.Res]]

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/WitnessAs.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/WitnessAs.scala
@@ -12,11 +12,10 @@ import shapeless.ops.nat.ToInt
  * `shapeless.Nat`.
  *
  * Example: {{{
- * scala> import eu.timepit.refined.W
- *      | import shapeless.nat._5
+ * scala> import shapeless.nat._5
  *
- * scala> WitnessAs[W.`5`.T, Int]
- * res1: WitnessAs[W.`5`.T, Int] = WitnessAs(5,5)
+ * scala> WitnessAs[5, Int]
+ * res1: WitnessAs[5, Int] = WitnessAs(5,5)
  *
  * scala> WitnessAs[_5, Int]
  * res2: WitnessAs[_5, Int] = WitnessAs(Succ(),5)

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -24,8 +24,8 @@ import shapeless.ops.nat.ToInt
  * scala> refineMV[Greater[_5]](10)
  * res1: Int Refined Greater[_5] = 10
  *
- * scala> refineMV[Greater[W.`1.5`.T]](1.6)
- * res2: Double Refined Greater[W.`1.5`.T] = 1.6
+ * scala> refineMV[Greater[1.5]](1.6)
+ * res2: Double Refined Greater[1.5] = 1.6
  * }}}
  *
  * Note: `[[generic.Equal]]` can also be used for numeric types.

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/package.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/package.scala
@@ -7,29 +7,6 @@ import shapeless.tag.@@
 package object refined {
 
   /**
-   * Alias for `shapeless.Witness` that provides concise syntax for
-   * literal-based singleton types.
-   *
-   * Example: {{{
-   * scala> val d: W.`3.14`.T = 3.14
-   * d: Double(3.14) = 3.14
-   *
-   * scala> val s: W.`"abc"`.T = "abc"
-   * s: String("abc") = abc
-   * }}}
-   *
-   * See the [[https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#singleton-typed-literals shapeless wiki]]
-   * for more information about its support for singleton types.
-   *
-   * Note that if a future version of Scala implements
-   * [[http://docs.scala-lang.org/sips/42.type.html SIP-23]],
-   * `shapeless.Witness` won't be necessary anymore to express
-   * literal-based singleton types. It will then be possible to use
-   * literals directly in a position where a type is expected.
-   */
-  val W = shapeless.Witness
-
-  /**
    * Alias for `[[api.RefType.refine]][P]` with `[[api.Refined]]` as type
    * parameter for `[[api.RefType]]`.
    *

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -3,7 +3,6 @@ package eu.timepit.refined
 import eu.timepit.refined.api.{Inference, Validate}
 import eu.timepit.refined.api.Inference.==>
 import eu.timepit.refined.string._
-import shapeless.Witness
 
 /**
  * Module for `String` related predicates. Note that most of the predicates
@@ -62,7 +61,7 @@ object string extends StringInference {
 
   object EndsWith {
     implicit def endsWithValidate[S <: String](
-        implicit ws: Witness.Aux[S]): Validate.Plain[String, EndsWith[S]] =
+        implicit ws: ValueOf[S]): Validate.Plain[String, EndsWith[S]] =
       Validate.fromPredicate(
         _.endsWith(ws.value),
         t => s""""$t".endsWith("${ws.value}")""",
@@ -130,7 +129,7 @@ object string extends StringInference {
 
   object MatchesRegex {
     implicit def matchesRegexValidate[S <: String](
-        implicit ws: Witness.Aux[S]): Validate.Plain[String, MatchesRegex[S]] =
+        implicit ws: ValueOf[S]): Validate.Plain[String, MatchesRegex[S]] =
       Validate.fromPredicate(
         _.matches(ws.value),
         t => s""""$t".matches("${ws.value}")""",
@@ -145,7 +144,7 @@ object string extends StringInference {
 
   object StartsWith {
     implicit def startsWithValidate[S <: String](
-        implicit ws: Witness.Aux[S]): Validate.Plain[String, StartsWith[S]] =
+        implicit ws: ValueOf[S]): Validate.Plain[String, StartsWith[S]] =
       Validate.fromPredicate(
         _.startsWith(ws.value),
         t => s""""$t".startsWith("${ws.value}")""",
@@ -215,14 +214,14 @@ object string extends StringInference {
 private[refined] trait StringInference {
 
   implicit def endsWithInference[A <: String, B <: String](
-      implicit wa: Witness.Aux[A],
-      wb: Witness.Aux[B]
+      implicit wa: ValueOf[A],
+      wb: ValueOf[B]
   ): EndsWith[A] ==> EndsWith[B] =
     Inference(wa.value.endsWith(wb.value), s"endsWithInference(${wa.value}, ${wb.value})")
 
   implicit def startsWithInference[A <: String, B <: String](
-      implicit wa: Witness.Aux[A],
-      wb: Witness.Aux[B]
+      implicit wa: ValueOf[A],
+      wb: ValueOf[B]
   ): StartsWith[A] ==> StartsWith[B] =
     Inference(wa.value.startsWith(wb.value), s"startsWithInference(${wa.value}, ${wb.value})")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/digests.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/digests.scala
@@ -1,6 +1,5 @@
 package eu.timepit.refined.types
 
-import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.boolean.And
 import eu.timepit.refined.collection.Size
@@ -9,22 +8,22 @@ import eu.timepit.refined.types.string.HexStringSpec
 
 /** Module for type representing message digests. */
 object digests {
-  type MD5 = String Refined (HexStringSpec And Size[Equal[W.`32`.T]])
+  type MD5 = String Refined (HexStringSpec And Size[Equal[32]])
   object MD5 extends RefinedTypeOps[MD5, String]
 
-  type SHA1 = String Refined (HexStringSpec And Size[Equal[W.`40`.T]])
+  type SHA1 = String Refined (HexStringSpec And Size[Equal[40]])
   object SHA1 extends RefinedTypeOps[SHA1, String]
 
-  type SHA224 = String Refined (HexStringSpec And Size[Equal[W.`56`.T]])
+  type SHA224 = String Refined (HexStringSpec And Size[Equal[56]])
   object SHA224 extends RefinedTypeOps[SHA224, String]
 
-  type SHA256 = String Refined (HexStringSpec And Size[Equal[W.`64`.T]])
+  type SHA256 = String Refined (HexStringSpec And Size[Equal[64]])
   object SHA256 extends RefinedTypeOps[SHA256, String]
 
-  type SHA384 = String Refined (HexStringSpec And Size[Equal[W.`96`.T]])
+  type SHA384 = String Refined (HexStringSpec And Size[Equal[96]])
   object SHA384 extends RefinedTypeOps[SHA384, String]
 
-  type SHA512 = String Refined (HexStringSpec And Size[Equal[W.`128`.T]])
+  type SHA512 = String Refined (HexStringSpec And Size[Equal[128]])
   object SHA512 extends RefinedTypeOps[SHA512, String]
 }
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/net.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/net.scala
@@ -1,6 +1,5 @@
 package eu.timepit.refined.types
 
-import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.boolean.{And, Or}
 import eu.timepit.refined.numeric.Interval
@@ -10,27 +9,27 @@ import eu.timepit.refined.string.{IPv4, MatchesRegex, StartsWith}
 object net {
 
   /** An `Int` in the range from 0 to 65535 representing a port number. */
-  type PortNumber = Int Refined Interval.Closed[W.`0`.T, W.`65535`.T]
+  type PortNumber = Int Refined Interval.Closed[0, 65535]
 
   object PortNumber extends RefinedTypeOps[PortNumber, Int]
 
   /** An `Int` in the range from 0 to 1023 representing a port number. */
-  type SystemPortNumber = Int Refined Interval.Closed[W.`0`.T, W.`1023`.T]
+  type SystemPortNumber = Int Refined Interval.Closed[0, 1023]
 
   object SystemPortNumber extends RefinedTypeOps[SystemPortNumber, Int]
 
   /** An `Int` in the range from 1024 to 49151 representing a port number. */
-  type UserPortNumber = Int Refined Interval.Closed[W.`1024`.T, W.`49151`.T]
+  type UserPortNumber = Int Refined Interval.Closed[1024, 49151]
 
   object UserPortNumber extends RefinedTypeOps[UserPortNumber, Int]
 
   /** An `Int` in the range from 49152 to 65535 representing a port number. */
-  type DynamicPortNumber = Int Refined Interval.Closed[W.`49152`.T, W.`65535`.T]
+  type DynamicPortNumber = Int Refined Interval.Closed[49152, 65535]
 
   object DynamicPortNumber extends RefinedTypeOps[DynamicPortNumber, Int]
 
   /** An `Int` in the range from 1024 to 65535 representing a port number. */
-  type NonSystemPortNumber = Int Refined Interval.Closed[W.`1024`.T, W.`65535`.T]
+  type NonSystemPortNumber = Int Refined Interval.Closed[1024, 65535]
 
   object NonSystemPortNumber extends RefinedTypeOps[NonSystemPortNumber, Int]
 
@@ -73,34 +72,34 @@ object net {
   object PrivateNetworks {
 
     type Rfc1918ClassAPrivateSpec =
-      IPv4 And StartsWith[W.`"10."`.T]
+      IPv4 And StartsWith["10."]
 
     type Rfc1918ClassBPrivateSpec =
-      IPv4 And MatchesRegex[W.`"^172\\\\.(15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31).+"`.T]
+      IPv4 And MatchesRegex["^172\\.(15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31).+"]
 
     type Rfc1918ClassCPrivateSpec =
-      IPv4 And StartsWith[W.`"192.168."`.T]
+      IPv4 And StartsWith["192.168."]
 
     type Rfc1918PrivateSpec =
       Rfc1918ClassAPrivateSpec Or Rfc1918ClassBPrivateSpec Or Rfc1918ClassCPrivateSpec
 
     type Rfc5737Testnet1Spec =
-      IPv4 And StartsWith[W.`"192.0.2."`.T]
+      IPv4 And StartsWith["192.0.2."]
 
     type Rfc5737Testnet2Spec =
-      IPv4 And StartsWith[W.`"198.51.100."`.T]
+      IPv4 And StartsWith["198.51.100."]
 
     type Rfc5737Testnet3Spec =
-      IPv4 And StartsWith[W.`"203.0.113."`.T]
+      IPv4 And StartsWith["203.0.113."]
 
     type Rfc5737TestnetSpec =
       Rfc5737Testnet1Spec Or Rfc5737Testnet2Spec Or Rfc5737Testnet3Spec
 
     type Rfc3927LocalLinkSpec =
-      IPv4 And StartsWith[W.`"169.254."`.T]
+      IPv4 And StartsWith["169.254."]
 
     type Rfc2544BenchmarkSpec =
-      IPv4 And Or[StartsWith[W.`"198.18."`.T], StartsWith[W.`"198.19."`.T]]
+      IPv4 And Or[StartsWith["198.18."], StartsWith["198.19."]]
   }
 }
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -1,10 +1,8 @@
 package eu.timepit.refined.types
 
-import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedType, RefinedTypeOps}
 import eu.timepit.refined.collection.{MaxSize, NonEmpty}
 import eu.timepit.refined.string.MatchesRegex
-import shapeless.Witness
 
 /** Module for `String` refined types. */
 object string {
@@ -16,7 +14,7 @@ object string {
     class FiniteStringOps[N <: Int](
         implicit
         rt: RefinedType.AuxT[FiniteString[N], String],
-        wn: Witness.Aux[N]
+        wn: ValueOf[N]
     ) extends RefinedTypeOps[FiniteString[N], String] {
 
       /** The maximum length of a `FiniteString[N]`. */
@@ -27,11 +25,10 @@ object string {
        * if it is longer than `N`.
        *
        * Example: {{{
-       * scala> import eu.timepit.refined.W
-       *      | import eu.timepit.refined.types.string.FiniteString
+       * scala> import eu.timepit.refined.types.string.FiniteString
        *
-       * scala> FiniteString[W.`3`.T].truncate("abcde")
-       * res1: FiniteString[W.`3`.T] = abc
+       * scala> FiniteString[3].truncate("abcde")
+       * res1: FiniteString[3] = abc
        * }}}
        */
       def truncate(t: String): FiniteString[N] =
@@ -42,7 +39,7 @@ object string {
     def apply[N <: Int](
         implicit
         rt: RefinedType.AuxT[FiniteString[N], String],
-        wn: Witness.Aux[N]
+        wn: ValueOf[N]
     ): FiniteStringOps[N] = new FiniteStringOps[N]
   }
 
@@ -52,12 +49,12 @@ object string {
   object NonEmptyString extends RefinedTypeOps[NonEmptyString, String]
 
   /** A `String` that contains no leading or trailing whitespace. */
-  type TrimmedString = String Refined MatchesRegex[W.`"""^(?!\\s).*(?<!\\s)"""`.T]
+  type TrimmedString = String Refined MatchesRegex["""^(?!\\s).*(?<!\\s)"""]
 
   object TrimmedString extends RefinedTypeOps[TrimmedString, String]
 
   /** A `String` representing a hexadecimal number */
-  type HexStringSpec = MatchesRegex[W.`"""^(([0-9a-f]+)|([0-9A-F]+))$"""`.T]
+  type HexStringSpec = MatchesRegex["""^(([0-9a-f]+)|([0-9A-F]+))$"""]
   type HexString = String Refined HexStringSpec
   object HexString extends RefinedTypeOps[HexString, String]
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/time.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/time.scala
@@ -1,6 +1,5 @@
 package eu.timepit.refined.types
 
-import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.numeric.Interval
 
@@ -8,7 +7,7 @@ import eu.timepit.refined.numeric.Interval
 object time {
 
   /** An `Int` in the range from 1 to 12 representing the month-of-year. */
-  type Month = Int Refined Interval.Closed[W.`1`.T, W.`12`.T]
+  type Month = Int Refined Interval.Closed[1, 12]
 
   object Month extends RefinedTypeOps[Month, Int]
 
@@ -16,27 +15,27 @@ object time {
    * An `Int` in the range from 1 to 31 representing the day-of-month.
    * Note that the days from 29 to 31 are not valid for all months.
    */
-  type Day = Int Refined Interval.Closed[W.`1`.T, W.`31`.T]
+  type Day = Int Refined Interval.Closed[1, 31]
 
   object Day extends RefinedTypeOps[Day, Int]
 
   /** An `Int` in the range from 0 to 23 representing the hour-of-day. */
-  type Hour = Int Refined Interval.Closed[W.`0`.T, W.`23`.T]
+  type Hour = Int Refined Interval.Closed[0, 23]
 
   object Hour extends RefinedTypeOps[Hour, Int]
 
   /** An `Int` in the range from 0 to 59 representing the minute-of-hour. */
-  type Minute = Int Refined Interval.Closed[W.`0`.T, W.`59`.T]
+  type Minute = Int Refined Interval.Closed[0, 59]
 
   object Minute extends RefinedTypeOps[Minute, Int]
 
   /** An `Int` in the range from 0 to 59 representing the second-of-minute. */
-  type Second = Int Refined Interval.Closed[W.`0`.T, W.`59`.T]
+  type Second = Int Refined Interval.Closed[0, 59]
 
   object Second extends RefinedTypeOps[Second, Int]
 
   /** An `Int` in the range from 0 to 999 representing the millisecond-of-second. */
-  type Millis = Int Refined Interval.Closed[W.`0`.T, W.`999`.T]
+  type Millis = Int Refined Interval.Closed[0, 999]
 
   object Millis extends RefinedTypeOps[Millis, Int]
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/AutoSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/AutoSpec.scala
@@ -13,11 +13,11 @@ import shapeless.test.illTyped
 class AutoSpec extends Properties("auto") {
 
   property("autoInfer") = secure {
-    val a: Char Refined Equal[W.`'0'`.T] = '0'
+    val a: Char Refined Equal['0'] = '0'
     val b: Char Refined Digit = a
     illTyped(
       "val c: Char Refined Letter = a",
-      """type mismatch \(invalid inference\):\s*eu.timepit.refined.generic.Equal\[Char\('0'\)\] does not imply\s*eu.timepit.refined.char.Letter"""
+      """type mismatch \(invalid inference\):\s*eu.timepit.refined.generic.Equal\['0'\] does not imply\s*eu.timepit.refined.char.Letter"""
     )
     a == b
   }
@@ -29,14 +29,14 @@ class AutoSpec extends Properties("auto") {
   }
 
   property("autoRefineV") = secure {
-    val a: Char Refined Equal[W.`'0'`.T] = '0'
-    illTyped("val b: Char Refined Equal[W.`'0'`.T] = '1'", """Predicate failed: \(1 == 0\).""")
+    val a: Char Refined Equal['0'] = '0'
+    illTyped("val b: Char Refined Equal['0'] = '1'", """Predicate failed: \(1 == 0\).""")
     a.value == '0'
   }
 
   property("autoRefineT") = secure {
-    val a: Char @@ Equal[W.`'0'`.T] = '0'
-    illTyped("val b: Char @@ Equal[W.`'0'`.T] = '1'", """Predicate failed: \(1 == 0\).""")
+    val a: Char @@ Equal['0'] = '0'
+    illTyped("val b: Char @@ Equal['0'] = '1'", """Predicate failed: \(1 == 0\).""")
     a == '0'
   }
 

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/CollectionInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/CollectionInferenceSpec.scala
@@ -13,7 +13,7 @@ import shapeless.test.illTyped
 class CollectionInferenceSpec extends Properties("CollectionInference") {
 
   property("Exists[A] ==> Exists[B]") = secure {
-    Inference[Contains[W.`'5'`.T], Exists[Digit]].isValid
+    Inference[Contains['5'], Exists[Digit]].isValid
   }
 
   property("Exists ==> NonEmpty") = secure {
@@ -42,7 +42,7 @@ class CollectionInferenceSpec extends Properties("CollectionInference") {
   }
 
   property("Index ==> Exists") = secure {
-    Inference[Index[W.`1`.T, LowerCase], Exists[LowerCase]].isValid
+    Inference[Index[1, LowerCase], Exists[LowerCase]].isValid
   }
 
   property("Last[A] ==> Last[B]") = secure {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/CollectionValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/CollectionValidateSpec.scala
@@ -12,19 +12,19 @@ import shapeless.nat._
 class CollectionValidateSpec extends Properties("CollectionValidate") {
 
   property("Contains.isValid") = forAll { (l: List[Int]) =>
-    isValid[Contains[W.`0`.T]](l) ?= l.contains(0)
+    isValid[Contains[0]](l) ?= l.contains(0)
   }
 
   property("Contains.showExpr") = secure {
-    showExpr[Contains[W.`0`.T]](List(1, 2, 3)) ?= "!(!(1 == 0) && !(2 == 0) && !(3 == 0))"
+    showExpr[Contains[0]](List(1, 2, 3)) ?= "!(!(1 == 0) && !(2 == 0) && !(3 == 0))"
   }
 
   property("Contains.String.isValid") = forAll { (s: String) =>
-    isValid[Contains[W.`'0'`.T]](s) ?= s.contains('0')
+    isValid[Contains['0']](s) ?= s.contains('0')
   }
 
   property("Contains.String.showExpr") = secure {
-    showExpr[Contains[W.`'0'`.T]]("012") ?= "!(!(0 == 0) && !(1 == 0) && !(2 == 0))"
+    showExpr[Contains['0']]("012") ?= "!(!(0 == 0) && !(1 == 0) && !(2 == 0))"
   }
 
   property("Count.isValid") = forAll { (l: List[Char]) =>
@@ -106,19 +106,19 @@ class CollectionValidateSpec extends Properties("CollectionValidate") {
   }
 
   property("Index.isValid") = forAll { (l: List[Char]) =>
-    isValid[Index[W.`2`.T, Digit]](l) ?= l.lift(2).fold(false)(_.isDigit)
+    isValid[Index[2, Digit]](l) ?= l.lift(2).fold(false)(_.isDigit)
   }
 
   property("Index.showExpr") = secure {
-    showExpr[Index[W.`1`.T, Digit]](List('a', 'b')) ?= "isDigit('b')"
+    showExpr[Index[1, Digit]](List('a', 'b')) ?= "isDigit('b')"
   }
 
   property("Index.showResult.empty") = secure {
-    showResult[Index[W.`2`.T, Digit]](List.empty[Char]) ?= "Predicate failed: empty collection."
+    showResult[Index[2, Digit]](List.empty[Char]) ?= "Predicate failed: empty collection."
   }
 
   property("Index.showResult.nonEmpty") = secure {
-    showResult[Index[W.`2`.T, Digit]](List('a', 'b', 'c')) ?=
+    showResult[Index[2, Digit]](List('a', 'b', 'c')) ?=
       "Predicate taking index(List(a, b, c), 2) = c failed: Predicate failed: isDigit('c')."
   }
 

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/GenericInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/GenericInferenceSpec.scala
@@ -11,18 +11,18 @@ import shapeless.Nat
 class GenericInferenceSpec extends Properties("GenericInference") {
 
   property("Equal[S1] ==> StartsWith[S2]") = secure {
-    Inference[Equal[W.`"abcd"`.T], StartsWith[W.`"ab"`.T]].isValid
+    Inference[Equal["abcd"], StartsWith["ab"]].isValid
   }
 
   property("Equal[S1] =!> StartsWith[S2]") = secure {
-    Inference[Equal[W.`"abcd"`.T], StartsWith[W.`"cd"`.T]].notValid
+    Inference[Equal["abcd"], StartsWith["cd"]].notValid
   }
 
   property("Equal[Nat] ==> Greater[I]") = secure {
-    Inference[Equal[Nat._10], Greater[W.`5`.T]].isValid
+    Inference[Equal[Nat._10], Greater[5]].isValid
   }
 
   property("Equal[Nat] =!> Greater[I]") = secure {
-    Inference[Equal[Nat._5], Greater[W.`10`.T]].notValid
+    Inference[Equal[Nat._5], Greater[10]].notValid
   }
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/GenericValidateSpec.scala
@@ -9,15 +9,15 @@ import shapeless.Nat._
 class GenericValidateSpec extends Properties("GenericValidate") {
 
   property("Equal.isValid") = secure {
-    isValid[Equal[W.`1.4`.T]](1.4)
+    isValid[Equal[1.4]](1.4)
   }
 
   property("Equal.notValid") = secure {
-    notValid[Equal[W.`1.4`.T]](2.4)
+    notValid[Equal[1.4]](2.4)
   }
 
   property("Equal.showExpr") = secure {
-    showExpr[Equal[W.`1.4`.T]](0.4) ?= "(0.4 == 1.4)"
+    showExpr[Equal[1.4]](0.4) ?= "(0.4 == 1.4)"
   }
 
   property("Equal.object.isValid") = secure {
@@ -26,15 +26,15 @@ class GenericValidateSpec extends Properties("GenericValidate") {
   }
 
   property("Equal.Symbol.isValid") = secure {
-    isValid[Equal[W.`'foo`.T]]('foo)
+    isValid[Equal['foo]]('foo)
   }
 
   property("Equal.Symbol.notValid") = secure {
-    notValid[Equal[W.`'foo`.T]]('bar)
+    notValid[Equal['foo]]('bar)
   }
 
   property("Equal.Symbol.showExpr") = secure {
-    showExpr[Equal[W.`'foo`.T]]('bar) ?= "('bar == 'foo)"
+    showExpr[Equal['foo]]('bar) ?= "('bar == 'foo)"
   }
 
   property("Equal.Nat.Int.isValid") = forAll { (i: Int) =>
@@ -54,6 +54,6 @@ class GenericValidateSpec extends Properties("GenericValidate") {
   }
 
   property("Equal.Nat ~= Equal.Int") = forAll { (i: Int) =>
-    showResult[Equal[_1]](i) ?= showResult[Equal[W.`1`.T]](i)
+    showResult[Equal[_1]](i) ?= showResult[Equal[1]](i)
   }
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/ImplicitScopeSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/ImplicitScopeSpec.scala
@@ -24,7 +24,7 @@ class ImplicitScopeSpec extends Properties("implicit scope") {
   }
 
   property("Validate[Int, Interval.Closed[0, 10]]") = wellTyped {
-    Validate[Int, numeric.Interval.Closed[W.`0`.T, W.`10`.T]]
+    Validate[Int, numeric.Interval.Closed[0, 10]]
   }
 
   property("Inference[And[UpperCase, Letter], And[Letter, UpperCase]]") = wellTyped {
@@ -32,6 +32,6 @@ class ImplicitScopeSpec extends Properties("implicit scope") {
   }
 
   property("Inference[Greater[1], Greater[0]]") = wellTyped {
-    Inference[numeric.Greater[W.`1`.T], numeric.Greater[W.`0`.T]]
+    Inference[numeric.Greater[1], numeric.Greater[0]]
   }
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/MaxSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/MaxSpec.scala
@@ -11,8 +11,8 @@ import shapeless.tag.@@
 
 class MaxSpec extends Properties("Max") {
 
-  property("Max[Int Refined Less[W.`1`.T]]") = secure {
-    Max[Int Refined Less[W.`1`.T]].max =? Refined.unsafeApply(0)
+  property("Max[Int Refined Less[1]]") = secure {
+    Max[Int Refined Less[1]].max =? Refined.unsafeApply(0)
   }
 
   property("Max[Int Refined Less[_0]]") = secure {
@@ -67,8 +67,8 @@ class MaxSpec extends Properties("Max") {
     Max[Double Refined NonPositive].max =? Refined.unsafeApply(0d)
   }
 
-  property("Max[Int Refined Not[Greater[W.`-5`.T]]]") = secure {
-    Max[Int Refined Not[Greater[W.`-5`.T]]].max =? Refined.unsafeApply(-5)
+  property("Max[Int Refined Not[Greater[-5]]]") = secure {
+    Max[Int Refined Not[Greater[-5]]].max =? Refined.unsafeApply(-5)
   }
 
   property("Max[Int Refined Interval.Open[_10, _20]]") = secure {
@@ -79,22 +79,22 @@ class MaxSpec extends Properties("Max") {
     Max[Double Refined Interval.Open[_10, _20]].max =? Refined.unsafeApply(19.999999999999996d)
   }
 
-  property("Max[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
-    Max[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]].max =? Refined.unsafeApply(10)
+  property("Max[Int Refined Interval.Closed[-20, 10]]") = secure {
+    Max[Int Refined Interval.Closed[-20, 10]].max =? Refined.unsafeApply(10)
   }
 
-  property("Max[Int @@ Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
-    Max[Int @@ Interval.Closed[W.`-20`.T, W.`10`.T]].max =?
-      refineMT[Interval.Closed[W.`-20`.T, W.`10`.T]](10)
+  property("Max[Int @@ Interval.Closed[-20, 10]]") = secure {
+    Max[Int @@ Interval.Closed[-20, 10]].max =?
+      refineMT[Interval.Closed[-20, 10]](10)
   }
 
-  property("Max[Double Refined Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
-    Max[Double Refined Interval.Closed[W.`-20d`.T, W.`10.99991d`.T]].max =?
+  property("Max[Double Refined Interval.Closed[-20, 10]]") = secure {
+    Max[Double Refined Interval.Closed[-20d, 10.99991d]].max =?
       Refined.unsafeApply(10.99991d)
   }
 
-  property("Max[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]]") = secure {
-    Max[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]].max =? Refined.unsafeApply('Z')
+  property("Max[Char Refined Interval.Closed['A', 'Z']]") = secure {
+    Max[Char Refined Interval.Closed['A', 'Z']].max =? Refined.unsafeApply('Z')
   }
 
   property("Max[Int Refined Even]") = secure {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/MinSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/MinSpec.scala
@@ -11,8 +11,8 @@ import shapeless.tag.@@
 
 class MinSpec extends Properties("Min") {
 
-  property("Min[Int Refined Greater[W.`1`.T]]") = secure {
-    Min[Int Refined Greater[W.`1`.T]].min =? Refined.unsafeApply(2)
+  property("Min[Int Refined Greater[1]]") = secure {
+    Min[Int Refined Greater[1]].min =? Refined.unsafeApply(2)
   }
 
   property("Min[Int Refined Greater[_0]]") = secure {
@@ -24,7 +24,7 @@ class MinSpec extends Properties("Min") {
   }
 
   property("Min[Float Refined Greater[_0]]") = secure {
-    Min[Float Refined Greater[W.`0f`.T]].min =? Refined.unsafeApply("1.4E-45".toFloat)
+    Min[Float Refined Greater[0f]].min =? Refined.unsafeApply("1.4E-45".toFloat)
   }
 
   property("Min[Byte Refined Less[_0]]") = secure {
@@ -67,8 +67,8 @@ class MinSpec extends Properties("Min") {
     Min[Double Refined NonNegative].min =? Refined.unsafeApply(0f)
   }
 
-  property("Min[Int Refined Not[Less[W.`-5`.T]]]") = secure {
-    Min[Int Refined Not[Less[W.`-5`.T]]].min =? Refined.unsafeApply(-5)
+  property("Min[Int Refined Not[Less[-5]]]") = secure {
+    Min[Int Refined Not[Less[-5]]].min =? Refined.unsafeApply(-5)
   }
 
   property("Min[Int Refined Interval.Open[_10, _20]]") = secure {
@@ -83,17 +83,17 @@ class MinSpec extends Properties("Min") {
     Min[Double Refined Interval.Open[_10, _20]].min =? Refined.unsafeApply(10.000000000000002d)
   }
 
-  property("Min[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
-    Min[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]].min =? Refined.unsafeApply(-20)
+  property("Min[Int Refined Interval.Closed[-20, 10]]") = secure {
+    Min[Int Refined Interval.Closed[-20, 10]].min =? Refined.unsafeApply(-20)
   }
 
-  property("Min[Double Refined Interval.Closed[W.`-20.001d`.T, W.`0d`.T]]") = secure {
-    Min[Double Refined Interval.Closed[W.`-20.001d`.T, W.`0d`.T]].min =? Refined.unsafeApply(
+  property("Min[Double Refined Interval.Closed[-20.001d, 0d]]") = secure {
+    Min[Double Refined Interval.Closed[-20.001d, 0d]].min =? Refined.unsafeApply(
       -20.001d)
   }
 
-  property("Min[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]]") = secure {
-    Min[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]].min =? Refined.unsafeApply('A')
+  property("Min[Char Refined Interval.Closed['A', 'Z']]") = secure {
+    Min[Char Refined Interval.Closed['A', 'Z']].min =? Refined.unsafeApply('A')
   }
 
   property("Min[Int Refined Even]") = secure {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericInferenceSpec.scala
@@ -10,49 +10,49 @@ import shapeless.nat._
 class NumericInferenceSpec extends Properties("NumericInference") {
 
   property("Less[A] ==> Less[B]") = secure {
-    Inference[Less[W.`7.2`.T], Less[W.`7.5`.T]].isValid
+    Inference[Less[7.2], Less[7.5]].isValid
   }
 
   property("Less[A] =!> Less[B]") = secure {
-    Inference[Less[W.`7.5`.T], Less[W.`7.2`.T]].notValid
+    Inference[Less[7.5], Less[7.2]].notValid
   }
 
   property("LessEqual[A] ==> LessEqual[B]") = secure {
-    Inference[LessEqual[W.`7.2`.T], LessEqual[W.`7.5`.T]].isValid
+    Inference[LessEqual[7.2], LessEqual[7.5]].isValid
   }
 
   // Does not compile on 2.10 without a warning.
   /*
   property("LessEqual[A] ==> LessEqual[A]") = secure {
-    Inference[LessEqual[W.`1`.T], LessEqual[W.`1`.T]].isValid
+    Inference[LessEqual[1], LessEqual[1]].isValid
   }
    */
 
   property("LessEqual[A] =!> LessEqual[B]") = secure {
-    Inference[LessEqual[W.`7.5`.T], LessEqual[W.`7.2`.T]].notValid
+    Inference[LessEqual[7.5], LessEqual[7.2]].notValid
   }
 
   property("Greater[A] ==> Greater[B]") = secure {
-    Inference[Greater[W.`7.5`.T], Greater[W.`7.2`.T]].isValid
+    Inference[Greater[7.5], Greater[7.2]].isValid
   }
 
   property("Greater[A] =!> Greater[B]") = secure {
-    Inference[Greater[W.`7.2`.T], Greater[W.`7.5`.T]].notValid
+    Inference[Greater[7.2], Greater[7.5]].notValid
   }
 
   property("GreaterEqual[A] ==> GreaterEqual[B]") = secure {
-    Inference[GreaterEqual[W.`7.5`.T], GreaterEqual[W.`7.2`.T]].isValid
+    Inference[GreaterEqual[7.5], GreaterEqual[7.2]].isValid
   }
 
   // Does not compile on 2.10 without a warning.
   /*
   property("GreaterEqual[A] ==> GreaterEqual[A]") = secure {
-    Inference[GreaterEqual[W.`1`.T], GreaterEqual[W.`1`.T]].isValid
+    Inference[GreaterEqual[1], GreaterEqual[1]].isValid
   }
    */
 
   property("GreaterEqual[A] =!> GreaterEqual[B]") = secure {
-    Inference[GreaterEqual[W.`7.2`.T], GreaterEqual[W.`7.5`.T]].notValid
+    Inference[GreaterEqual[7.2], GreaterEqual[7.5]].notValid
   }
 
   property("Less[Nat] ==> Less[Nat]") = secure {
@@ -64,11 +64,11 @@ class NumericInferenceSpec extends Properties("NumericInference") {
   }
 
   property("Less[A] ==> Less[Nat]") = secure {
-    Inference[Less[W.`5`.T], Less[_10]].isValid
+    Inference[Less[5], Less[_10]].isValid
   }
 
   property("Less[A] =!> Less[Nat]") = secure {
-    Inference[Less[W.`10`.T], Less[_5]].notValid
+    Inference[Less[10], Less[_5]].notValid
   }
 
   property("Greater[Nat] ==> Greater[Nat]") = secure {
@@ -80,11 +80,11 @@ class NumericInferenceSpec extends Properties("NumericInference") {
   }
 
   property("Greater[A] ==> Greater[Nat]") = secure {
-    Inference[Greater[W.`10`.T], Greater[_5]].isValid
+    Inference[Greater[10], Greater[_5]].isValid
   }
 
   property("Greater[A] =!> Greater[Nat]") = secure {
-    Inference[Greater[W.`5`.T], Greater[_10]].notValid
+    Inference[Greater[5], Greater[_10]].notValid
   }
 
   property("Interval[Nat] ==> LessEqual[Nat]") = secure {
@@ -92,11 +92,11 @@ class NumericInferenceSpec extends Properties("NumericInference") {
   }
 
   property("Greater[A] ==> GreaterEqual[A]") = secure {
-    Inference[Greater[W.`0`.T], GreaterEqual[W.`0`.T]].isValid
+    Inference[Greater[0], GreaterEqual[0]].isValid
   }
 
   property("Less[A] ==> LessEqual[A]") = secure {
-    Inference[Less[W.`0`.T], LessEqual[W.`0`.T]].isValid
+    Inference[Less[0], LessEqual[0]].isValid
   }
 
   /*
@@ -105,11 +105,11 @@ class NumericInferenceSpec extends Properties("NumericInference") {
   }
 
   property("Equal[Nat] ==> Greater[A]") = secure {
-    Inference[Equal[_10], Greater[W.`5`.T]].isValid
+    Inference[Equal[_10], Greater[5]].isValid
   }
 
   property("Equal[Nat] =!> Greater[A]") = secure {
-    Inference[Equal[_5], Greater[W.`10`.T]].notValid
+    Inference[Equal[_5], Greater[10]].notValid
   }
  */
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
@@ -9,11 +9,11 @@ import shapeless.nat._
 class NumericValidateSpec extends Properties("NumericValidate") {
 
   property("Less.isValid") = forAll { (d: Double) =>
-    isValid[Less[W.`1.0`.T]](d) ?= (d < 1.0)
+    isValid[Less[1.0]](d) ?= (d < 1.0)
   }
 
   property("Less.showExpr") = secure {
-    showExpr[Less[W.`1.1`.T]](0.1) ?= "(0.1 < 1.1)"
+    showExpr[Less[1.1]](0.1) ?= "(0.1 < 1.1)"
   }
 
   property("Less.Nat.isValid") = forAll { (i: Int) =>
@@ -33,15 +33,15 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   }
 
   property("Less.Nat ~= Less.Int") = forAll { (i: Int) =>
-    showResult[Less[_5]](i) ?= showResult[Less[W.`5`.T]](i)
+    showResult[Less[_5]](i) ?= showResult[Less[5]](i)
   }
 
   property("Greater.isValid") = forAll { (d: Double) =>
-    isValid[Greater[W.`1.0`.T]](d) ?= (d > 1.0)
+    isValid[Greater[1.0]](d) ?= (d > 1.0)
   }
 
   property("Greater.showExpr") = secure {
-    showExpr[Greater[W.`1.1`.T]](0.1) ?= "(0.1 > 1.1)"
+    showExpr[Greater[1.1]](0.1) ?= "(0.1 > 1.1)"
   }
 
   property("Greater.Nat.isValid") = forAll { (i: Int) =>
@@ -61,7 +61,7 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   }
 
   property("Greater.Nat ~= Greater.Int") = forAll { (i: Int) =>
-    showResult[Greater[_5]](i) ?= showResult[Greater[W.`5`.T]](i)
+    showResult[Greater[_5]](i) ?= showResult[Greater[5]](i)
   }
 
   property("Modulo.isValid - Nat - Byte") = forAll { (b: Byte) =>
@@ -77,7 +77,7 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   }
 
   property("Modulo.isValid - Wit - Int") = forAll { (i: Int) =>
-    isValid[Modulo[W.`2`.T, W.`0`.T]](i) ?= (i % 2 == 0)
+    isValid[Modulo[2, 0]](i) ?= (i % 2 == 0)
   }
 
   property("Modulo.isValid - Nat - Long") = forAll { (l: Long) =>
@@ -85,11 +85,11 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   }
 
   property("Modulo.isValid - Wit - Long") = forAll { (l: Long) =>
-    isValid[Modulo[W.`2L`.T, W.`0L`.T]](l) ?= (l % 2 == 0)
+    isValid[Modulo[2L, 0L]](l) ?= (l % 2 == 0)
   }
 
   property("Modulo.showExpr") = secure {
-    showExpr[Modulo[W.`2`.T, W.`0`.T]](4) ?= s"(${4} % ${2} == ${0})"
+    showExpr[Modulo[2, 0]](4) ?= s"(${4} % ${2} == ${0})"
   }
 
   property("Modulo.Nat.isValid") = forAll { (i: Int) =>
@@ -101,7 +101,7 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   }
 
   property("Modulo.Nat ~= Modulo.Int") = forAll { (i: Int) =>
-    showResult[Modulo[_5, _2]](i) ?= showResult[Modulo[W.`5`.T, W.`2`.T]](i)
+    showResult[Modulo[_5, _2]](i) ?= showResult[Modulo[5, 2]](i)
   }
 
   property("Divisible.Nat.isValid") = forAll { (i: Int) =>
@@ -109,7 +109,7 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   }
 
   property("Divisible.Int.isValid") = forAll { (i: Int) =>
-    isValid[Divisible[W.`2`.T]](i) ?= (i % 2 == 0)
+    isValid[Divisible[2]](i) ?= (i % 2 == 0)
   }
 
   property("Divisible.Nat.showExpr") = secure {
@@ -117,7 +117,7 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   }
 
   property("Divisible.Int.showExpr") = secure {
-    showExpr[Divisible[W.`2`.T]](4) ?= "(4 % 2 == 0)"
+    showExpr[Divisible[2]](4) ?= "(4 % 2 == 0)"
   }
 
   property("NonDivisible.isValid") = forAll { (i: Int) =>

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/RefineMSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/RefineMSpec.scala
@@ -50,24 +50,24 @@ class RefineMSpec extends Properties("refineM") {
   }
 
   property("refineM with MatchesRegex") = wellTyped {
-    def ignore1: String Refined MatchesRegex[W.`"[0-9]+"`.T] = refineMV("123")
-    def ignore2: String @@ MatchesRegex[W.`"[0-9]+"`.T] = refineMT("123")
-    illTyped("""refineMV[MatchesRegex[W.`"[0-9]+"`.T]]("abc")""", "Predicate.*fail.*")
-    illTyped("""refineMT[MatchesRegex[W.`"[0-9]+"`.T]]("abc")""", "Predicate.*fail.*")
+    def ignore1: String Refined MatchesRegex["[0-9]+"] = refineMV("123")
+    def ignore2: String @@ MatchesRegex["[0-9]+"] = refineMT("123")
+    illTyped("""refineMV[MatchesRegex["[0-9]+"]]("abc")""", "Predicate.*fail.*")
+    illTyped("""refineMT[MatchesRegex["[0-9]+"]]("abc")""", "Predicate.*fail.*")
   }
 
   property("refineM with Contains") = wellTyped {
-    def ignore1: String Refined Contains[W.`'c'`.T] = refineMV("abcd")
-    def ignore2: String @@ Contains[W.`'c'`.T] = refineMT("abcd")
-    illTyped("""refineMV[Contains[W.`'c'`.T]]("abde")""", "Predicate.*fail.*")
-    illTyped("""refineMT[Contains[W.`'c'`.T]]("abde")""", "Predicate.*fail.*")
+    def ignore1: String Refined Contains['c'] = refineMV("abcd")
+    def ignore2: String @@ Contains['c'] = refineMT("abcd")
+    illTyped("""refineMV[Contains['c']]("abde")""", "Predicate.*fail.*")
+    illTyped("""refineMT[Contains['c']]("abde")""", "Predicate.*fail.*")
   }
 
   property("refineM with Double Witness") = wellTyped {
-    def ignore1: Double Refined Greater[W.`2.3`.T] = refineMV(2.4)
-    def ignore2: Double @@ Greater[W.`2.3`.T] = refineMT(2.4)
-    illTyped("refineMT[Greater[W.`2.3`.T]](2.2)", "Predicate.*fail.*")
-    illTyped("refineMV[Greater[W.`2.3`.T]](2.2)", "Predicate.*fail.*")
+    def ignore1: Double Refined Greater[2.3] = refineMV(2.4)
+    def ignore2: Double @@ Greater[2.3] = refineMT(2.4)
+    illTyped("refineMT[Greater[2.3]](2.2)", "Predicate.*fail.*")
+    illTyped("refineMV[Greater[2.3]](2.2)", "Predicate.*fail.*")
   }
 
   property("refineM failure with non-literals") = wellTyped {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/StringInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/StringInferenceSpec.scala
@@ -8,18 +8,18 @@ import org.scalacheck.Properties
 class StringInferenceSpec extends Properties("StringInference") {
 
   property("EndsWith ==> EndsWith") = secure {
-    Inference[EndsWith[W.`"cde"`.T], EndsWith[W.`"de"`.T]].isValid
+    Inference[EndsWith["cde"], EndsWith["de"]].isValid
   }
 
   property("EndsWith =!> EndsWith") = secure {
-    Inference[EndsWith[W.`"de"`.T], EndsWith[W.`"cde"`.T]].notValid
+    Inference[EndsWith["de"], EndsWith["cde"]].notValid
   }
 
   property("StartsWith ==> StartsWith") = secure {
-    Inference[StartsWith[W.`"cde"`.T], StartsWith[W.`"cd"`.T]].isValid
+    Inference[StartsWith["cde"], StartsWith["cd"]].isValid
   }
 
   property("StartsWith =!> StartsWith") = secure {
-    Inference[StartsWith[W.`"cde"`.T], StartsWith[W.`"de"`.T]].notValid
+    Inference[StartsWith["cde"], StartsWith["de"]].notValid
   }
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/StringValidateSpec.scala
@@ -5,26 +5,25 @@ import eu.timepit.refined.api.Validate
 import eu.timepit.refined.string._
 import org.scalacheck.{Arbitrary, Properties}
 import org.scalacheck.Prop._
-import shapeless.Witness
 
 class StringValidateSpec extends Properties("StringValidate") {
 
   property("EndsWith.isValid") = secure {
     val s = "abcd"
-    val suffix = Witness("cd")
-    isValid[EndsWith[suffix.T]](s) ?= s.endsWith(suffix.value)
+    val suffix: "cd" = "cd"
+    isValid[EndsWith[suffix.type]](s) ?= s.endsWith(suffix)
   }
 
   property("EndsWith.showExpr") = secure {
-    showExpr[EndsWith[W.`"cd"`.T]]("abcd") ?= """"abcd".endsWith("cd")"""
+    showExpr[EndsWith["cd"]]("abcd") ?= """"abcd".endsWith("cd")"""
   }
 
   property("MatchesRegex.isValid") = forAll { (s: String) =>
-    isValid[MatchesRegex[W.`".{2,10}"`.T]](s) ?= s.matches(".{2,10}")
+    isValid[MatchesRegex[".{2,10}"]](s) ?= s.matches(".{2,10}")
   }
 
   property("MatchesRegex.showExpr") = secure {
-    showExpr[MatchesRegex[W.`".{2,10}"`.T]]("Hello") ?= """"Hello".matches(".{2,10}")"""
+    showExpr[MatchesRegex[".{2,10}"]]("Hello") ?= """"Hello".matches(".{2,10}")"""
   }
 
   property("Regex.isValid") = secure {
@@ -37,12 +36,12 @@ class StringValidateSpec extends Properties("StringValidate") {
 
   property("StartsWith.isValid") = secure {
     val s = "abcd"
-    val prefix = Witness("ab")
-    isValid[StartsWith[prefix.T]](s) ?= s.startsWith(prefix.value)
+    val prefix: "ab" = "ab"
+    isValid[StartsWith[prefix.type]](s) ?= s.startsWith(prefix)
   }
 
   property("StartsWith.showExpr") = secure {
-    showExpr[StartsWith[W.`"ab"`.T]]("abcd") ?= """"abcd".startsWith("ab")"""
+    showExpr[StartsWith["ab"]]("abcd") ?= """"abcd".startsWith("ab")"""
   }
 
   property("Uri.isValid") = secure {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -1,7 +1,6 @@
 package eu.timepit.refined.api
 
 import eu.timepit.refined.TestUtils._
-import eu.timepit.refined.W
 import eu.timepit.refined.api.RefType.ops._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.char.{Digit, LowerCase}
@@ -37,7 +36,7 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F])
   }
 
   property("refine success with Less") = secure {
-    rt.refine[Less[W.`100`.T]](-100).isRight
+    rt.refine[Less[100]](-100).isRight
   }
 
   property("refine success with Greater") = secure {
@@ -45,7 +44,7 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F])
   }
 
   property("refine failure with Interval.Closed") = secure {
-    rt.refine[Interval.Closed[W.`-0.5`.T, W.`0.5`.T]](0.6).isLeft
+    rt.refine[Interval.Closed[-0.5, 0.5]](0.6).isLeft
   }
 
   property("refine failure with Forall") = secure {
@@ -53,7 +52,7 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F])
   }
 
   property("refine success with MatchesRegex") = secure {
-    type DigitsOnly = MatchesRegex[W.`"[0-9]+"`.T]
+    type DigitsOnly = MatchesRegex["[0-9]+"]
     rt.refine[DigitsOnly]("123").isRight
   }
 

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -1,13 +1,12 @@
 package eu.timepit.refined.types
 
-import eu.timepit.refined.W
 import eu.timepit.refined.types.all._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 
 class StringTypesSpec extends Properties("StringTypes") {
 
-  final val FString3 = FiniteString[W.`3`.T]
+  final val FString3 = FiniteString[3]
 
   property("FString3.from(str)") = forAll { (str: String) =>
     FString3.from(str).isRight ?= (str.length <= FString3.maxLength)


### PR DESCRIPTION
This PR replaces `shapeless.Witness` with proper literal singleton types that will be available with Scala 2.13.

:sparkles: This is a glimpse into a better world. :sparkles: