### PR TITLE
Deprecate RefType#refineMF in favor of RefinedTypeOps

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefType.scala
@@ -73,25 +73,11 @@ trait RefType[F[_, _]] extends Serializable {
   def refineM[P]: RefineMPartiallyApplied[F, P] =
     new RefineMPartiallyApplied
 
-  /**
-   * Macro that returns a value of type `T` refined as `F[T, P]` if
-   * it satisfies the predicate `P`, or fails to compile otherwise.
-   *
-   * Example: {{{
-   * scala> import eu.timepit.refined.api.{ Refined, RefType }
-   *      | import eu.timepit.refined.numeric.Positive
-   *
-   * scala> RefType[Refined].refineMF[Long, Positive](10)
-   * res0: Refined[Long, Positive] = 10
-   * }}}
-   *
-   * Note: `M` stands for '''m'''acro and `F` for '''f'''ully applied.
-   *
-   * Note: The return type is `[[internal.RefineMFullyApplied]][F, T, P]`,
-   * which has an `apply` method on it, allowing `refineMF` to be called
-   * like in the given example. In contrast to `[[refineM]]`, the type
-   * `T` needs to be specified before `apply` can be called.
-   */
+  @deprecated(
+    "refineMF has been replaced in favor or RefinedTypeOps. " +
+      "Replace 'RefType[F].refineMF[T, P]' with 'new RefinedTypeOps[F[T, P], T]'.",
+    "0.9.1"
+  )
   def refineMF[T, P]: RefineMFullyApplied[F, T, P] =
     new RefineMFullyApplied
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedTypeOps.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedTypeOps.scala
@@ -40,6 +40,7 @@ class RefinedTypeOps[FTP, T](implicit rt: RefinedType.AuxT[FTP, T]) extends Seri
   def unsafeFrom(t: T): FTP =
     rt.unsafeRefine(t)
 }
+
 object RefinedTypeOps {
   class Numeric[FTP: Min: Max, T](implicit rt: RefinedType.AuxT[FTP, T])
       extends RefinedTypeOps[FTP, T] {

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/RefineMFullyApplied.scala
@@ -3,6 +3,11 @@ package eu.timepit.refined.internal
 import eu.timepit.refined.api.{RefType, Validate}
 import eu.timepit.refined.macros.RefineMacro
 
+@deprecated(
+  "RefineMFullyApplied has been replaced in favor or RefinedTypeOps. " +
+    "Replace 'new RefineMFullyApplied[F, T, P]' with 'new RefinedTypeOps[F[T, P], T]'.",
+  "0.9.1"
+)
 final class RefineMFullyApplied[F[_, _], T, P] {
 
   def apply(t: T)(implicit rt: RefType[F], v: Validate[T, P]): F[T, P] =

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/api/RefTypeSpec.scala
@@ -107,18 +107,6 @@ class RefTypeSpecRefined extends RefTypeSpec[Refined]("Refined") {
     x == y && y == z
   }
 
-  property("refineMF alias") = secure {
-    type Natural = Long Refined NonNegative
-    val Natural = RefType[Refined].refineMF[Long, NonNegative]
-
-    val x: Natural = Natural(1L)
-    val y: Natural = 1L
-    val z = 1L: Natural
-    illTyped("Natural(-1L)", "Predicate.*fail.*")
-    illTyped("Natural(1.3)", "type mismatch.*")
-    x == y && y == z
-  }
-
   property("applyRefM alias") = secure {
     type Natural = Long Refined NonNegative
     val Natural = RefType.applyRefM[Natural]
@@ -145,17 +133,6 @@ class RefTypeSpecTag extends RefTypeSpec[@@]("@@") {
     illTyped("val x: PositiveInt = RefType[@@].refineM(5)", "could not find implicit value.*")
     illTyped("val y: PositiveInt = 5", "type mismatch.*")
     illTyped("val z: PositiveInt = -5", "type mismatch.*")
-  }
-
-  property("refineMF alias") = secure {
-    val Natural = RefType[@@].refineMF[Long, NonNegative]
-
-    val x: Long @@ NonNegative = Natural(1L)
-    val y: Long @@ NonNegative = 1L
-    val z = 1L: Long @@ NonNegative
-    illTyped("Natural(-1L)", "Predicate.*fail.*")
-    illTyped("Natural(1.3)", "type mismatch.*")
-    (x: Long) == (y: Long) && (y: Long) == (z: Long)
   }
 
   property("(T @@ P) <: T") = wellTyped {

--- a/notes/0.9.1.markdown
+++ b/notes/0.9.1.markdown
@@ -15,6 +15,11 @@
 * Improve performance of `RefinedType#unsafeFrom`.
   ([#499][#499] by [@fthomas][@fthomas])
 
+### Deprecations
+
+* Deprecate `RefType#refineMF` in favor of `RefinedTypeOps`.
+  ([#514][#514] by [@fthomas][@fthomas])
+
 ### Updates
 
 * Update `refined-scalaz` to Scalaz 7.2.22.
@@ -28,6 +33,7 @@
 [#500]: https://github.com/fthomas/refined/pull/500
 [#501]: https://github.com/fthomas/refined/pull/501
 [#504]: https://github.com/fthomas/refined/pull/504
+[#514]: https://github.com/fthomas/refined/pull/514
 
 [@ceedubs]: https://github.com/ceedubs
 [@fthomas]: https://github.com/fthomas


### PR DESCRIPTION
`RefineMFullyApplied` provides a subset of the functionality of `RefinedTypeOps` so we can replace the former with the latter.

This is one step towards #386.