### PR TITLE
add semigroup and monoid instances for numeric types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,9 +100,12 @@ lazy val benchmark = project
   .settings(noPublishSettings)
 
 lazy val cats = myCrossProject("cats")
-  .dependsOn(core % "compile->compile;test->test")
+  .dependsOn(core % "compile->compile;test->test", scalacheck_1_13 % Test)
   .settings(
-    libraryDependencies += "org.typelevel" %%% "cats-core" % catsVersion,
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-core" % catsVersion,
+      "org.typelevel" %% "cats-testkit" % catsVersion % Test
+    ),
     initialCommands += s"""
       import $rootPkg.cats._
     """

--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/Shift.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/Shift.scala
@@ -1,0 +1,43 @@
+package eu.timepit.refined.cats
+
+/**
+ * Typeclass to shift Negative values to Non Negative values.
+ */
+private[cats] trait NonNegShift[T] extends Serializable {
+  def shift(t: T): T
+}
+
+private[cats] object NonNegShift {
+  def apply[T](implicit ev: NonNegShift[T]): NonNegShift[T] = ev
+
+  def instance[T](function: T => T): NonNegShift[T] = new NonNegShift[T] {
+    def shift(t: T): T = function(t)
+  }
+
+  // Instances
+  implicit val byteNonNegShift: NonNegShift[Byte] = instance(t => (t & Byte.MaxValue).toByte)
+  implicit val shortNonNegShift: NonNegShift[Short] = instance(t => (t & Short.MaxValue).toShort)
+  implicit val intNonNegShift: NonNegShift[Int] = instance(t => t & Int.MaxValue)
+  implicit val longNonNegShift: NonNegShift[Long] = instance(t => t & Long.MaxValue)
+}
+
+/**
+ * Typeclass to shift Positive values to Negative values.
+ */
+private[cats] trait NegShift[T] extends Serializable {
+  def shift(t: T): T
+}
+
+private[cats] object NegShift {
+  def apply[T](implicit ev: NegShift[T]): NegShift[T] = ev
+
+  def instance[T](function: T => T): NegShift[T] = new NegShift[T] {
+    def shift(t: T): T = function(t)
+  }
+
+  // Instances
+  implicit val byteNegShift: NegShift[Byte] = instance(t => (t | Byte.MinValue).toByte)
+  implicit val shortNegShift: NegShift[Short] = instance(t => (t | Short.MinValue).toShort)
+  implicit val intNegShift: NegShift[Int] = instance(t => t | Int.MinValue)
+  implicit val longNegShift: NegShift[Long] = instance(t => t | Long.MinValue)
+}

--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/package.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/package.scala
@@ -2,8 +2,10 @@ package eu.timepit.refined
 
 import _root_.cats.{Contravariant, MonadError, Show}
 import _root_.cats.implicits._
-import _root_.cats.kernel.{Eq, Order}
-import eu.timepit.refined.api.{RefType, Validate}
+import _root_.cats.kernel.{Eq, Monoid, Order, Semigroup}
+import eu.timepit.refined.api.{Refined, RefType, Validate}
+import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, Positive}
+import eu.timepit.refined.types.numeric._
 
 package object cats {
 
@@ -27,6 +29,91 @@ package object cats {
    */
   implicit def refTypeShow[F[_, _], T: Show, P](implicit rt: RefType[F]): Show[F[T, P]] =
     cats.derivation.refTypeViaContravariant[F, Show, T, P]
+
+  // Semigroup instances
+  implicit val posByteSemigroup: Semigroup[PosByte] = getPosIntegralSemigroup[Byte]
+  implicit val posShortSemigroup: Semigroup[PosShort] = getPosIntegralSemigroup[Short]
+  implicit val posIntSemigroup: Semigroup[PosInt] = getPosIntegralSemigroup[Int]
+  implicit val posLongSemigroup: Semigroup[PosLong] = getPosIntegralSemigroup[Long]
+  implicit val posFloatSemigroup: Semigroup[PosFloat] = getSemigroup[Float, Positive]
+  implicit val posDoubleSemigroup: Semigroup[PosDouble] = getSemigroup[Double, Positive]
+
+  implicit val negByteSemigroup: Semigroup[NegByte] = getNegIntegralSemigroup[Byte]
+  implicit val negShortSemigroup: Semigroup[NegShort] = getNegIntegralSemigroup[Short]
+  implicit val negIntSemigroup: Semigroup[NegInt] = getNegIntegralSemigroup[Int]
+  implicit val negLongSemigroup: Semigroup[NegLong] = getNegIntegralSemigroup[Long]
+  implicit val negFloatSemigroup: Semigroup[NegFloat] = getSemigroup[Float, Negative]
+  implicit val negDoubleSemigroup: Semigroup[NegDouble] = getSemigroup[Double, Negative]
+
+  // Monoid instances
+  implicit val nonNegByteMonoid: Monoid[NonNegByte] = getNonNegIntegralMonoid[Byte]
+  implicit val nonNegShortMonoid: Monoid[NonNegShort] = getNonNegIntegralMonoid[Short]
+  implicit val nonNegIntMonoid: Monoid[NonNegInt] = getNonNegIntegralMonoid[Int]
+  implicit val nonNegLongMonoid: Monoid[NonNegLong] = getNonNegIntegralMonoid[Long]
+  implicit val nonNegFloatMonoid: Monoid[NonNegFloat] = getMonoid[Float, NonNegative]
+  implicit val nonNegDoubleMonoid: Monoid[NonNegDouble] = getMonoid[Double, NonNegative]
+
+  implicit val nonPosFloatMonoid: Monoid[NonPosFloat] = getMonoid[Float, NonPositive]
+  implicit val nonPosDoubleMonoid: Monoid[NonPosDouble] = getMonoid[Double, NonPositive]
+
+  private def getPosIntegralSemigroup[A: Semigroup: NonNegShift](
+      implicit integral: Integral[A],
+      v: Validate[A, Positive]
+  ): Semigroup[A Refined Positive] =
+    Semigroup.instance { (x, y) =>
+      val combined: A = x.value |+| y.value
+
+      refineV[Positive](combined).getOrElse {
+        val result: A = Semigroup[A].combine(NonNegShift[A].shift(combined), integral.one)
+        refineV[Positive](result).right.get
+      }
+    }
+
+  private def getNegIntegralSemigroup[A: Integral: Semigroup: NegShift](
+      implicit v: Validate[A, Negative]
+  ): Semigroup[A Refined Negative] =
+    Semigroup.instance { (x, y) =>
+      val combined: A = x.value |+| y.value
+
+      refineV[Negative](combined).getOrElse {
+        val result: A = NegShift[A].shift(combined)
+        refineV[Negative](result).right.get
+      }
+    }
+
+  private def getSemigroup[A: Semigroup, P](
+      implicit v: Validate[A, P]
+  ): Semigroup[A Refined P] =
+    Semigroup.instance { (x, y) =>
+      refineV[P](x.value |+| y.value).right.get
+    }
+
+  private def getNonNegIntegralMonoid[A: Integral: Monoid: NonNegShift](
+      implicit v: Validate[A, NonNegative]
+  ): Monoid[A Refined NonNegative] = new Monoid[A Refined NonNegative] {
+    override def empty: A Refined NonNegative = refineV[NonNegative](Monoid[A].empty).right.get
+
+    override def combine(
+        x: A Refined NonNegative,
+        y: A Refined NonNegative
+    ): A Refined NonNegative = {
+      val combined: A = x.value |+| y.value
+
+      refineV[NonNegative](combined).getOrElse {
+        val result: A = NonNegShift[A].shift(combined)
+        refineV[NonNegative](result).right.get
+      }
+    }
+  }
+
+  private def getMonoid[A: Monoid, P](
+      implicit v: Validate[A, P]
+  ): Monoid[A Refined P] = new Monoid[A Refined P] {
+    override def empty: A Refined P = refineV[P](Monoid[A].empty).right.get
+
+    override def combine(x: A Refined P, y: A Refined P): A Refined P =
+      refineV[P](x.value |+| y.value).right.get
+  }
 
   @deprecated("Generic derivation instances have been moved into the `derivation` object", "0.9.4")
   def refTypeViaContravariant[F[_, _], G[_], T, P](

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/RefTypeMonadErrorSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/RefTypeMonadErrorSpec.scala
@@ -68,7 +68,7 @@ object Decoder {
 
 class RefTypeMonadErrorSpec extends Properties("MonadError") {
 
-  property("Deocder[Int]") = secure {
+  property("Decoder[Int]") = secure {
     Decoder[Int].decode("1") ?= Right(1)
   }
 

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SemigroupAndMonoidLawTests.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SemigroupAndMonoidLawTests.scala
@@ -1,0 +1,58 @@
+package eu.timepit.refined.cats
+
+import cats.kernel.{Monoid, Semigroup}
+import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests, SerializableTests}
+import cats.tests.CatsSuite
+import eu.timepit.refined.scalacheck.numeric._
+import eu.timepit.refined.types.numeric._
+
+class SemigroupAndMonoidLawTests extends CatsSuite {
+  // Positive semigroups
+  checkAll("Semigroup[PosByte]", SemigroupTests[PosByte].semigroup)
+  checkAll("Semigroup[PosByte]", SerializableTests.serializable(Semigroup[PosByte]))
+  checkAll("Semigroup[PosShort]", SemigroupTests[PosShort].semigroup)
+  checkAll("Semigroup[PosShort]", SerializableTests.serializable(Semigroup[PosShort]))
+  checkAll("Semigroup[PosInt]", SemigroupTests[PosInt].semigroup)
+  checkAll("Semigroup[PosInt]", SerializableTests.serializable(Semigroup[PosInt]))
+  checkAll("Semigroup[PosLong]", SemigroupTests[PosLong].semigroup)
+  checkAll("Semigroup[PosLong]", SerializableTests.serializable(Semigroup[PosLong]))
+  // checkAll("Semigroup[PosFloat]", SemigroupTests[PosFloat].semigroup) // approximately associative
+  checkAll("Semigroup[PosFloat]", SerializableTests.serializable(Semigroup[PosFloat]))
+  // checkAll("Semigroup[PosDouble]", SemigroupTests[PosDouble].semigroup) // approximately associative
+  checkAll("Semigroup[PosDouble]", SerializableTests.serializable(Semigroup[PosDouble]))
+
+  // Negative semigroups
+  checkAll("Semigroup[NegByte]", SemigroupTests[NegByte].semigroup)
+  checkAll("Semigroup[NegByte]", SerializableTests.serializable(Semigroup[NegByte]))
+  checkAll("Semigroup[NegShort]", SemigroupTests[NegShort].semigroup)
+  checkAll("Semigroup[NegShort]", SerializableTests.serializable(Semigroup[NegShort]))
+  checkAll("Semigroup[NegInt]", SemigroupTests[NegInt].semigroup)
+  checkAll("Semigroup[NegInt]", SerializableTests.serializable(Semigroup[NegInt]))
+  checkAll("Semigroup[NegLong]", SemigroupTests[NegLong].semigroup)
+  checkAll("Semigroup[NegLong]", SerializableTests.serializable(Semigroup[NegLong]))
+  // checkAll("Semigroup[NegFloat]", SemigroupTests[NegFloat].semigroup) // approximately associative
+  checkAll("Semigroup[NegFloat]", SerializableTests.serializable(Semigroup[NegFloat]))
+  // checkAll("Semigroup[NegDouble]", SemigroupTests[NegDouble].semigroup) // approximately associative
+  checkAll("Semigroup[NegDouble]", SerializableTests.serializable(Semigroup[NegDouble]))
+
+  // NonNegative monoids
+  checkAll("Monoid[NonNegByte]", MonoidTests[NonNegByte].monoid)
+  checkAll("Monoid[NonNegByte]", SerializableTests.serializable(Monoid[NonNegByte]))
+  checkAll("Monoid[NonNegShort]", MonoidTests[NonNegShort].monoid)
+  checkAll("Monoid[NonNegShort]", SerializableTests.serializable(Monoid[NonNegShort]))
+  checkAll("Monoid[NonNegInt]", MonoidTests[NonNegInt].monoid)
+  checkAll("Monoid[NonNegInt]", SerializableTests.serializable(Monoid[NonNegInt]))
+  checkAll("Monoid[NonNegLong]", MonoidTests[NonNegLong].monoid)
+  checkAll("Monoid[NonNegLong]", SerializableTests.serializable(Monoid[NonNegLong]))
+  // checkAll("Monoid[NonNegFloat]", MonoidTests[NonNegFloat].monoid) // approximately associative
+  checkAll("Monoid[NonNegFloat]", SerializableTests.serializable(Monoid[NonNegFloat]))
+  // checkAll("Monoid[NonNegDouble]", MonoidTests[NonNegDouble].monoid) // approximately associative
+  checkAll("Monoid[NonNegDouble]", SerializableTests.serializable(Monoid[NonNegDouble]))
+
+  // NonPositive monoids
+  // checkAll("Monoid[NonPosFloat]", MonoidTests[NonPosFloat].monoid) // approximately associative
+  checkAll("Monoid[NonPosFloat]", SerializableTests.serializable(Monoid[NonPosFloat]))
+  // checkAll("Monoid[NonPosDouble]", MonoidTests[NonPosDouble].monoid) // approximately associative
+  checkAll("Monoid[NonPosDouble]", SerializableTests.serializable(Monoid[NonPosDouble]))
+
+}

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SemigroupSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SemigroupSpec.scala
@@ -8,21 +8,21 @@ import org.scalacheck.Properties
 class SemigroupSpec extends Properties("Semigroup") {
 
   property("Positive Integral types overflow") =
-    secure { (PosByte.MaxValue |+| PosByte.unsafeFrom(1)) === PosByte.unsafeFrom(1) } &&
-      secure { (PosShort.MaxValue |+| PosShort.unsafeFrom(1)) === PosShort.unsafeFrom(1) } &&
-      secure { (PosInt.MaxValue |+| PosInt.unsafeFrom(1)) === PosInt.unsafeFrom(1) } &&
-      secure { (PosLong.MaxValue |+| PosLong.unsafeFrom(1)) === PosLong.unsafeFrom(1) }
+    secure { (PosByte.MaxValue |+| PosByte.unsafeFrom(1)) === PosByte.MinValue } &&
+      secure { (PosShort.MaxValue |+| PosShort.unsafeFrom(1)) === PosShort.MinValue } &&
+      secure { (PosInt.MaxValue |+| PosInt.unsafeFrom(1)) === PosInt.MinValue } &&
+      secure { (PosLong.MaxValue |+| PosLong.unsafeFrom(1)) === PosLong.MinValue }
 
   property("NonNegative Integral types overflow") =
-    secure { (NonNegByte.MaxValue |+| NonNegByte.unsafeFrom(1)) === NonNegByte.unsafeFrom(0) } &&
-      secure { (NonNegShort.MaxValue |+| NonNegShort.unsafeFrom(1)) === NonNegShort.unsafeFrom(0) } &&
-      secure { (NonNegInt.MaxValue |+| NonNegInt.unsafeFrom(1)) === NonNegInt.unsafeFrom(0) } &&
-      secure { (NonNegLong.MaxValue |+| NonNegLong.unsafeFrom(1)) === NonNegLong.unsafeFrom(0) }
+    secure { (NonNegByte.MaxValue |+| NonNegByte.unsafeFrom(1)) === NonNegByte.MinValue } &&
+      secure { (NonNegShort.MaxValue |+| NonNegShort.unsafeFrom(1)) === NonNegShort.MinValue } &&
+      secure { (NonNegInt.MaxValue |+| NonNegInt.unsafeFrom(1)) === NonNegInt.MinValue } &&
+      secure { (NonNegLong.MaxValue |+| NonNegLong.unsafeFrom(1)) === NonNegLong.MinValue }
 
   property("Negative Integral types overflow") =
-    secure { (NegByte.MinValue |+| NegByte.unsafeFrom(-1)) === NegByte.unsafeFrom(-1) } &&
-      secure { (NegShort.MinValue |+| NegShort.unsafeFrom(-1)) === NegShort.unsafeFrom(-1) } &&
-      secure { (NegInt.MinValue |+| NegInt.unsafeFrom(-1)) === NegInt.unsafeFrom(-1) } &&
-      secure { (NegLong.MinValue |+| NegLong.unsafeFrom(-1)) === NegLong.unsafeFrom(-1) }
+    secure { (NegByte.MinValue |+| NegByte.unsafeFrom(-1)) === NegByte.MaxValue } &&
+      secure { (NegShort.MinValue |+| NegShort.unsafeFrom(-1)) === NegShort.MaxValue } &&
+      secure { (NegInt.MinValue |+| NegInt.unsafeFrom(-1)) === NegInt.MaxValue } &&
+      secure { (NegLong.MinValue |+| NegLong.unsafeFrom(-1)) === NegLong.MaxValue }
 
 }

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SemigroupSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SemigroupSpec.scala
@@ -1,0 +1,28 @@
+package eu.timepit.refined.cats
+
+import cats.implicits._
+import eu.timepit.refined.types.numeric._
+import org.scalacheck.Prop.secure
+import org.scalacheck.Properties
+
+class SemigroupSpec extends Properties("Semigroup") {
+
+  property("Positive Integral types overflow") =
+    secure { (PosByte.MaxValue |+| PosByte.unsafeFrom(1)) === PosByte.unsafeFrom(1) } &&
+      secure { (PosShort.MaxValue |+| PosShort.unsafeFrom(1)) === PosShort.unsafeFrom(1) } &&
+      secure { (PosInt.MaxValue |+| PosInt.unsafeFrom(1)) === PosInt.unsafeFrom(1) } &&
+      secure { (PosLong.MaxValue |+| PosLong.unsafeFrom(1)) === PosLong.unsafeFrom(1) }
+
+  property("NonNegative Integral types overflow") =
+    secure { (NonNegByte.MaxValue |+| NonNegByte.unsafeFrom(1)) === NonNegByte.unsafeFrom(0) } &&
+      secure { (NonNegShort.MaxValue |+| NonNegShort.unsafeFrom(1)) === NonNegShort.unsafeFrom(0) } &&
+      secure { (NonNegInt.MaxValue |+| NonNegInt.unsafeFrom(1)) === NonNegInt.unsafeFrom(0) } &&
+      secure { (NonNegLong.MaxValue |+| NonNegLong.unsafeFrom(1)) === NonNegLong.unsafeFrom(0) }
+
+  property("Negative Integral types overflow") =
+    secure { (NegByte.MinValue |+| NegByte.unsafeFrom(-1)) === NegByte.unsafeFrom(-1) } &&
+      secure { (NegShort.MinValue |+| NegShort.unsafeFrom(-1)) === NegShort.unsafeFrom(-1) } &&
+      secure { (NegInt.MinValue |+| NegInt.unsafeFrom(-1)) === NegInt.unsafeFrom(-1) } &&
+      secure { (NegLong.MinValue |+| NegLong.unsafeFrom(-1)) === NegLong.unsafeFrom(-1) }
+
+}

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/ShiftSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/ShiftSpec.scala
@@ -1,0 +1,41 @@
+package eu.timepit.refined.cats
+
+import eu.timepit.refined.api.{Max, Min}
+import org.scalacheck.{Arbitrary, Prop, Properties}
+import org.scalacheck.Prop._
+
+class NonNegShiftSpec extends Properties("NonNegShift") {
+  def createProperty[A: Arbitrary: Min: NonNegShift](implicit num: Numeric[A]): Prop = {
+    import num.{abs, gteq, lt, plus, zero}
+
+    forAll { a: A =>
+      gteq(a, zero) ==> (NonNegShift[A].shift(a) == a)
+    } &&
+    forAll { a: A =>
+      lt(a, zero) ==> (NonNegShift[A].shift(a) == plus(a, abs(Min[A].min)))
+    }
+  }
+
+  property("shift Byte") = createProperty[Byte]
+  property("shift Short") = createProperty[Short]
+  property("shift Int") = createProperty[Int]
+  property("shift Long") = createProperty[Long]
+}
+
+class NegShiftSpec extends Properties("NegShift") {
+  def createProperty[A: Arbitrary: Max: NegShift](implicit num: Numeric[A]): Prop = {
+    import num.{gteq, lt, minus, one, zero}
+
+    forAll { a: A =>
+      lt(a, zero) ==> (NegShift[A].shift(a) == a)
+    } &&
+    forAll { a: A =>
+      gteq(a, zero) ==> (NegShift[A].shift(a) == minus(minus(a, Max[A].max), one))
+    }
+  }
+
+  property("shift Byte") = createProperty[Byte]
+  property("shift Short") = createProperty[Short]
+  property("shift Int") = createProperty[Int]
+  property("shift Long") = createProperty[Long]
+}


### PR DESCRIPTION
This merge request partially fixes https://github.com/fthomas/refined/issues/527. It adds:

- semigroup instances for Positive and Negative numeric types (Byte, Short, Int, Long, Float and Double)
- monoid instances for NonPosFloat, NonPosDouble and NonNegative numeric types (Byte, Short, Int, Long, Float and Double) 
- law tests for these instances. Law tests for Float and Double are commented (as done in [cats tests](https://github.com/typelevel/cats/blob/v1.6.0/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala#L218)), because floating point addition is not associative.

As discussed in https://github.com/fthomas/refined/issues/527, the instances overflow for Integral types.

FYI, I tried adding monoid instances for NonPositive Integral types, but they are not associative:
```
  implicit val nonPosByteMonoid: Monoid[NonPosByte] = getNonPosIntegralMonoid[Byte]
  implicit val nonPosShortMonoid: Monoid[NonPosShort] = getNonPosIntegralMonoid[Short]
  implicit val nonPosIntMonoid: Monoid[NonPosInt] = getNonPosIntegralMonoid[Int]
  implicit val nonPosLongMonoid: Monoid[NonPosLong] = getNonPosIntegralMonoid[Long]

  private def getNonPosIntegralMonoid[A: Integral: Monoid: NegShift](
      implicit v: Validate[A, NonPositive]
  ): Monoid[A Refined NonPositive] = new Monoid[A Refined NonPositive] {
    override def empty: A Refined NonPositive = refineV[NonPositive](Monoid[A].empty).right.get

    override def combine(
        x: A Refined NonPositive,
        y: A Refined NonPositive
    ): A Refined NonPositive = {
      val combined: A = x.value |+| y.value

      refineV[NonPositive](combined).getOrElse {
        val result: A = NegShift[A].shift(combined) |+| implicitly[Integral[A]].one
        refineV[NonPositive](result).right.get
      }
    }
  }
```

Example of failed test for Monoid[NonPosByte] : 
```
[info] - Monoid[NonPosByte].monoid.associative *** FAILED ***
[info]   GeneratorDrivenPropertyCheckFailedException was thrown during property evaluation.
[info]    (Discipline.scala:14)
[info]     Falsified after 25 successful property evaluations.
[info]     Location: (Discipline.scala:14)
[info]     Occurred when passed generated values (
[info]       arg0 = -1,
[info]       arg1 = -128,
[info]       arg2 = -128
[info]     )
[info]     Label of failing property:
[info]       Expected: -1
[info]   Received: -128
```