### PR TITLE
Add syntax for Cats NonEmptyList

### DIFF
--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
@@ -1,14 +1,21 @@
 package eu.timepit.refined.cats
 
-import cats.data.ValidatedNel
+import cats.data.{NonEmptyList, ValidatedNel}
 import cats.syntax.either._
 import eu.timepit.refined.api.RefinedTypeOps
+import eu.timepit.refined.types.numeric.PosInt
 
-object syntax extends CatsRefinedTypeOpsSyntax
+object syntax extends CatsRefinedTypeOpsSyntax with CatsNonEmptyListSyntax
 
 trait CatsRefinedTypeOpsSyntax {
   implicit class CatsRefinedTypeOps[FTP, T](rtOps: RefinedTypeOps[FTP, T]) {
     def validate(t: T): ValidatedNel[String, FTP] =
       rtOps.from(t).toValidatedNel
+  }
+}
+
+trait CatsNonEmptyListSyntax {
+  implicit class CatsNonEmptyListRefinedOps[A](nel: NonEmptyList[A]) {
+    def refinedSize: PosInt = PosInt.unsafeFrom(nel.size)
   }
 }

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SyntaxSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SyntaxSpec.scala
@@ -1,9 +1,10 @@
 package eu.timepit.refined.cats
 
-import _root_.cats.data.Validated
+import _root_.cats.data.{NonEmptyList, Validated}
 import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
-import eu.timepit.refined.numeric.Interval
+import eu.timepit.refined.numeric.{Interval, Positive}
+import eu.timepit.refined.refineMV
 import eu.timepit.refined.types.numeric.PosInt
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
@@ -25,4 +26,15 @@ class SyntaxSpec extends Properties("syntax") {
     object OneToTen extends RefinedTypeOps[OneToTen, Int] with CatsRefinedTypeOpsSyntax
     OneToTen.validate(5) ?= Validated.valid(OneToTen.unsafeFrom(5))
   }
+
+  property("NonEmptyList refinedSize (1)") = secure {
+    import syntax._
+    NonEmptyList.of("one").refinedSize ?= refineMV[Positive](1)
+  }
+
+  property("NonEmptyList refinedSize (> 1)") = secure {
+    import syntax._
+    NonEmptyList.of("one", "two", "three").refinedSize ?= refineMV[Positive](3)
+  }
+
 }


### PR DESCRIPTION
Adds a `refinedSize` extension method that returns the size of a NonEmptyList as a positive int.

Based on [this Twitter thread](https://twitter.com/LukaJacobowitz/status/1015216561152577536), at least 2 people in the world want this 😄 