### PR TITLE
Support scala.js 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
     script:
     - sbt ++$TRAVIS_SCALA_VERSION validateJVM &&
       sbt ++$TRAVIS_SCALA_VERSION validateJS
+    - SCALAJS_VERSION=0.6.32 sbt ++$TRAVIS_SCALA_VERSION clean validateJS
     after_success:
     - codecov
 
@@ -38,9 +39,12 @@ jobs:
     script:
     - sbt ++$TRAVIS_SCALA_VERSION testJVM213 &&
       sbt ++$TRAVIS_SCALA_VERSION testJS213
+    - SCALAJS_VERSION=0.6.32 sbt ++$TRAVIS_SCALA_VERSION clean validateJS
 
   - stage: release
-    script: sbt ci-release
+    script:
+    - sbt ci-release
+    - SCALAJS_VERSION=0.6.32 sbt ci-release
 
 notifications:
   webhooks:

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossProject
 import sbtcrossproject.Platform
 
 /// variables
-
+val scalaJSVersion06 = Option(System.getenv("SCALAJS_VERSION")).exists(_.startsWith("0.6"))
 val groupId = "eu.timepit"
 val projectName = "refined"
 val rootPkg = s"$groupId.$projectName"
@@ -316,7 +316,8 @@ def moduleJvmSettings(name: String): Seq[Def.Setting[_]] = Def.settings(
       ProblemFilters.exclude[DirectMissingMethodProblem]("eu.timepit.refined.api.Max.findValid"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("eu.timepit.refined.api.Min.findValid")
     )
-  }
+  },
+  skip.in(publish) := scalaJSVersion06
 )
 
 def moduleJsSettings(name: String): Seq[Def.Setting[_]] = Def.settings(

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val shapelessVersion = "2.3.3"
 val scalaCheckVersion = "1.14.3"
 val scalaXmlVersion = "1.2.0"
 val scalazVersion = "7.2.28"
-val scodecVersion = "1.11.4"
+val scodecVersion = "1.11.6"
 val scoptVersion = "3.7.1"
 
 def macroParadise(configuration: Configuration): Def.Initialize[Seq[ModuleID]] = Def.setting {
@@ -48,9 +48,9 @@ val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
   "jsonpath" -> List(JVMPlatform),
   "pureconfig" -> List(JVMPlatform),
   "scalacheck" -> List(JVMPlatform, JSPlatform),
-  "scalaz" -> List(JVMPlatform, JSPlatform),
+  // "scalaz" -> List(JVMPlatform, JSPlatform),
   "scodec" -> List(JVMPlatform, JSPlatform),
-  "scopt" -> List(JVMPlatform, JSPlatform),
+  // "scopt" -> List(JVMPlatform, JSPlatform),
   "shapeless" -> List(JVMPlatform, JSPlatform)
 )
 
@@ -193,19 +193,19 @@ lazy val scalacheck = myCrossProject("scalacheck")
 lazy val scalacheckJVM = scalacheck.jvm
 lazy val scalacheckJS = scalacheck.js
 
-lazy val scalaz = myCrossProject("scalaz")
-  .dependsOn(core % "compile->compile;test->test")
-  .settings(
-    libraryDependencies += "org.scalaz" %%% "scalaz-core" % scalazVersion,
-    initialCommands += s"""
-      import $rootPkg.scalaz._
-      import $rootPkg.scalaz.auto._
-      import _root_.scalaz.@@
-    """
-  )
-
-lazy val scalazJVM = scalaz.jvm
-lazy val scalazJS = scalaz.js
+// lazy val scalaz = myCrossProject("scalaz")
+//   .dependsOn(core % "compile->compile;test->test")
+//   .settings(
+//     libraryDependencies += "org.scalaz" %%% "scalaz-core" % scalazVersion,
+//     initialCommands += s"""
+//       import $rootPkg.scalaz._
+//       import $rootPkg.scalaz.auto._
+//       import _root_.scalaz.@@
+//     """
+//   )
+//
+// lazy val scalazJVM = scalaz.jvm
+// lazy val scalazJS = scalaz.js
 
 lazy val scodec = myCrossProject("scodec")
   .dependsOn(core % "compile->compile;test->test")
@@ -222,19 +222,16 @@ lazy val scodec = myCrossProject("scodec")
 lazy val scodecJVM = scodec.jvm
 lazy val scodecJS = scodec.js
 
-lazy val scopt = myCrossProject("scopt")
-  .dependsOn(core % "compile->compile;test->test")
-  .settings(
-    libraryDependencies ++= macroParadise(Test).value ++ Seq(
-      "com.github.scopt" %%% "scopt" % scoptVersion
-    )
-  )
-  // This is required by scopt (which uses the 'os' modue), although I'm not 100% sure what other potential side effects
-  // this might have.
-  .jsSettings(scalaJSModuleKind := ModuleKind.CommonJSModule)
-
-lazy val scoptJVM = scopt.jvm
-lazy val scoptJS = scopt.js
+// lazy val scopt = myCrossProject("scopt")
+//   .dependsOn(core % "compile->compile;test->test")
+//   .settings(
+//     libraryDependencies ++= macroParadise(Test).value ++ Seq(
+//       "com.github.scopt" %%% "scopt" % scoptVersion
+//     )
+//   )
+//
+// lazy val scoptJVM = scopt.jvm
+// lazy val scoptJS = scopt.js
 
 lazy val shapeless = myCrossProject("shapeless")
   .dependsOn(core % "compile->compile;test->test")
@@ -464,10 +461,10 @@ addCommandsAlias(
   Seq(
     "clean",
     "fmtCheck",
-    "coverage",
+    // "coverage",
     "mimaReportBinaryIssues",
     "testJVM",
-    "coverageReport",
+    // "coverageReport",
     "doc",
     "docs/tut",
     "package",

--- a/build.sbt
+++ b/build.sbt
@@ -199,10 +199,10 @@ lazy val scalaz = myCrossProject("scalaz")
   .settings(
     libraryDependencies += "org.scalaz" %%% "scalaz-core" % scalazVersion,
     initialCommands += s"""
-       import $rootPkg.scalaz._
-       import $rootPkg.scalaz.auto._
-       import _root_.scalaz.@@
-     """
+      import $rootPkg.scalaz._
+      import $rootPkg.scalaz.auto._
+      import _root_.scalaz.@@
+    """
   )
   .jsSettings(disabledWhenScalaJS10)
 

--- a/build.sbt
+++ b/build.sbt
@@ -231,6 +231,7 @@ lazy val scopt = myCrossProject("scopt")
       "com.github.scopt" %%% "scopt" % scoptVersion
     )
   )
+  .jsSettings(scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) })
   .jsSettings(disabledWhenScalaJS10)
 
 lazy val scoptJVM = scopt.jvm

--- a/modules/scodec/shared/src/test/scala/eu/timepit/refined/scodec/RefTypeCodecSpec.scala
+++ b/modules/scodec/shared/src/test/scala/eu/timepit/refined/scodec/RefTypeCodecSpec.scala
@@ -17,25 +17,25 @@ class RefTypeCodecSpec extends Properties("RefTypeCodec") {
   implicit val intCodec = int8
 
   property("decode success") = secure {
-    Codec[PosInt].decode(bin"00000101") ?=
+    Codec.summon[PosInt].decode(bin"00000101") ?=
       Attempt.successful(DecodeResult(5: PosInt, BitVector.empty))
   }
 
   property("decode failure") = secure {
-    Codec[PosInt].decode(bin"10000101") ?=
+    Codec.summon[PosInt].decode(bin"10000101") ?=
       Attempt.failure(Err("Predicate failed: (-123 > 0)."))
   }
 
   property("encode success") = secure {
-    Codec[PosInt].encode(5) ?=
+    Codec.summon[PosInt].encode(5) ?=
       Attempt.successful(bin"00000101")
   }
 
   property("encode failure") = wellTyped {
-    illTyped("""Codec[PosInt].encode(-5)""", "Predicate failed.*")
+    illTyped("""Codec.summon[PosInt].encode(-5)""", "Predicate failed.*")
   }
 
   property("sizeBound") = secure {
-    Codec[PosInt].sizeBound ?= intCodec.sizeBound
+    Codec.summon[PosInt].sizeBound ?= intCodec.sizeBound
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,11 +12,14 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+// addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
 


### PR DESCRIPTION
This PR contains fixes to partially support Scala.js 1.0.0
There are some important notes
`scalaz` and `scopt` are ommited. The first requires some code changes and the second has a conflict on the way the `OS` object is used that conflicts with scala.js
`scoverage` was disabled as well
It should be possible to run this on 0.6.32 and dual release
How is release handled?