### PR TITLE
uuidStringArbitrary does not need to be in StringInstancesBinCompat1

### DIFF
--- a/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
+++ b/modules/scalacheck/shared/src/main/scala/eu/timepit/refined/scalacheck/string.scala
@@ -38,6 +38,11 @@ trait StringInstances {
       arbSize: Arbitrary[Int Refined P]
   ): Arbitrary[F[String, Size[P]]] =
     collection.buildableSizeArbitrary[F, String, Char, P]
+
+  implicit def uuidStringArbitrary[F[_, _]](
+      implicit rt: RefType[F]
+  ): Arbitrary[F[String, Uuid]] =
+    arbitraryRefType(Arbitrary.arbUuid.arbitrary.map(_.toString))
 }
 
 trait StringInstancesBinCompat1 {
@@ -45,10 +50,4 @@ trait StringInstancesBinCompat1 {
       implicit rt: RefType[F]
   ): Arbitrary[F[String, Trimmed]] =
     arbitraryRefType(Arbitrary.arbString.arbitrary.map(TrimmedString.trim(_).value))
-
-  implicit def uuidStringArbitrary[F[_, _]](
-      implicit rt: RefType[F]
-  ): Arbitrary[F[String, Uuid]] =
-    arbitraryRefType(Arbitrary.arbUuid.arbitrary.map(_.toString))
-
 }


### PR DESCRIPTION
It seems that new Arbitrary instances do not need to be added to
*BinCompatN traits any more since support for 2.11 has been dropped.