### PR TITLE
Replace TrimmedString regex with Trimmed predicate type

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -69,6 +69,9 @@ object string extends StringInference {
   /** Predicate that checks if a `String` is a valid XPath expression. */
   final case class XPath()
 
+  /** Predicate that checks if a `String` has no leading or trailing whitespace. */
+  final case class Trimmed()
+
   object EndsWith {
     implicit def endsWithValidate[S <: String](
         implicit ws: Witness.Aux[S]): Validate.Plain[String, EndsWith[S]] =
@@ -233,6 +236,11 @@ object string extends StringInference {
         "XPath",
         XPath()
       )
+  }
+
+  object Trimmed {
+    implicit def trimmedValidate: Validate.Plain[String, Trimmed] =
+      Validate.fromPredicate(s => s.trim == s, t => s"$t is trimmed", Trimmed())
   }
 }
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -3,7 +3,7 @@ package eu.timepit.refined.types
 import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedType, RefinedTypeOps}
 import eu.timepit.refined.collection.{MaxSize, NonEmpty}
-import eu.timepit.refined.string.MatchesRegex
+import eu.timepit.refined.string.{MatchesRegex, Trimmed}
 import shapeless.Witness
 
 /** Module for `String` refined types. */
@@ -52,9 +52,13 @@ object string {
   object NonEmptyString extends RefinedTypeOps[NonEmptyString, String]
 
   /** A `String` that contains no leading or trailing whitespace. */
-  type TrimmedString = String Refined MatchesRegex[W.`"""^(?!\\s).*(?<!\\s)"""`.T]
+  type TrimmedString = String Refined Trimmed
 
-  object TrimmedString extends RefinedTypeOps[TrimmedString, String]
+  object TrimmedString extends RefinedTypeOps[TrimmedString, String] {
+
+    /** Creates a `TrimmedString` from `s` by trimming it. */
+    def trim(s: String): TrimmedString = Refined.unsafeApply(s.trim)
+  }
 
   /** A `String` representing a hexadecimal number */
   type HexStringSpec = MatchesRegex[W.`"""^(([0-9a-f]+)|([0-9A-F]+))$"""`.T]

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -35,6 +35,11 @@ class StringTypesSpec extends Properties("StringTypes") {
     (truncated.value ?= str.take(FString3.maxLength))
   }
 
+  property("""TrimmedString.trim(str)""") = forAll { (str: String) =>
+    val trimmed = TrimmedString.trim(str)
+    TrimmedString.from(str) ?= Right(trimmed)
+  }
+
   // Hashes for ""
   object EmptyString {
     val md5 = "d41d8cd98f00b204e9800998ecf8427e"

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
@@ -7,5 +7,6 @@ object all
     with NumericInstances
     with RefTypeInstances
     with StringInstances
+    with StringInstancesBinCompat1
     with CollectionInstances
     with CollectionInstancesBinCompat1

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -11,7 +11,7 @@ import shapeless.Witness
  * Module that provides `Arbitrary` instances for `String` related
  * predicates.
  */
-object string extends StringInstances
+object string extends StringInstances with StringInstancesBinCompat1
 
 trait StringInstances {
 
@@ -32,15 +32,17 @@ trait StringInstances {
   ): Arbitrary[F[String, NonEmpty]] =
     collection.buildableNonEmptyArbitrary[F, String, Char]
 
-  implicit def trimmedStringArbitrary[F[_, _]](
-      implicit rt: RefType[F]
-  ): Arbitrary[F[String, Trimmed]] =
-    arbitraryRefType(Arbitrary.arbString.arbitrary.map(TrimmedString.trim(_).value))
-
   implicit def stringSizeArbitrary[F[_, _]: RefType, P](
       implicit
       arbChar: Arbitrary[Char],
       arbSize: Arbitrary[Int Refined P]
   ): Arbitrary[F[String, Size[P]]] =
     collection.buildableSizeArbitrary[F, String, Char, P]
+}
+
+trait StringInstancesBinCompat1 {
+  implicit def trimmedStringArbitrary[F[_, _]](
+      implicit rt: RefType[F]
+  ): Arbitrary[F[String, Trimmed]] =
+    arbitraryRefType(Arbitrary.arbString.arbitrary.map(TrimmedString.trim(_).value))
 }

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -2,7 +2,8 @@ package eu.timepit.refined.scalacheck
 
 import eu.timepit.refined.api.{Refined, RefType}
 import eu.timepit.refined.collection.{NonEmpty, Size}
-import eu.timepit.refined.string.{EndsWith, StartsWith}
+import eu.timepit.refined.string.{EndsWith, StartsWith, Trimmed}
+import eu.timepit.refined.types.string.TrimmedString
 import org.scalacheck.Arbitrary
 import shapeless.Witness
 
@@ -30,6 +31,11 @@ trait StringInstances {
       implicit rt: RefType[F]
   ): Arbitrary[F[String, NonEmpty]] =
     collection.buildableNonEmptyArbitrary[F, String, Char]
+
+  implicit def trimmedStringArbitrary[F[_, _]](
+      implicit rt: RefType[F]
+  ): Arbitrary[F[String, Trimmed]] =
+    arbitraryRefType(Arbitrary.arbString.arbitrary.map(TrimmedString.trim(_).value))
 
   implicit def stringSizeArbitrary[F[_, _]: RefType, P](
       implicit

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -8,7 +8,7 @@ import eu.timepit.refined.scalacheck.generic._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.string._
-import eu.timepit.refined.types.string.{FiniteString, NonEmptyString}
+import eu.timepit.refined.types.string.{FiniteString, NonEmptyString, TrimmedString}
 import org.scalacheck.Properties
 
 class StringArbitrarySpec extends Properties("StringArbitrary") {
@@ -18,6 +18,8 @@ class StringArbitrarySpec extends Properties("StringArbitrary") {
   property("StartsWith[S]") = checkArbitraryRefinedType[String Refined StartsWith[W.`"abc"`.T]]
 
   property("NonEmptyString") = checkArbitraryRefinedType[NonEmptyString]
+
+  property("TrimmedString") = checkArbitraryRefinedType[TrimmedString]
 
   property("MaxSize[16]") = checkArbitraryRefinedType[String Refined MaxSize[W.`16`.T]]
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -42,7 +42,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
-   <parameter name="maxTypes"><![CDATA[40]]></parameter>
+   <parameter name="maxTypes"><![CDATA[45]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">


### PR DESCRIPTION
This also adds `TrimmedString.trim` and is a replacement for #487 based
on the discussion there.

While we are at it I threw in an `Arbitrary` instance for `TrimedString`.