### PR TITLE
Restrict Scala Native projects to Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -324,6 +324,8 @@ lazy val moduleJsSettings = Def.settings(
 )
 
 lazy val moduleNativeSettings = Def.settings(
+  scalaVersion := Scala211,
+  crossScalaVersions := Seq(Scala211),
   // Disable Scaladoc generation because of:
   // [error] dropping dependency on node with no phase object: mixin
   Compile / doc / sources := Seq.empty


### PR DESCRIPTION
Scala Native is only available for 2.11, so scalaVersion for
`coreNative` and all other Native projects should be a 2.11 version.

closes #524