### PR TITLE
Add Inference instance for Size[Interval.Closed[1, N]] ==> NonEmpty

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
@@ -8,7 +8,7 @@ import eu.timepit.refined.generic.Equal
 import eu.timepit.refined.internal.Resources
 import eu.timepit.refined.numeric.{GreaterEqual, Interval}
 import shapeless.Witness
-import shapeless.nat._0
+import shapeless.nat.{_0, _1}
 
 /** Module for collection predicates. */
 object collection extends CollectionInference {
@@ -342,4 +342,7 @@ private[refined] trait CollectionInference {
 
   implicit def sizeInference[A, B](implicit p1: A ==> B): Size[A] ==> Size[B] =
     p1.adapt("sizeInference(%s)")
+
+  implicit def sizeNonEmpty[N]: Size[Interval.Closed[_1, N]] ==> NonEmpty =
+    Inference.alwaysValid("sizeNonEmpty")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
@@ -343,6 +343,8 @@ private[refined] trait CollectionInference {
   implicit def sizeInference[A, B](implicit p1: A ==> B): Size[A] ==> Size[B] =
     p1.adapt("sizeInference(%s)")
 
-  implicit def sizeNonEmptyInference[N]: Size[Interval.Closed[_1, N]] ==> NonEmpty =
-    Inference.alwaysValid("sizeNonEmpty")
+  implicit def sizeGreaterEqual1NonEmptyInference[A](
+      implicit p1: A ==> GreaterEqual[_1]
+  ): Size[A] ==> NonEmpty =
+    p1.adapt("sizeGreaterEqual1NonEmptyInference(%s)")
 }

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/collection.scala
@@ -343,6 +343,6 @@ private[refined] trait CollectionInference {
   implicit def sizeInference[A, B](implicit p1: A ==> B): Size[A] ==> Size[B] =
     p1.adapt("sizeInference(%s)")
 
-  implicit def sizeNonEmpty[N]: Size[Interval.Closed[_1, N]] ==> NonEmpty =
+  implicit def sizeNonEmptyInference[N]: Size[Interval.Closed[_1, N]] ==> NonEmpty =
     Inference.alwaysValid("sizeNonEmpty")
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/CollectionInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/CollectionInferenceSpec.scala
@@ -4,7 +4,7 @@ import eu.timepit.refined.TestUtils.wellTyped
 import eu.timepit.refined.api.Inference
 import eu.timepit.refined.char._
 import eu.timepit.refined.collection._
-import eu.timepit.refined.numeric.Greater
+import eu.timepit.refined.numeric.{Greater, Interval}
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import shapeless.nat._
@@ -62,5 +62,13 @@ class CollectionInferenceSpec extends Properties("CollectionInference") {
 
   property("Size[A] ==> Size[B]") = secure {
     Inference[Size[Greater[_5]], Size[Greater[_4]]].isValid
+  }
+
+  property("Size[Greater[_1]] ==> NonEmpty") = secure {
+    Inference[Size[Greater[_1]], NonEmpty].isValid
+  }
+
+  property("Size[Interval.Closed[_2, _5]] ==> NonEmpty") = secure {
+    Inference[Size[Interval.Closed[_2, _5]], NonEmpty].isValid
   }
 }

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -1,5 +1,6 @@
 package eu.timepit.refined.types
 
+import eu.timepit.refined.TestUtils.wellTyped
 import eu.timepit.refined.W
 import eu.timepit.refined.types.all._
 import eu.timepit.refined.types.string.NonEmptyFiniteString
@@ -65,6 +66,12 @@ class StringTypesSpec extends Properties("StringTypes") {
     NEFString3.from(str) ?= Left(
       "Predicate taking size(abcd) = 4 failed: Right predicate of (!(4 < 1) && !(4 > 3)) failed: Predicate (4 > 3) did not fail."
     )
+  }
+
+  property("NEFString implies NEString") = wellTyped {
+    import eu.timepit.refined.auto._
+    val s1 = NEFString3.unsafeFrom("abc")
+    val s2: NonEmptyString = s1
   }
 
   // Hashes for ""


### PR DESCRIPTION
This allows, amongst others, the inference of `NonEmptyString` from `NonEmptyFiniteString`.