### PR TITLE
Adding NonNull type for validation of potentially null values.

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/impure.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/impure.scala
@@ -1,0 +1,35 @@
+package eu.timepit.refined
+
+import eu.timepit.refined.api.{Failed, Result, Validate}
+import eu.timepit.refined.internal.Resources
+
+object impure {
+
+  final case class Null()
+
+  /** Safe evaluation of potentially null values. */
+  final case class NonNull[A](a: A)
+
+  object NonNull {
+    implicit def nonNullValidate[T, A, R](
+        implicit v: Validate.Aux[T, A, R]
+    ): Validate.Aux[T, NonNull[A], NonNull[Either[Null, v.Res]]] =
+      new Validate[T, NonNull[A]] {
+        override type R = NonNull[Either[Null, v.Res]]
+
+        override def validate(t: T): Res = {
+          if (t == null) Failed(NonNull(Left(Null())))
+          else {
+            val ra = v.validate(t)
+            Result.fromBoolean(ra.isPassed, NonNull(Right(ra)))
+          }
+        }
+
+        override def showExpr(t: T): String = {
+          if (t == null) "source is null"
+          else if (v.validate(t).isFailed) Resources.showResultAndLeftFailed("NonNull passed", v.showExpr(t))
+          else Resources.showResultAndBothPassed(s"NonNull and ${v.showExpr(t)}")
+        }
+      }
+  }
+}

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/impure.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/impure.scala
@@ -17,19 +17,18 @@ object impure {
       new Validate[T, NonNull[A]] {
         override type R = NonNull[Either[Null, v.Res]]
 
-        override def validate(t: T): Res = {
+        override def validate(t: T): Res =
           if (t == null) Failed(NonNull(Left(Null())))
           else {
             val ra = v.validate(t)
             Result.fromBoolean(ra.isPassed, NonNull(Right(ra)))
           }
-        }
 
-        override def showExpr(t: T): String = {
+        override def showExpr(t: T): String =
           if (t == null) "source is null"
-          else if (v.validate(t).isFailed) Resources.showResultAndLeftFailed("NonNull passed", v.showExpr(t))
+          else if (v.validate(t).isFailed)
+            Resources.showResultAndLeftFailed("NonNull passed", v.showExpr(t))
           else Resources.showResultAndBothPassed(s"NonNull and ${v.showExpr(t)}")
-        }
       }
   }
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
@@ -7,6 +7,7 @@ trait AllPredicates
     with CharPredicates
     with CollectionPredicates
     with GenericPredicates
+    with ImpurePredicates
     with NumericPredicates
     with StringPredicates
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
@@ -1,14 +1,15 @@
 package eu.timepit.refined.predicates
 
-object all extends AllPredicates with AllPredicatesBinCompat1
+object all extends AllPredicates with AllPredicatesBinCompat1 with AllPredicatesBinCompat2
 
 trait AllPredicates
     extends BooleanPredicates
     with CharPredicates
     with CollectionPredicates
     with GenericPredicates
-    with ImpurePredicates
     with NumericPredicates
     with StringPredicates
 
 trait AllPredicatesBinCompat1 extends StringPredicatesBinCompat1
+
+trait AllPredicatesBinCompat2 extends ImpurePredicates

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/impure.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/impure.scala
@@ -1,0 +1,10 @@
+package eu.timepit.refined.predicates
+
+import eu.timepit.refined
+
+object impure extends ImpurePredicates
+
+trait ImpurePredicates {
+  final type NonNull[U] = refined.impure.NonNull[U]
+  final val NonNull = refined.impure.NonNull
+}

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/ImpureValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/ImpureValidateSpec.scala
@@ -19,8 +19,6 @@ class ImpureValidateSpec extends Properties("ImpureValidate") {
   }
 
   property("NonNull.showResult - String - invalid") = secure {
-    import eu.timepit.refined.collection.NonEmpty
-
     val string: String = null
     showResult[NonNull[NonEmpty]](string) ?= "Predicate failed: source is null."
   }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/ImpureValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/ImpureValidateSpec.scala
@@ -1,0 +1,63 @@
+package eu.timepit.refined
+
+
+import eu.timepit.refined.TestUtils._
+import eu.timepit.refined.boolean._
+import eu.timepit.refined.collection._
+import eu.timepit.refined.impure.NonNull
+import eu.timepit.refined.numeric._
+import eu.timepit.refined.string._
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class ImpureValidateSpec extends Properties("ImpureValidate") {
+
+  property("NonNull safe for String") = secure {
+    import eu.timepit.refined.collection.NonEmpty
+
+    val string: String = null
+    notValid[NonNull[NonEmpty]](string)
+  }
+
+  property("NonNull.showResult - String - invalid") = secure {
+    import eu.timepit.refined.collection.NonEmpty
+
+    val string: String = null
+    showResult[NonNull[NonEmpty]](string) ?= "Predicate failed: source is null."
+  }
+
+  property("NonNull safe for List") = secure {
+    val list: List[Int] = null
+    notValid[NonNull[NonEmpty]](list)
+  }
+
+  property("NonNull valid String") = forAll { string: String =>
+    string.nonEmpty ==>
+      isValid[NonNull[NonEmpty]](string)
+  }
+
+  property("NonNull.showResult - String - left valid") = secure {
+    showResult[NonNull[NonEmpty]]("") ?= "Predicate failed: Left predicate of NonNull passed failed: !isEmpty()."
+  }
+
+  property("NonNull.showResult - String - both valid") = forAll { string: String =>
+    string.nonEmpty ==>
+      (showResult[NonNull[NonEmpty]](string) ?=
+        s"Predicate passed: Both predicates of NonNull and !isEmpty($string) passed..")
+  }
+
+  property("NonNull.showResult - List - invalid") = forAll { list: List[Int] =>
+    list.nonEmpty ==>
+      isValid[NonNull[NonEmpty]](list)
+  }
+
+  property("NonNull safe for non nullable values") = forAll { int: Int =>
+    (int > 0) ==>
+      isValid[NonNull[Positive]](int)
+  }
+
+  property("NonNull compound String refinements") = secure {
+    isValid[NonNull[StartsWith[W.`"r"`.T] And EndsWith[W.`"e"`.T]]]("refine")
+  }
+
+}

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/ImpureValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/ImpureValidateSpec.scala
@@ -1,6 +1,5 @@
 package eu.timepit.refined
 
-
 import eu.timepit.refined.TestUtils._
 import eu.timepit.refined.boolean._
 import eu.timepit.refined.collection._

--- a/modules/docs/util_string.md
+++ b/modules/docs/util_string.md
@@ -103,3 +103,22 @@ scala> xpath("A//B/*[1")
        xpath("A//B/*[1")
              ^
 ```
+
+Manage interoperability with impure code to safely handle `null`. `NonNull[P]` wraps a predicate `P` and validates if the value is defined.
+
+```scala
+import java.net.URL                          
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.impure._
+import eu.timepit.refined.refineV
+import eu.timepit.refined.collection.NonEmpty
+
+scala> val url = new URL("https://www.google.com")
+<console>url: java.net.URL = https://www.google.com
+scala> val unsafe = url.getUserInfo
+<console>unsafe: String = null
+scala> val refined = refineV[NonNull[NonEmpty]](unsafe).toOption
+<console>refined: Option[Refined[String,NonNull[NonEmpty]]] = None
+
+```
+


### PR DESCRIPTION
This is a duplicate of fthomas/refined/issues/450, which is a request to provide safe `null` handling.

There is a discussion on the previous PR that I would like to address. I agree with @jan0sch [comment](https://github.com/fthomas/refined/issues/450#issuecomment-375655000) that it is the responsibility of the developer to handle `null`, but it seems reasonable that the library should afford the developer a mechanism to do so. I believe this patch would not cause any breaking changes and the maintenance overhead should be minimal.