### PR TITLE
Do not use self type in Validate

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
@@ -9,7 +9,7 @@ import scala.util.control.NonFatal
  * predicate `P`. The semantics of `P` are defined by the instance(s) of
  * this type class for `P`.
  */
-trait Validate[T, P] extends Serializable { self =>
+trait Validate[T, P] extends Serializable {
 
   type R
 
@@ -38,7 +38,8 @@ trait Validate[T, P] extends Serializable { self =>
   def accumulateShowExpr(t: T): List[String] =
     List(showExpr(t))
 
-  private[refined] def contramap[U](f: U => T): Validate.Aux[U, P, R] =
+  private[refined] def contramap[U](f: U => T): Validate.Aux[U, P, R] = {
+    val self: Validate.Aux[T, P, R] = this
     new Validate[U, P] {
       override type R = self.R
       override def validate(u: U): Res = self.validate(f(u))
@@ -46,6 +47,7 @@ trait Validate[T, P] extends Serializable { self =>
       override def showResult(u: U, r: Res): String = self.showResult(f(u), r)
       override def accumulateShowExpr(u: U): List[String] = self.accumulateShowExpr(f(u))
     }
+  }
 }
 
 object Validate {

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
@@ -2,7 +2,6 @@ package eu.timepit.refined.macros
 
 import eu.timepit.refined.api.{Refined, RefType}
 import scala.reflect.macros.blackbox
-import scala.util.{Success, Try}
 import shapeless.tag.@@
 
 trait MacroUtils {
@@ -16,14 +15,8 @@ trait MacroUtils {
     // Duplicate and untypecheck before calling `eval`, see:
     // http://www.scala-lang.org/api/2.12.0/scala-reflect/scala/reflect/macros/Evals.html#eval[T]%28expr:Evals.this.Expr[T]%29:T
     val expr = c.Expr[T](c.untypecheck(t.tree.duplicate))
-
-    // Try evaluating expr twice before failing, see
-    // https://github.com/fthomas/refined/issues/3
-    tryN(2, c.eval(expr))
+    c.eval(expr)
   }
-
-  def tryN[T](n: Int, t: => T): T =
-    Stream.fill(n)(Try(t)).collectFirst { case Success(r) => r }.getOrElse(t)
 
   protected def refTypeInstance[F[_, _]](rt: c.Expr[RefType[F]]): RefType[F] =
     if (rt.tree.tpe =:= weakTypeOf[RefType[Refined]])

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
@@ -2,6 +2,7 @@ package eu.timepit.refined.macros
 
 import eu.timepit.refined.api.{Refined, RefType}
 import scala.reflect.macros.blackbox
+import scala.util.{Success, Try}
 import shapeless.tag.@@
 
 trait MacroUtils {
@@ -17,6 +18,9 @@ trait MacroUtils {
     val expr = c.Expr[T](c.untypecheck(t.tree.duplicate))
     c.eval(expr)
   }
+
+  def tryN[T](n: Int, t: => T): T =
+    Stream.fill(n)(Try(t)).collectFirst { case Success(r) => r }.getOrElse(t)
 
   protected def refTypeInstance[F[_, _]](rt: c.Expr[RefType[F]]): RefType[F] =
     if (rt.tree.tpe =:= weakTypeOf[RefType[Refined]])

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/MacroUtils.scala
@@ -16,7 +16,10 @@ trait MacroUtils {
     // Duplicate and untypecheck before calling `eval`, see:
     // http://www.scala-lang.org/api/2.12.0/scala-reflect/scala/reflect/macros/Evals.html#eval[T]%28expr:Evals.this.Expr[T]%29:T
     val expr = c.Expr[T](c.untypecheck(t.tree.duplicate))
-    c.eval(expr)
+
+    // Try evaluating expr twice before failing, see
+    // https://github.com/fthomas/refined/issues/3
+    tryN(2, c.eval(expr))
   }
 
   def tryN[T](n: Int, t: => T): T =


### PR DESCRIPTION
This change might prevent the compiler crash reported in #260 by removing the self type in `Validate` (see https://github.com/fthomas/refined/issues/260#issuecomment-574623965). Since I haven't been able to reproduce or even observe the crash in #260, I can't say if this actually improves anything.
