### PR TITLE
Adding neotypes to the external modules list

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ list it here:
 * [kantan.regex-refined](https://nrinaudo.github.io/kantan.regex/refined.html)
 * [kantan.xpath-refined](https://nrinaudo.github.io/kantan.xpath/refined.html)
 * [monocle-refined](https://github.com/julien-truffaut/Monocle)
+* [neotypes-refined](https://github.com/neotypes/neotypes)
 * [play-refined](https://github.com/kwark/play-refined)
 * [play-json-refined](https://github.com/lunaryorn/play-json-refined)
 * [play-json-refined](https://github.com/btlines/play-json-refined)


### PR DESCRIPTION
[**neotypes**](https://neotypes.github.io/neotypes/) is a Scala lightweight, type-safe, asynchronous driver for neo4j. And we provide a module to allow inserting and reading refined types.

And we would like to be added on the external modules list.