### PR TITLE
Update holidaycheck url to tech blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ opening a pull request to list it here:
 
 * [Besedo](https://besedo.com/)
 * [Zalando](https://tech.zalando.de/)
-* [HolidayCheck](https://www.holidaycheck.de/)
+* [HolidayCheck](http://techblog.holidaycheck.com/)
 
 ## Documentation
 


### PR DESCRIPTION
@fthomas My colleagues pointed me, that we always give our techblog url for github projects.