### PR TITLE
Add syntax module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ val gitPubUrl = s"https://github.com/$gitHubOwner/$projectName.git"
 val gitDevUrl = s"git@github.com:$gitHubOwner/$projectName.git"
 
 val catsVersion = "1.4.0"
+val contextualVersion = "1.1.0"
 val jsonpathVersion = "2.4.0"
 val macroParadiseVersion = "2.1.1"
 val pureconfigVersion = "0.10.0"
@@ -53,7 +54,8 @@ val moduleCrossPlatformMatrix = Map(
   "scalaz" -> List(JVMPlatform, JSPlatform, NativePlatform),
   "scodec" -> List(JVMPlatform, JSPlatform),
   "scopt" -> List(JVMPlatform, JSPlatform),
-  "shapeless" -> List(JVMPlatform, JSPlatform, NativePlatform)
+  "shapeless" -> List(JVMPlatform, JSPlatform, NativePlatform),
+  "syntax" -> List(JVMPlatform, JSPlatform, NativePlatform)
 )
 
 def allSubprojectsOf(platform: sbtcrossproject.Platform): List[String] =
@@ -255,6 +257,18 @@ lazy val shapeless = myCrossProject("shapeless")
 lazy val shapelessJVM = shapeless.jvm
 lazy val shapelessJS = shapeless.js
 lazy val shapelessNative = shapeless.native
+
+lazy val syntax = myCrossProject("syntax")
+  .dependsOn(core % "compile->compile;test->test")
+  .settings(
+    libraryDependencies += "com.propensive" %% "contextual" % contextualVersion,
+    crossScalaVersions += Scala213,
+    initialCommands += s"""
+      import $rootPkg.syntax._
+    """
+  )
+
+lazy val syntaxJVM = syntax.jvm
 
 /// settings
 
@@ -484,6 +498,7 @@ lazy val releaseSettings = {
       releaseStepCommand("scalazJS/publishSigned"),
       releaseStepCommand("shapelessJVM/publishSigned"),
       releaseStepCommand("shapelessJS/publishSigned"),
+      releaseStepCommand("syntaxJVM/publishSigned"),
       releaseStepCommand(s"++$Scala211"),
       releaseStepCommand("coreNative/publishSigned"),
       releaseStepCommand("scalazNative/publishSigned"),

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -7,4 +7,5 @@ bincompatVersions in ThisBuild := Set(
 unreleasedModules in ThisBuild := Set(
   // Example:
   // "refined-eval"
+  "refined-syntax"
 )

--- a/modules/syntax/jvm/src/main/scala/eu/timepit/refined/syntax/package.scala
+++ b/modules/syntax/jvm/src/main/scala/eu/timepit/refined/syntax/package.scala
@@ -1,0 +1,3 @@
+package eu.timepit.refined
+
+package object syntax extends NonEmptyStringSyntax with NonEmptyStringInterpolation

--- a/modules/syntax/jvm/src/main/scala/eu/timepit/refined/syntax/string.scala
+++ b/modules/syntax/jvm/src/main/scala/eu/timepit/refined/syntax/string.scala
@@ -1,0 +1,42 @@
+package eu.timepit.refined
+package syntax
+
+import contextual._
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.{NonEmptyString, TrimmedString}
+
+trait NonEmptyStringSyntax {
+  implicit class NonEmptyStringOps(nes: NonEmptyString) {
+    def *(n: Int): NonEmptyString = NonEmptyString.unsafeFrom(nes.value * n)
+    def +(s: String): NonEmptyString = NonEmptyString.unsafeFrom(nes.value + s)
+    def size: PosInt = PosInt.unsafeFrom(nes.value.size)
+    def trim: TrimmedString = TrimmedString.unsafeFrom(nes.value.trim)
+  }
+}
+
+trait NonEmptyStringInterpolation {
+  // $COVERAGE-OFF$ SCoverage does not report this correctly
+  implicit class NonEmptyStringContext(sc: StringContext) {
+    val nes = Prefix(NonEmptyStringInterpolation.NESInterpolator, sc)
+  }
+  // $COVERAGE-ON$
+}
+
+object NonEmptyStringInterpolation {
+  object NESInterpolator extends Interpolator {
+    type Output = NonEmptyString
+
+    def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = {
+      val lit @ Literal(_, s) = interpolation.parts.head
+      NonEmptyString
+        .from(s)
+        .fold(
+          _ => interpolation.abort(lit, 0, "The string was empty"),
+          _ => Nil
+        )
+    }
+
+    def evaluate(interpolation: RuntimeInterpolation): NonEmptyString =
+      NonEmptyString.unsafeFrom(interpolation.literals.head)
+  }
+}

--- a/modules/syntax/jvm/src/test/scala/eu/timepit/refined/syntax/Test.scala
+++ b/modules/syntax/jvm/src/test/scala/eu/timepit/refined/syntax/Test.scala
@@ -1,0 +1,33 @@
+package syntax.test
+
+import eu.timepit.refined.TestUtils.wellTyped
+import eu.timepit.refined.syntax._
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.{NonEmptyString, TrimmedString}
+import org.scalacheck.Properties
+import shapeless.test.illTyped
+
+object SyntaxSpec extends Properties("syntax") {
+  val nes: NonEmptyString = NonEmptyString.unsafeFrom("Hello World")
+
+  property("size") = wellTyped {
+    val s: PosInt = nes.size
+  }
+
+  property("+") = wellTyped {
+    val nes2: NonEmptyString = nes + "!"
+  }
+
+  property("*") = wellTyped {
+    val nes2: NonEmptyString = nes * 3
+  }
+
+  property("trim") = wellTyped {
+    val trimmed: TrimmedString = nes.trim
+  }
+
+  property("interpolator") = wellTyped {
+    val nes2: NonEmptyString = nes"Hello World"
+    illTyped("""val nes3: NonEmptyString = nes""""")
+  }
+}


### PR DESCRIPTION
I could have used this a lot today, so I am finally getting around to contributing a syntax module :)

Basically, these return refined types for a few methods on `NonEmptyString`.
Also, I added a string interpolator that creates `NonEmptyString`.

Anybody is welcome to add to this, I may provide more convenience syntax as I need it.

Notes: I know virtually nothing about Scala.js or Scala.Native. I created the cross-build targets but am unsure whether they should exist...

Edit: Removed Scaja.js and Scala.Native. Looks like the string interpolator does not work there