### PR TITLE
fix StringValidateSpecJvm in another locale

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -304,6 +304,8 @@ lazy val moduleCrossSettings = Def.settings(
 
 def moduleJvmSettings(name: String): Seq[Def.Setting[_]] = Def.settings(
   scalaVersion := Scala212,
+  javaOptions ++= Seq("-Duser.language=en"),
+  Test / fork := true,
   crossScalaVersions := moduleCrossScalaVersionsMatrix(name, JVMPlatform),
   mimaPreviousArtifacts := {
     val hasPredecessor = !unreleasedModules.value.contains(moduleName.value)


### PR DESCRIPTION
if set `-Duser.language=ja`

https://travis-ci.org/xuwei-k/refined/jobs/657092376#L1887

```
failing seed for StringValidate.Xml.showResult is JM9OWVbVeuRDnptFtOfwU-0lbs8XXj59Gu7jiF0R7GE=
[info] ! StringValidate.Xml.showResult: Falsified after 0 passed tests.
[info] > Labels of failing property: 
[info] Expected "Xml predicate failed: XML document structures must start and end within the same entity." but got "Xml predicate failed: XMLドキュメント構造は、同じエンティティ内で開始および終了する必要があります。"
[info] + StringValidate.XPath.isValid: OK, proved property.
failing seed for StringValidate.XPath.showResult is -xPWjCC6cDN_IQGuY7bnJFPE5wzl9KeRsUkycqsB0pN=
[info] ! StringValidate.XPath.showResult: Falsified after 0 passed tests.
[info] > Labels of failing property: 
[info] Expected "XPath predicate failed: javax.xml.transform.TransformerException: Expected ], but found: " but got "XPath predicate failed: javax.xml.transform.TransformerException: ]ではなくが検出されました"
```