### PR TITLE
Do not turn coverage off in validateJVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -485,7 +485,6 @@ addCommandsAlias(
     "mimaReportBinaryIssues",
     "testJVM",
     "coverageReport",
-    "coverageOff",
     "doc",
     "docs/tut",
     "package",


### PR DESCRIPTION
so that `sbt doc` won't recompile sources.