### PR TITLE
Improve performance of RefinedType#unsafeFrom

### DIFF
--- a/modules/benchmark/src/main/scala/eu/timepit/refined/benchmark/PosIntBenchmark.scala
+++ b/modules/benchmark/src/main/scala/eu/timepit/refined/benchmark/PosIntBenchmark.scala
@@ -1,0 +1,14 @@
+package eu.timepit.refined.benchmark
+
+import eu.timepit.refined.types.numeric.PosInt
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+class PosIntBenchmark {
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def unsafeFrom_1: Any =
+    PosInt.unsafeFrom(1)
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
@@ -26,8 +26,11 @@ trait RefinedType[FTP] extends Serializable {
     else Left(validate.showResult(t, res))
   }
 
-  final def unsafeRefine(t: T): FTP =
-    refine(t).fold(err => throw new IllegalArgumentException(err), identity)
+  final def unsafeRefine(t: T): FTP = {
+    val res = validate.validate(t)
+    if (res.isPassed) alias(refType.unsafeWrap(t))
+    else throw new IllegalArgumentException(validate.showResult(t, res))
+  }
 }
 
 object RefinedType {

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedType.scala
@@ -22,13 +22,13 @@ trait RefinedType[FTP] extends Serializable {
 
   final def refine(t: T): Either[String, FTP] = {
     val res = validate.validate(t)
-    if (res.isPassed) Right(alias(refType.unsafeWrap(t)))
+    if (res.isPassed) Right(refType.unsafeWrap(t).asInstanceOf[FTP])
     else Left(validate.showResult(t, res))
   }
 
   final def unsafeRefine(t: T): FTP = {
     val res = validate.validate(t)
-    if (res.isPassed) alias(refType.unsafeWrap(t))
+    if (res.isPassed) refType.unsafeWrap(t).asInstanceOf[FTP]
     else throw new IllegalArgumentException(validate.showResult(t, res))
   }
 }

--- a/notes/0.9.1.markdown
+++ b/notes/0.9.1.markdown
@@ -6,8 +6,14 @@
   if a `String` is a parsable `Byte`, `Short`, or `Float`.
   ([#492][#492] by [@sh0hei][@sh0hei])
 
+### Changes
+
+* Improve performance of `RefinedType#unsafeFrom`.
+  ([#499][#499] by [@fthomas][@fthomas])
+
 [#486]: https://github.com/fthomas/refined/pull/486
 [#492]: https://github.com/fthomas/refined/pull/492
+[#499]: https://github.com/fthomas/refined/pull/499
 
 [@fthomas]: https://github.com/fthomas
 [@sh0hei]: https://github.com/sh0hei

--- a/project/plugin-jmh.sbt
+++ b/project/plugin-jmh.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")


### PR DESCRIPTION
Before this change:

[info] Result
"eu.timepit.refined.benchmark.PosIntBenchmark.unsafeFrom_1":
[info]   23.575 ±(99.9%) 0.264 ns/op [Average]
[info]   (min, avg, max) = (22.521, 23.575, 29.684), stdev = 1.119
[info]   CI (99.9%): [23.311, 23.840] (assumes normal distribution)
[info] # Run complete. Total time: 00:06:43
[info] Benchmark                     Mode  Cnt   Score   Error  Units
[info] PosIntBenchmark.unsafeFrom_1  avgt  200  23.575 ± 0.264  ns/op

After this change:

[info] Result
"eu.timepit.refined.benchmark.PosIntBenchmark.unsafeFrom_1":
[info]   13.410 ±(99.9%) 0.076 ns/op [Average]
[info]   (min, avg, max) = (12.855, 13.410, 14.228), stdev = 0.323
[info]   CI (99.9%): [13.334, 13.487] (assumes normal distribution)
[info] # Run complete. Total time: 00:06:43
[info] Benchmark                     Mode  Cnt   Score   Error  Units
[info] PosIntBenchmark.unsafeFrom_1  avgt  200  13.410 ± 0.076  ns/op