### PR TITLE
Add NonEmptyFiniteString.truncate function

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -75,6 +75,22 @@ object string {
 
       /** The maximum length of a `NonEmptyFiniteString[N]`. */
       final val maxLength: N = wn.value
+
+      /**
+       * Creates a `NonEmptyFiniteString[N]` from `t` by truncating it
+       * if it is longer than `N`. Returns `None` if `t` is empty.
+       *
+       * Example: {{{
+       * scala> import eu.timepit.refined.W
+       *      | import eu.timepit.refined.types.string.NonEmptyFiniteString
+       *
+       * scala> NonEmptyFiniteString[W.`3`.T].truncate("abcde")
+       * res1: Option[NonEmptyFiniteString[W.`3`.T]] = Some(abc)
+       * }}}
+       */
+      def truncate(t: String): Option[NonEmptyFiniteString[N]] =
+        if (t.isEmpty) None
+        else Some(Refined.unsafeApply(t.substring(0, math.min(t.length, maxLength))))
     }
 
     /**


### PR DESCRIPTION
This function was proposed before by @Hjdskes in https://github.com/fthomas/refined/pull/760#issuecomment-614248478. I argued against adding it if nobody is needing it right now. After looking at our codebase at $WORK again I found out that we are using exactly this function for our custom `NonEmptyFiniteString`. So at least we would benefit from an official `NonEmptyFiniteString.truncate`. :-)