### PR TITLE
Moved HexStringSpec and added documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ The library comes with these predefined predicates:
 * `Xml`: checks if a `String` is well-formed XML
 * `XPath`: checks if a `String` is a valid XPath expression
 * `Trimmed`: checks if a `String` has no leading or trailing whitespace
+* `HexStringSpec`: checks if a `String` represents a hexadecimal number
 
 ## Contributors and participation
 
@@ -424,6 +425,7 @@ The following people have helped making **refined** great:
 * [Vladimir Koshelev](https://github.com/koshelev)
 * [Yuki Ishikawa](https://github.com/rider-yi)
 * [Zainab Ali](https://github.com/zainab-ali)
+* [Michael Thomas](https://github.com/Michaelt293)
 * Your name here :-)
 
 **refined** is a [Typelevel][typelevel] project. This means we embrace pure,

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ The following people have helped making **refined** great:
 * [kusamakura](https://github.com/kusamakura)
 * [Leif Wickland](https://github.com/leifwickland)
 * [Matt Pickering](https://github.com/matthedude)
+* [Michael Thomas](https://github.com/Michaelt293)
 * [Naoki Aoyama](https://github.com/aoiroaoino)
 * [Nicolas Rinaudo](https://github.com/nrinaudo)
 * [Olli Helenius](https://github.com/liff)
@@ -425,7 +426,6 @@ The following people have helped making **refined** great:
 * [Vladimir Koshelev](https://github.com/koshelev)
 * [Yuki Ishikawa](https://github.com/rider-yi)
 * [Zainab Ali](https://github.com/zainab-ali)
-* [Michael Thomas](https://github.com/Michaelt293)
 * Your name here :-)
 
 **refined** is a [Typelevel][typelevel] project. This means we embrace pure,

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/string.scala
@@ -66,4 +66,6 @@ trait StringPredicatesBinCompat1 {
 
   final type ValidFloat = refined.string.ValidFloat
   final val ValidFloat = refined.string.ValidFloat
+
+  final type HexStringSpec = refined.string.HexStringSpec
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -72,6 +72,10 @@ object string extends StringInference {
   /** Predicate that checks if a `String` has no leading or trailing whitespace. */
   final case class Trimmed()
 
+  /** Predicate that checks if a `String` represents a hexadecimal number. */
+  type HexStringSpec = MatchesRegex[W.`"""^(([0-9a-f]+)|([0-9A-F]+))$"""`.T]
+
+
   object EndsWith {
     implicit def endsWithValidate[S <: String](
         implicit ws: Witness.Aux[S]

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala
@@ -75,7 +75,6 @@ object string extends StringInference {
   /** Predicate that checks if a `String` represents a hexadecimal number. */
   type HexStringSpec = MatchesRegex[W.`"""^(([0-9a-f]+)|([0-9A-F]+))$"""`.T]
 
-
   object EndsWith {
     implicit def endsWithValidate[S <: String](
         implicit ws: Witness.Aux[S]

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/digests.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/digests.scala
@@ -5,7 +5,7 @@ import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.boolean.And
 import eu.timepit.refined.collection.Size
 import eu.timepit.refined.generic.Equal
-import eu.timepit.refined.types.string.HexStringSpec
+import eu.timepit.refined.string.HexStringSpec
 
 /** Module for type representing message digests. */
 object digests {

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -3,7 +3,7 @@ package eu.timepit.refined.types
 import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedType, RefinedTypeOps}
 import eu.timepit.refined.collection.{MaxSize, NonEmpty}
-import eu.timepit.refined.string.{MatchesRegex, Trimmed}
+import eu.timepit.refined.string.{HexStringSpec, Trimmed}
 import shapeless.Witness
 
 /** Module for `String` refined types. */
@@ -71,9 +71,9 @@ object string {
     def trim(s: String): TrimmedString = Refined.unsafeApply(s.trim)
   }
 
-  /** A `String` representing a hexadecimal number */
-  type HexStringSpec = MatchesRegex[W.`"""^(([0-9a-f]+)|([0-9A-F]+))$"""`.T]
+  /** A `String` representing a hexadecimal number. */
   type HexString = String Refined HexStringSpec
+
   object HexString extends RefinedTypeOps[HexString, String]
 }
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -1,6 +1,5 @@
 package eu.timepit.refined.types
 
-import eu.timepit.refined.W
 import eu.timepit.refined.api.{Refined, RefinedType, RefinedTypeOps}
 import eu.timepit.refined.collection.{MaxSize, NonEmpty}
 import eu.timepit.refined.string.{HexStringSpec, Trimmed}


### PR DESCRIPTION
 I believe that this PR brings `HexStringSpec` in line with the layout used in refined. See for example `LetterOrDigit` in https://github.com/fthomas/refined/blob/0820276b7cc80390a7cec5ecb353507376167a7f/modules/core/shared/src/main/scala/eu/timepit/refined/char.scala