### PR TITLE
Added `NotNaN` predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ The library comes with these predefined predicates:
 * `NonDivisible[N]`: checks if an integral value is not evenly divisible by `N`
 * `Even`: checks if an integral value is evenly divisible by 2
 * `Odd`: checks if an integral value is not evenly divisible by 2
-* `NotNaN`: checks if a floating-point number is not NaN
+* `NonNaN`: checks if a floating-point number is not NaN
 
 [`string`](https://github.com/fthomas/refined/blob/master/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala)
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ The library comes with these predefined predicates:
 * `NonDivisible[N]`: checks if an integral value is not evenly divisible by `N`
 * `Even`: checks if an integral value is evenly divisible by 2
 * `Odd`: checks if an integral value is not evenly divisible by 2
+* `NotNaN`: checks if a floating-point number is not NaN
 
 [`string`](https://github.com/fthomas/refined/blob/master/modules/core/shared/src/main/scala/eu/timepit/refined/string.scala)
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -41,6 +41,9 @@ object numeric extends NumericInference {
   /** Predicate that checks if an integral value modulo `N` is `O`. */
   final case class Modulo[N, O](n: N, o: O)
 
+  /** Predicate that checks if a floating-point number value is not NaN. */
+  case class NotNaN()
+
   /** Predicate that checks if a numeric value is less than or equal to `N`. */
   type LessEqual[N] = Not[Greater[N]]
 
@@ -116,6 +119,14 @@ object numeric extends NumericInference {
         t => s"($t % ${wn.snd} == ${wo.snd})",
         Modulo(wn.fst, wo.fst)
       )
+  }
+
+  object NotNaN {
+    implicit def floatNotNaNValidate: Validate.Plain[Float, NotNaN] = fromIsNaN(_.isNaN)
+    implicit def doubleNotNaNValidate: Validate.Plain[Double, NotNaN] = fromIsNaN(_.isNaN)
+
+    def fromIsNaN[A](isNaN: A => Boolean): Validate.Plain[A, NotNaN] =
+      Validate.fromPredicate(x => !isNaN(x), x => s"$x != NaN", NotNaN())
   }
 }
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -42,7 +42,7 @@ object numeric extends NumericInference {
   final case class Modulo[N, O](n: N, o: O)
 
   /** Predicate that checks if a floating-point number value is not NaN. */
-  case class NotNaN()
+  final case class NonNaN()
 
   /** Predicate that checks if a numeric value is less than or equal to `N`. */
   type LessEqual[N] = Not[Greater[N]]
@@ -121,12 +121,12 @@ object numeric extends NumericInference {
       )
   }
 
-  object NotNaN {
-    implicit def floatNotNaNValidate: Validate.Plain[Float, NotNaN] = fromIsNaN(_.isNaN)
-    implicit def doubleNotNaNValidate: Validate.Plain[Double, NotNaN] = fromIsNaN(_.isNaN)
+  object NonNaN {
+    implicit def floatNonNaNValidate: Validate.Plain[Float, NonNaN] = fromIsNaN(_.isNaN)
+    implicit def doubleNonNaNValidate: Validate.Plain[Double, NonNaN] = fromIsNaN(_.isNaN)
 
-    def fromIsNaN[A](isNaN: A => Boolean): Validate.Plain[A, NotNaN] =
-      Validate.fromPredicate(x => !isNaN(x), x => s"$x != NaN", NotNaN())
+    def fromIsNaN[A](isNaN: A => Boolean): Validate.Plain[A, NonNaN] =
+      Validate.fromPredicate(x => !isNaN(x), x => s"($x != NaN)", NonNaN())
   }
 }
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/all.scala
@@ -1,6 +1,6 @@
 package eu.timepit.refined.predicates
 
-object all extends AllPredicates with AllPredicatesBinCompat1
+object all extends AllPredicates with AllPredicatesBinCompat1 with AllPredicatesBinCompat2
 
 trait AllPredicates
     extends BooleanPredicates
@@ -11,3 +11,5 @@ trait AllPredicates
     with StringPredicates
 
 trait AllPredicatesBinCompat1 extends StringPredicatesBinCompat1
+
+trait AllPredicatesBinCompat2 extends NumericPredicatesBinCompat1

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
@@ -38,6 +38,6 @@ trait NumericPredicates {
 }
 
 trait NumericPredicatesBinCompat1 {
-  final type NotNaN = refined.numeric.NotNaN
-  final val NotNaN = refined.numeric.NotNaN
+  final type NonNaN = refined.numeric.NonNaN
+  final val NonNaN = refined.numeric.NonNaN
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
@@ -2,7 +2,7 @@ package eu.timepit.refined.predicates
 
 import eu.timepit.refined
 
-object numeric extends NumericPredicates
+object numeric extends NumericPredicates with NumericPredicatesBinCompat1
 
 trait NumericPredicates {
   final type Less[N] = refined.numeric.Less[N]
@@ -13,9 +13,6 @@ trait NumericPredicates {
 
   final type Modulo[N, O] = refined.numeric.Modulo[N, O]
   final val Modulo = refined.numeric.Modulo
-
-  final type NotNaN = refined.numeric.NotNaN
-  final val NotNaN = refined.numeric.NotNaN
 
   final type LessEqual[N] = refined.numeric.LessEqual[N]
 
@@ -38,4 +35,9 @@ trait NumericPredicates {
   final type Odd = refined.numeric.Odd
 
   final val Interval = refined.numeric.Interval
+}
+
+trait NumericPredicatesBinCompat1 {
+  final type NotNaN = refined.numeric.NotNaN
+  final val NotNaN = refined.numeric.NotNaN
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/predicates/numeric.scala
@@ -14,6 +14,9 @@ trait NumericPredicates {
   final type Modulo[N, O] = refined.numeric.Modulo[N, O]
   final val Modulo = refined.numeric.Modulo
 
+  final type NotNaN = refined.numeric.NotNaN
+  final val NotNaN = refined.numeric.NotNaN
+
   final type LessEqual[N] = refined.numeric.LessEqual[N]
 
   final type GreaterEqual[N] = refined.numeric.GreaterEqual[N]

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/all.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/all.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined.types
 
 /** Module for all predefined refined types. */
-object all extends AllTypes with AllTypesBinCompat1
+object all extends AllTypes with AllTypesBinCompat1 with AllTypesBinCompat2
 
 trait AllTypes
     extends CharTypes
@@ -12,3 +12,5 @@ trait AllTypes
     with TimeTypes
 
 trait AllTypesBinCompat1 extends NumericTypesBinCompat1
+
+trait AllTypesBinCompat2 extends NumericTypesBinCompat2

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/numeric.scala
@@ -225,12 +225,6 @@ trait NumericTypes {
 
   final type NonPosDouble = numeric.NonPosDouble
   final val NonPosDouble = numeric.NonPosDouble
-
-  final type FloatNotNaN = numeric.FloatNotNaN
-  final val FloatNotNaN = numeric.FloatNotNaN
-
-  final type DoubleNotNaN = numeric.DoubleNotNaN
-  final val DoubleNotNaN = numeric.DoubleNotNaN
 }
 
 trait NumericTypesBinCompat1 {
@@ -281,4 +275,12 @@ trait NumericTypesBinCompat1 {
 
   final type NonPosBigDecimal = numeric.NonPosBigDecimal
   final val NonPosBigDecimal = numeric.NonPosBigDecimal
+}
+
+trait NumericTypesBinCompat2 {
+  final type FloatNotNaN = numeric.FloatNotNaN
+  final val FloatNotNaN = numeric.FloatNotNaN
+
+  final type DoubleNotNaN = numeric.DoubleNotNaN
+  final val DoubleNotNaN = numeric.DoubleNotNaN
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/numeric.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined.types
 
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
-import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, NotNaN, Positive}
+import eu.timepit.refined.numeric.{Negative, NonNaN, NonNegative, NonPositive, Positive}
 
 /** Module for numeric refined types. */
 object numeric {
@@ -167,14 +167,14 @@ object numeric {
   object NonPosBigDecimal extends RefinedTypeOps[NonPosBigDecimal, BigDecimal]
 
   /** A `Float` that is not NaN. */
-  type FloatNotNaN = Float Refined NotNaN
+  type NonNaNFloat = Float Refined NonNaN
 
-  object FloatNotNaN extends RefinedTypeOps[FloatNotNaN, Float]
+  object NonNaNFloat extends RefinedTypeOps[NonNaNFloat, Float]
 
   /** A `Double` that is not NaN. */
-  type DoubleNotNaN = Double Refined NotNaN
+  type NonNaNDouble = Double Refined NonNaN
 
-  object DoubleNotNaN extends RefinedTypeOps[DoubleNotNaN, Double]
+  object NonNaNDouble extends RefinedTypeOps[NonNaNDouble, Double]
 }
 
 trait NumericTypes {
@@ -278,9 +278,9 @@ trait NumericTypesBinCompat1 {
 }
 
 trait NumericTypesBinCompat2 {
-  final type FloatNotNaN = numeric.FloatNotNaN
-  final val FloatNotNaN = numeric.FloatNotNaN
+  final type NonNaNFloat = numeric.NonNaNFloat
+  final val NonNaNFloat = numeric.NonNaNFloat
 
-  final type DoubleNotNaN = numeric.DoubleNotNaN
-  final val DoubleNotNaN = numeric.DoubleNotNaN
+  final type NonNaNDouble = numeric.NonNaNDouble
+  final val NonNaNDouble = numeric.NonNaNDouble
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/numeric.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined.types
 
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
-import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, Positive}
+import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, NotNaN, Positive}
 
 /** Module for numeric refined types. */
 object numeric {
@@ -165,6 +165,16 @@ object numeric {
   type NonPosBigDecimal = BigDecimal Refined NonPositive
 
   object NonPosBigDecimal extends RefinedTypeOps[NonPosBigDecimal, BigDecimal]
+
+  /** A `Float` that is not NaN. */
+  type FloatNotNaN = Float Refined NotNaN
+
+  object FloatNotNaN extends RefinedTypeOps[FloatNotNaN, Float]
+
+  /** A `Double` that is not NaN. */
+  type DoubleNotNaN = Double Refined NotNaN
+
+  object DoubleNotNaN extends RefinedTypeOps[DoubleNotNaN, Double]
 }
 
 trait NumericTypes {
@@ -215,6 +225,12 @@ trait NumericTypes {
 
   final type NonPosDouble = numeric.NonPosDouble
   final val NonPosDouble = numeric.NonPosDouble
+
+  final type FloatNotNaN = numeric.FloatNotNaN
+  final val FloatNotNaN = numeric.FloatNotNaN
+
+  final type DoubleNotNaN = numeric.DoubleNotNaN
+  final val DoubleNotNaN = numeric.DoubleNotNaN
 }
 
 trait NumericTypesBinCompat1 {

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
@@ -2,8 +2,8 @@ package eu.timepit.refined
 
 import eu.timepit.refined.TestUtils._
 import eu.timepit.refined.numeric._
+import org.scalacheck.{Arbitrary, Gen, Properties}
 import org.scalacheck.Prop._
-import org.scalacheck.Properties
 import shapeless.nat._
 
 class NumericValidateSpec extends Properties("NumericValidate") {
@@ -179,4 +179,24 @@ class NumericValidateSpec extends Properties("NumericValidate") {
     val s = showExpr[Interval.Closed[_0, _1]](0.5)
     (s ?= "(!(0.5 < 0) && !(0.5 > 1))") || (s ?= "(!(0.5 < 0.0) && !(0.5 > 1.0))")
   }
+
+  val floatWithNaN: Gen[Float] = Gen.frequency(8 -> Arbitrary.arbitrary[Float], 2 -> Float.NaN)
+  val doubleWithNaN: Gen[Double] = Gen.frequency(8 -> Arbitrary.arbitrary[Double], 2 -> Double.NaN)
+
+  property("NotNaN.Float.isValid") = forAll(floatWithNaN) { (d: Float) =>
+    isValid[NotNaN](d) ?= !d.isNaN
+  }
+
+  property("NotNaN.Float.showExpr") = secure {
+    showExpr[NotNaN](Float.NaN) ?= "NaN != NaN"
+  }
+
+  property("NotNaN.Double.isValid") = forAll(doubleWithNaN) { (d: Double) =>
+    isValid[NotNaN](d) ?= !d.isNaN
+  }
+
+  property("NotNaN.Double.showExpr") = secure {
+    showExpr[NotNaN](Double.NaN) ?= "NaN != NaN"
+  }
+
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/NumericValidateSpec.scala
@@ -183,20 +183,20 @@ class NumericValidateSpec extends Properties("NumericValidate") {
   val floatWithNaN: Gen[Float] = Gen.frequency(8 -> Arbitrary.arbitrary[Float], 2 -> Float.NaN)
   val doubleWithNaN: Gen[Double] = Gen.frequency(8 -> Arbitrary.arbitrary[Double], 2 -> Double.NaN)
 
-  property("NotNaN.Float.isValid") = forAll(floatWithNaN) { (d: Float) =>
-    isValid[NotNaN](d) ?= !d.isNaN
+  property("NonNaN.Float.isValid") = forAll(floatWithNaN) { (d: Float) =>
+    isValid[NonNaN](d) ?= !d.isNaN
   }
 
-  property("NotNaN.Float.showExpr") = secure {
-    showExpr[NotNaN](Float.NaN) ?= "NaN != NaN"
+  property("NonNaN.Float.showExpr") = secure {
+    showExpr[NonNaN](Float.NaN) ?= "(NaN != NaN)"
   }
 
-  property("NotNaN.Double.isValid") = forAll(doubleWithNaN) { (d: Double) =>
-    isValid[NotNaN](d) ?= !d.isNaN
+  property("NonNaN.Double.isValid") = forAll(doubleWithNaN) { (d: Double) =>
+    isValid[NonNaN](d) ?= !d.isNaN
   }
 
-  property("NotNaN.Double.showExpr") = secure {
-    showExpr[NotNaN](Double.NaN) ?= "NaN != NaN"
+  property("NonNaN.Double.showExpr") = secure {
+    showExpr[NonNaN](Double.NaN) ?= "(NaN != NaN)"
   }
 
 }

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/all.scala
@@ -5,6 +5,7 @@ object all
     with CharInstances
     with GenericInstances
     with NumericInstances
+    with NumericInstancesBinCompat1
     with RefTypeInstances
     with StringInstances
     with StringInstancesBinCompat1

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -113,13 +113,13 @@ trait NumericInstances {
 }
 
 trait NumericInstancesBinCompat1 {
-  implicit def floatNotNaNArbitrary[F[_, _]: RefType](
+  implicit def floatNonNaNArbitrary[F[_, _]: RefType](
       implicit arb: Arbitrary[Float]
-  ): Arbitrary[F[Float, NotNaN]] =
-    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
+  ): Arbitrary[F[Float, NonNaN]] =
+    arbitraryRefType(arb.arbitrary.map(x => if (x.isNaN) 0.0f else x))
 
-  implicit def doubleNotNaNArbitrary[F[_, _]: RefType](
+  implicit def doubleNonNaNArbitrary[F[_, _]: RefType](
       implicit arb: Arbitrary[Double]
-  ): Arbitrary[F[Double, NotNaN]] =
-    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
+  ): Arbitrary[F[Double, NonNaN]] =
+    arbitraryRefType(arb.arbitrary.map(x => if (x.isNaN) 0.0d else x))
 }

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -57,6 +57,16 @@ trait NumericInstances {
   ): Arbitrary[F[T, GreaterEqual[N]]] =
     rangeClosedArbitrary(wn.snd, max.max)
 
+  implicit def floatNotNaNArbitrary[F[_, _]: RefType](
+      implicit arb: Arbitrary[Float]
+  ): Arbitrary[F[Float, NotNaN]] =
+    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
+
+  implicit def doubleNotNaNArbitrary[F[_, _]: RefType](
+      implicit arb: Arbitrary[Double]
+  ): Arbitrary[F[Double, NotNaN]] =
+    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
+
   ///
 
   implicit def intervalOpenArbitrary[F[_, _]: RefType, T: Numeric: Choose: Adjacent, L, H](

--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/numeric.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Gen.Choose
  * Module that provides `Arbitrary` instances and generators for
  * numeric predicates.
  */
-object numeric extends NumericInstances
+object numeric extends NumericInstances with NumericInstancesBinCompat1
 
 trait NumericInstances {
 
@@ -56,16 +56,6 @@ trait NumericInstances {
       wn: WitnessAs[N, T]
   ): Arbitrary[F[T, GreaterEqual[N]]] =
     rangeClosedArbitrary(wn.snd, max.max)
-
-  implicit def floatNotNaNArbitrary[F[_, _]: RefType](
-      implicit arb: Arbitrary[Float]
-  ): Arbitrary[F[Float, NotNaN]] =
-    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
-
-  implicit def doubleNotNaNArbitrary[F[_, _]: RefType](
-      implicit arb: Arbitrary[Double]
-  ): Arbitrary[F[Double, NotNaN]] =
-    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
 
   ///
 
@@ -120,4 +110,16 @@ trait NumericInstances {
       max: T
   ): Arbitrary[F[T, P]] =
     arbitraryRefType(Gen.chooseNum(min, max))
+}
+
+trait NumericInstancesBinCompat1 {
+  implicit def floatNotNaNArbitrary[F[_, _]: RefType](
+      implicit arb: Arbitrary[Float]
+  ): Arbitrary[F[Float, NotNaN]] =
+    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
+
+  implicit def doubleNotNaNArbitrary[F[_, _]: RefType](
+      implicit arb: Arbitrary[Double]
+  ): Arbitrary[F[Double, NotNaN]] =
+    arbitraryRefType(arb.arbitrary.suchThat(x => !x.isNaN))
 }

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -36,9 +36,9 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
 
   property("GreaterEqual[_10]") = checkArbitraryRefinedType[Int Refined GreaterEqual[_10]]
 
-  property("FloatNotNaN") = checkArbitraryRefinedType[FloatNotNaN]
+  property("NonNaNFloat") = checkArbitraryRefinedType[NonNaNFloat]
 
-  property("DoubleNotNaN") = checkArbitraryRefinedType[DoubleNotNaN]
+  property("NonNaNDouble") = checkArbitraryRefinedType[NonNaNDouble]
 
   property("PosFloat") = checkArbitraryRefinedType[PosFloat]
 

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/NumericArbitrarySpec.scala
@@ -4,7 +4,7 @@ import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.scalacheck.numeric._
-import eu.timepit.refined.types.numeric.{NegDouble, NonNegInt, NonNegLong, PosFloat}
+import eu.timepit.refined.types.numeric._
 import eu.timepit.refined.types.time.Minute
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
@@ -35,6 +35,10 @@ class NumericArbitrarySpec extends Properties("NumericArbitrary") {
   property("GreaterEqual[123]") = checkArbitraryRefinedType[Int Refined GreaterEqual[W.`-123`.T]]
 
   property("GreaterEqual[_10]") = checkArbitraryRefinedType[Int Refined GreaterEqual[_10]]
+
+  property("FloatNotNaN") = checkArbitraryRefinedType[FloatNotNaN]
+
+  property("DoubleNotNaN") = checkArbitraryRefinedType[DoubleNotNaN]
 
   property("PosFloat") = checkArbitraryRefinedType[PosFloat]
 


### PR DESCRIPTION
As previously discussed in the gitter channel.

There is some duplication for `Float` and `Double`, the only types with a NaN value. I've considered adding a `HasNaN[A]` typeclass to reduce duplication, but ultimately thought the complexity was unwarranted in this case. If the maintainers think otherwise, I'd happy to make this change though.