### PR TITLE
Cats validatenec

### DIFF
--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
@@ -1,6 +1,6 @@
 package eu.timepit.refined.cats
 
-import cats.data.{NonEmptyList, ValidatedNel, ValidatedNec}
+import cats.data.{NonEmptyList, ValidatedNec, ValidatedNel}
 import cats.syntax.either._
 import eu.timepit.refined.api.RefinedTypeOps
 import eu.timepit.refined.types.numeric.PosInt
@@ -9,11 +9,11 @@ object syntax extends CatsRefinedTypeOpsSyntax with CatsNonEmptyListSyntax
 
 trait CatsRefinedTypeOpsSyntax {
   implicit class CatsRefinedTypeOps[FTP, T](rtOps: RefinedTypeOps[FTP, T]) {
-    def validateNel(t: T): ValidatedNel[String, FTP] =
-      rtOps.from(t).toValidatedNel
-    
     def validateNec(t: T): ValidatedNec[String, FTP] =
       rtOps.from(t).toValidatedNec
+
+    def validateNel(t: T): ValidatedNel[String, FTP] =
+      rtOps.from(t).toValidatedNel
   }
 }
 

--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
@@ -9,6 +9,9 @@ object syntax extends CatsRefinedTypeOpsSyntax with CatsNonEmptyListSyntax
 
 trait CatsRefinedTypeOpsSyntax {
   implicit class CatsRefinedTypeOps[FTP, T](rtOps: RefinedTypeOps[FTP, T]) {
+    def validate(t: T): ValidatedNel[String, FTP] =
+      validateNel(t)
+
     def validateNec(t: T): ValidatedNec[String, FTP] =
       rtOps.from(t).toValidatedNec
 

--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/syntax.scala
@@ -1,6 +1,6 @@
 package eu.timepit.refined.cats
 
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.{NonEmptyList, ValidatedNel, ValidatedNec}
 import cats.syntax.either._
 import eu.timepit.refined.api.RefinedTypeOps
 import eu.timepit.refined.types.numeric.PosInt
@@ -9,8 +9,11 @@ object syntax extends CatsRefinedTypeOpsSyntax with CatsNonEmptyListSyntax
 
 trait CatsRefinedTypeOpsSyntax {
   implicit class CatsRefinedTypeOps[FTP, T](rtOps: RefinedTypeOps[FTP, T]) {
-    def validate(t: T): ValidatedNel[String, FTP] =
+    def validateNel(t: T): ValidatedNel[String, FTP] =
       rtOps.from(t).toValidatedNel
+    
+    def validateNec(t: T): ValidatedNec[String, FTP] =
+      rtOps.from(t).toValidatedNec
   }
 }
 

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SyntaxSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SyntaxSpec.scala
@@ -26,7 +26,7 @@ class SyntaxSpec extends Properties("syntax") {
     object OneToTen extends RefinedTypeOps[OneToTen, Int] with CatsRefinedTypeOpsSyntax
     OneToTen.validateNel(5) ?= Validated.valid(OneToTen.unsafeFrom(5))
   }
-  
+
   property("ValidateNec when Valid") = secure {
     import syntax._
     PosInt.validateNec(5) ?= Validated.Valid(PosInt.unsafeFrom(5))

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SyntaxSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/SyntaxSpec.scala
@@ -11,20 +11,36 @@ import org.scalacheck.Properties
 
 class SyntaxSpec extends Properties("syntax") {
 
-  property("Validate when Valid") = secure {
+  property("ValidateNel when Valid") = secure {
     import syntax._
-    PosInt.validate(5) ?= Validated.Valid(PosInt.unsafeFrom(5))
+    PosInt.validateNel(5) ?= Validated.Valid(PosInt.unsafeFrom(5))
   }
 
-  property("Validate when Invalid") = secure {
+  property("ValidateNel when Invalid") = secure {
     import syntax._
-    PosInt.validate(-1) ?= Validated.invalidNel("Predicate failed: (-1 > 0).")
+    PosInt.validateNel(-1) ?= Validated.invalidNel("Predicate failed: (-1 > 0).")
   }
 
-  property("validate without import") = secure {
+  property("validateNel without import") = secure {
     type OneToTen = Int Refined Interval.Closed[W.`1`.T, W.`10`.T]
     object OneToTen extends RefinedTypeOps[OneToTen, Int] with CatsRefinedTypeOpsSyntax
-    OneToTen.validate(5) ?= Validated.valid(OneToTen.unsafeFrom(5))
+    OneToTen.validateNel(5) ?= Validated.valid(OneToTen.unsafeFrom(5))
+  }
+  
+  property("ValidateNec when Valid") = secure {
+    import syntax._
+    PosInt.validateNec(5) ?= Validated.Valid(PosInt.unsafeFrom(5))
+  }
+
+  property("ValidateNec when Invalid") = secure {
+    import syntax._
+    PosInt.validateNec(-1) ?= Validated.invalidNec("Predicate failed: (-1 > 0).")
+  }
+
+  property("validateNec without import") = secure {
+    type OneToTen = Int Refined Interval.Closed[W.`1`.T, W.`10`.T]
+    object OneToTen extends RefinedTypeOps[OneToTen, Int] with CatsRefinedTypeOpsSyntax
+    OneToTen.validateNec(5) ?= Validated.valid(OneToTen.unsafeFrom(5))
   }
 
   property("NonEmptyList refinedSize (1)") = secure {


### PR DESCRIPTION
I think it may be useful _(at least it is for me 😅)_.

Uhm, I just realized that the rename from `validate` to `validateNel` would break existing code...
Would you want me to leave it as `validate`, or keep both `validate` & `validateNel` _(maybe in a future deprecate the first?)_.