### PR TITLE
Fix #755 - expose Implies[P,C] variation of Inference[P,C]

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/macros/InferMacro.scala
@@ -1,5 +1,6 @@
 package eu.timepit.refined.macros
 
+import eu.timepit.refined.api.Implies
 import eu.timepit.refined.api.Inference.==>
 import eu.timepit.refined.api.RefType
 import eu.timepit.refined.internal.Resources
@@ -19,5 +20,13 @@ class InferMacro(val c: blackbox.Context) extends MacroUtils {
     }
 
     refTypeInstance(rt).unsafeRewrapM(c)(ta)
+  }
+
+  def implies[A: c.WeakTypeTag, B: c.WeakTypeTag](ir: c.Expr[A ==> B]): c.Expr[Implies[A, B]] = {
+    val inference = eval(ir)
+    if (inference.notValid) {
+      abort(Resources.invalidInference(weakTypeOf[A].toString, weakTypeOf[B].toString))
+    }
+    Implies.manifest(c)(ir)
   }
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/AutoSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/AutoSpec.scala
@@ -1,9 +1,10 @@
 package eu.timepit.refined
 
-import eu.timepit.refined.api.Refined
+import eu.timepit.refined.api.{Implies, Refined}
 import eu.timepit.refined.auto._
 import eu.timepit.refined.char.{Digit, Letter}
 import eu.timepit.refined.generic._
+import eu.timepit.refined.numeric.{Greater}
 import eu.timepit.refined.types.numeric.PosInt
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
@@ -20,6 +21,15 @@ class AutoSpec extends Properties("auto") {
       """type mismatch \(invalid inference\):\s*eu.timepit.refined.generic.Equal\[Char\('0'\)\] does not imply\s*eu.timepit.refined.char.Letter"""
     )
     a == b
+  }
+
+  property("autoImply") = secure {
+    val t = implicitly[Implies[Greater[W.`1`.T], Greater[W.`0`.T]]]
+    illTyped(
+      "implicitly[Implies[Greater[W.`-1`.T], Greater[W.`0`.T]]]",
+      """type mismatch \(invalid inference\):\s*eu.timepit.refined.numeric.Greater\[Int\(-1\)\] does not imply\s*eu.timepit.refined.numeric.Greater\[Int\(0\)\]"""
+    )
+    t.show == "greaterInference(1, 0)"
   }
 
   property("autoUnwrap: PosInt: Int") = secure {


### PR DESCRIPTION
Fixes #755. `Implies[P, C]` has essentially same semantic as `Inference[P, C]` except that instead of manifesting with a `false` conclusion, it will NOT manifest, and so it can be used effectively in chained implicit definitions.