### PR TITLE
Update cats-core to 2.2.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val gitDevUrl = s"git@github.com:$gitHubOwner/$projectName.git"
 val Scala212 = "2.12.11"
 val Scala213 = "2.13.3"
 
-val catsVersion = "2.1.1"
+val catsVersion = "2.2.0-RC3"
 val jsonpathVersion = "2.4.0"
 val macroParadiseVersion = "2.1.1"
 val pureconfigVersion = "0.13.0"

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/RefTypeContravariantSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/RefTypeContravariantSpec.scala
@@ -1,6 +1,8 @@
 package eu.timepit.refined.cats
 
 import _root_.cats.Contravariant
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosInt
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
@@ -34,10 +36,9 @@ class RefTypeContravariantSpec extends Properties("Contravariant") {
   }
 
   property("derive Encoder[PosInt] via Contravariant[Encoder]") = secure {
-    // This import is needed because of https://github.com/scala/bug/issues/10753
-    import Encoder.encoderContravariant
     import eu.timepit.refined.cats.derivation._
 
-    Encoder[PosInt].encode(PosInt.unsafeFrom(1)) ?= "1"
+    val encoder: Encoder[PosInt] = refTypeViaContravariant[Refined, Encoder, Int, Positive]
+    encoder.encode(PosInt.unsafeFrom(1)) ?= "1"
   }
 }


### PR DESCRIPTION
For testing the Cats 2.2.0 Scalafix migration: https://github.com/scala-steward-org/scala-steward/pull/1588