### PR TITLE
WIP: Validator trait modification proposal

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/Validate.scala
@@ -17,11 +17,19 @@ trait Validate[T, P] extends Serializable {
 
   def validate(t: T): Res
 
-  /** Returns a string representation of this `[[Validate]]` using `t`. */
-  def showExpr(t: T): String
+  /** Get `t` string representation. */
+  def serializeValue(t: T): String
+
+  /** Returns a string representation of this `[[Validate]]` using `t` string representation. */
+  def constructExpr(valueString: String): String
+
+  final def description: String = constructExpr("x")
 
   def showResult(t: T, r: Res): String =
     Resources.predicateResultDetailDot(r, showExpr(t))
+
+  /** Returns a string representation of this `[[Validate]]` using `t`. */
+  final def showExpr(t: T): String = constructExpr(serializeValue(t))
 
   /** Checks if `t` satisfies the predicate `P`. */
   final def isValid(t: T): Boolean =
@@ -43,7 +51,8 @@ trait Validate[T, P] extends Serializable {
     new Validate[U, P] {
       override type R = self.R
       override def validate(u: U): Res = self.validate(f(u))
-      override def showExpr(u: U): String = self.showExpr(f(u))
+      override def constructExpr(uString: String): String = self.constructExpr(uString)
+      override def serializeValue(u: U): String = self.serializeValue(f(u))
       override def showResult(u: U, r: Res): String = self.showResult(f(u), r)
       override def accumulateShowExpr(u: U): List[String] = self.accumulateShowExpr(f(u))
     }
@@ -59,27 +68,30 @@ object Validate {
   def apply[T, P](implicit v: Validate[T, P]): Aux[T, P, v.R] = v
 
   /** Constructs a `[[Validate]]` from its parameters. */
-  def instance[T, P, R0](f: T => Result[R0], g: T => String): Aux[T, P, R0] =
+  def instance[T, P, R0](f: T => Result[R0], serializer: T => String, expr: String => String): Aux[T, P, R0] =
     new Validate[T, P] {
       override type R = R0
       override def validate(t: T): Res = f(t)
-      override def showExpr(t: T): String = g(t)
+      override def serializeValue(t: T): String = expr(t)
+      override def constructExpr(valueString: String): String = expr(valueString)
     }
 
   /** Constructs a constant `[[Validate]]` from its parameters. */
   def constant[T, P, R](isValidV: Result[R], showV: String): Aux[T, P, R] =
-    instance(_ => isValidV, _ => showV)
+    instance(_ => isValidV, _ => "will not be used", _ => showV)
 
   /**
    * Constructs a `[[Validate]]` from the predicate `f`. All values of type
    * `T` for which `f` returns `true` are considered valid according to `P`.
    */
-  def fromPredicate[T, P](f: T => Boolean, showExpr: T => String, p: P): Plain[T, P] = {
-    val g = showExpr
+  def fromPredicate[T, P](f: T => Boolean, serializeValue: T => String, constructExpr: String => String, p: P): Plain[T, P] = {
+    val g = serializeValue
+    val h = constructExpr
     new Validate[T, P] {
       override type R = P
       override def validate(t: T): Res = Result.fromBoolean(f(t), p)
-      override def showExpr(t: T): String = g(t)
+      override def serializeValue(t: T): String = g(t)
+      override def constructExpr(tString: String): String = h(tString)
     }
   }
 
@@ -99,8 +111,10 @@ object Validate {
           case NonFatal(_) => Failed(p)
         }
 
-      override def showExpr(t: T): String =
-        Resources.isValidName(name, t)
+      override def constructExpr(tString: String): String =
+        Resources.isValidName(name, tString)
+
+      override def serializeValue(t: T): String = s"$t"
 
       override def showResult(t: T, res: Res): String =
         Resources.namePredicateResultMessage(name, res, Try(pf(t)))


### PR DESCRIPTION
While doing this PR for Tapir: https://github.com/softwaremill/tapir/pull/405.
I realize it would be great to be able to serialize a validator without having to run it again a concrete value.

For that I think we could just use showRepr by replacing `t` by "x".

In order to do that, it would need a lot of change.
Before doing all of them, here a work in progress PR.

Tell me what you think about it.