### PR TITLE
Add new NonEmptyFiniteString type

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/all.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/all.scala
@@ -1,7 +1,7 @@
 package eu.timepit.refined.types
 
 /** Module for all predefined refined types. */
-object all extends AllTypes with AllTypesBinCompat1 with AllTypesBinCompat2
+object all extends AllTypes with AllTypesBinCompat1 with AllTypesBinCompat2 with AllTypesBinCompat3
 
 trait AllTypes
     extends CharTypes
@@ -14,3 +14,5 @@ trait AllTypes
 trait AllTypesBinCompat1 extends NumericTypesBinCompat1
 
 trait AllTypesBinCompat2 extends NumericTypesBinCompat2
+
+trait AllTypesBinCompat3 extends StringTypesBinCompat1

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -118,12 +118,14 @@ trait StringTypes {
   final type NonEmptyString = string.NonEmptyString
   final val NonEmptyString = string.NonEmptyString
 
-  final type NonEmptyFiniteString[N] = string.NonEmptyFiniteString[N]
-  final val NonEmptyFiniteString = string.NonEmptyFiniteString
-
   final type TrimmedString = string.TrimmedString
   final val TrimmedString = string.TrimmedString
 
   final type HexString = string.HexString
   final val HexString = string.HexString
+}
+
+trait StringTypesBinCompat1 {
+  final type NonEmptyFiniteString[N] = string.NonEmptyFiniteString[N]
+  final val NonEmptyFiniteString = string.NonEmptyFiniteString
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -1,8 +1,10 @@
 package eu.timepit.refined.types
 
 import eu.timepit.refined.api.{Refined, RefinedType, RefinedTypeOps}
-import eu.timepit.refined.collection.{MaxSize, NonEmpty}
+import eu.timepit.refined.collection.{MaxSize, NonEmpty, Size}
+import eu.timepit.refined.numeric.Interval
 import eu.timepit.refined.string.{HexStringSpec, Trimmed}
+import shapeless.Nat._1
 import shapeless.Witness
 
 /** Module for `String` refined types. */
@@ -61,6 +63,39 @@ object string {
 
   object NonEmptyString extends RefinedTypeOps[NonEmptyString, String]
 
+  /** A `String` that is not empty with length less than or equal to `N`. */
+  type NonEmptyFiniteString[N] = String Refined Size[Interval.Closed[_1, N]]
+
+  object NonEmptyFiniteString {
+    class NonEmptyFiniteStringOps[N <: Int](
+        implicit
+        rt: RefinedType.AuxT[NonEmptyFiniteString[N], String],
+        wn: Witness.Aux[N]
+    ) extends RefinedTypeOps[NonEmptyFiniteString[N], String] {
+
+      /** The maximum length of a `NonEmptyFiniteString[N]`. */
+      final val maxLength: N = wn.value
+    }
+
+    /**
+     * Creates a "companion object" for `NonEmptyFiniteString[N]` with a fixed `N`.
+     *
+     * Example: {{{
+     * scala> import eu.timepit.refined.W
+     *      | import eu.timepit.refined.types.string.NonEmptyFiniteString
+     *
+     * scala> val NEFString4 = NonEmptyFiniteString[W.`4`.T]
+     * scala> NEFString4.from("abcd")
+     * res1: Either[String, NonEmptyFiniteString[W.`4`.T]] = Right(abcd)
+     * }}}
+     */
+    def apply[N <: Int](
+        implicit
+        rt: RefinedType.AuxT[NonEmptyFiniteString[N], String],
+        wn: Witness.Aux[N]
+    ): NonEmptyFiniteStringOps[N] = new NonEmptyFiniteStringOps[N]
+  }
+
   /** A `String` that contains no leading or trailing whitespace. */
   type TrimmedString = String Refined Trimmed
 
@@ -82,6 +117,9 @@ trait StringTypes {
 
   final type NonEmptyString = string.NonEmptyString
   final val NonEmptyString = string.NonEmptyString
+
+  final type NonEmptyFiniteString[N] = string.NonEmptyFiniteString[N]
+  final val NonEmptyFiniteString = string.NonEmptyFiniteString
 
   final type TrimmedString = string.TrimmedString
   final val TrimmedString = string.TrimmedString

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -2,6 +2,7 @@ package eu.timepit.refined.types
 
 import eu.timepit.refined.W
 import eu.timepit.refined.types.all._
+import eu.timepit.refined.types.string.NonEmptyFiniteString
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 
@@ -39,6 +40,31 @@ class StringTypesSpec extends Properties("StringTypes") {
   property("""TrimmedString.trim(str)""") = forAll { (str: String) =>
     val trimmed = TrimmedString.trim(str)
     TrimmedString.from(trimmed.value) ?= Right(trimmed)
+  }
+
+  final val NEFString3 = NonEmptyFiniteString[W.`3`.T]
+
+  property("NEFString3.from(str)") = forAll { (str: String) =>
+    NEFString3.from(str).isRight ?= (!str.isEmpty && str.length <= NEFString3.maxLength)
+  }
+
+  property("""NEFString3.from("")""") = secure {
+    val str = ""
+    NEFString3.from(str) ?= Left(
+      "Predicate taking size() = 0 failed: Left predicate of (!(0 < 1) && !(0 > 3)) failed: Predicate (0 < 1) did not fail."
+    )
+  }
+
+  property("""NEFString3.from("abc")""") = secure {
+    val str = "abc"
+    NEFString3.from(str).right.map(_.value) ?= Right(str)
+  }
+
+  property("""NEFString3.from("abcd")""") = secure {
+    val str = "abcd"
+    NEFString3.from(str) ?= Left(
+      "Predicate taking size(abcd) = 4 failed: Right predicate of (!(4 < 1) && !(4 > 3)) failed: Predicate (4 > 3) did not fail."
+    )
   }
 
   // Hashes for ""

--- a/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
+++ b/modules/scalacheck/shared/src/test/scala/eu/timepit/refined/scalacheck/StringArbitrarySpec.scala
@@ -8,7 +8,12 @@ import eu.timepit.refined.scalacheck.generic._
 import eu.timepit.refined.scalacheck.numeric._
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.string._
-import eu.timepit.refined.types.string.{FiniteString, NonEmptyString, TrimmedString}
+import eu.timepit.refined.types.string.{
+  FiniteString,
+  NonEmptyFiniteString,
+  NonEmptyString,
+  TrimmedString
+}
 import org.scalacheck.Properties
 
 class StringArbitrarySpec extends Properties("StringArbitrary") {
@@ -26,4 +31,6 @@ class StringArbitrarySpec extends Properties("StringArbitrary") {
   property("FiniteString[10]") = checkArbitraryRefinedType[FiniteString[W.`10`.T]]
 
   property("Size[Equal[8]]") = checkArbitraryRefinedType[String Refined Size[Equal[W.`8`.T]]]
+
+  property("NonEmptyFiniteString[10]") = checkArbitraryRefinedType[NonEmptyFiniteString[W.`10`.T]]
 }


### PR DESCRIPTION
This type is a conjunction of the existing FiniteString and NonEmptyString types.

In our codebase at work, we often have to deal with strings that are both non-empty and finite of length. I thought this could be a useful addition to refined, rather than just having it privately in our codebase.

I'll comment down below on things that I am not sure of or that are currently broken that I don't know how to fix.