### PR TITLE
Add NonEmptyFiniteString[N].truncateNes

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/types/string.scala
@@ -91,6 +91,24 @@ object string {
       def truncate(t: String): Option[NonEmptyFiniteString[N]] =
         if (t.isEmpty) None
         else Some(Refined.unsafeApply(t.substring(0, math.min(t.length, maxLength))))
+
+      /**
+       * Creates a `NonEmptyFiniteString[N]` from `nes` by truncating it
+       * if it is longer than `N`.
+       *
+       * Example: {{{
+       * scala> import eu.timepit.refined.W
+       *      | import eu.timepit.refined.types.string.{NonEmptyString, NonEmptyFiniteString}
+       *
+       * scala> val nes = NonEmptyString.unsafeFrom("abcde")
+       * scala> NonEmptyFiniteString[W.`3`.T].truncate(nes)
+       * res1: NonEmptyFiniteString[W.`3`.T] = abc
+       * }}}
+       */
+      def truncateNes(nes: NonEmptyString): NonEmptyFiniteString[N] = {
+        val s = nes.value
+        Refined.unsafeApply(s.substring(0, math.min(s.length, maxLength)))
+      }
     }
 
     /**

--- a/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
+++ b/modules/core/shared/src/test/scala/eu/timepit/refined/types/StringTypesSpec.scala
@@ -4,8 +4,8 @@ import eu.timepit.refined.TestUtils.wellTyped
 import eu.timepit.refined.W
 import eu.timepit.refined.types.all._
 import eu.timepit.refined.types.string.NonEmptyFiniteString
+import org.scalacheck.{Prop, Properties}
 import org.scalacheck.Prop._
-import org.scalacheck.Properties
 
 class StringTypesSpec extends Properties("StringTypes") {
 
@@ -66,6 +66,12 @@ class StringTypesSpec extends Properties("StringTypes") {
     NEFString3.from(str) ?= Left(
       "Predicate taking size(abcd) = 4 failed: Right predicate of (!(4 < 1) && !(4 > 3)) failed: Predicate (4 > 3) did not fail."
     )
+  }
+
+  property("""NEFString3.truncate(str)""") = forAll { (str: String) =>
+    val truncated = NEFString3.truncate(str)
+    truncated.fold(Prop(str.isEmpty))(nefs =>
+      nefs.value.length <= NEFString3.maxLength && (nefs.value ?= str.take(NEFString3.maxLength)))
   }
 
   property("NEFString implies NEString") = wellTyped {


### PR DESCRIPTION
This PR adds the `truncateNes` method in `NonEmptyFiniteString[N]` as discussed on Gitter.

I'm not sure about how to write a test for this. Ideally, we'd add

```scala
  property("""NEFString3.truncate(neStr)""") = forAll { (neStr: NonEmptyString) =>
    val truncated = NEFString3.truncateNes(neStr)
    truncated.value.length <= NEFString3.maxLength &&
    (truncated.value ?= neStr.value.take(NEFString3.maxLength))
  }
```

but this requires a dependency in `core` on `scalacheck`, which introduces a cycle that I am not sure how to resolve yet:

```
build.sbt:187: error: recursive lazy value core needs type
.dependsOn(core)
^
```