### PR TITLE
Avoid Scala 2 macros in Scaladoc examples

### DIFF
--- a/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedTypeOps.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/api/RefinedTypeOps.scala
@@ -15,11 +15,11 @@ import eu.timepit.refined.macros.RefineMacro
  *
  * scala> object PosInt extends RefinedTypeOps[PosInt, Int]
  *
- * scala> PosInt(1)
- * res0: PosInt = 1
+ * scala> PosInt.from(1)
+ * res0: Either[String, PosInt] = Right(1)
  *
- * scala> PosInt.from(2)
- * res1: Either[String, PosInt] = Right(2)
+ * scala> PosInt.unsafeFrom(2)
+ * res1: PosInt = 2
  * }}}
  */
 class RefinedTypeOps[FTP, T](implicit rt: RefinedType.AuxT[FTP, T]) extends Serializable {

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/auto.scala
@@ -38,12 +38,11 @@ object auto {
    * used as it were a subtype of `T`.
    *
    * Example: {{{
-   * scala> import eu.timepit.refined.api.Refined
-   *      | import eu.timepit.refined.auto.{ autoRefineV, autoUnwrap }
-   *      | import eu.timepit.refined.numeric.Positive
+   * scala> import eu.timepit.refined.auto.autoUnwrap
+   *      | import eu.timepit.refined.types.numeric.PosInt
    *
    * scala> def plusOne(i: Int): Int = i + 1
-   *      | val x: Int Refined Positive = 42
+   *      | val x = PosInt.unsafeFrom(42)
    *
    * // converts x implicitly to an Int:
    * scala> plusOne(x)

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/numeric.scala
@@ -21,11 +21,11 @@ import shapeless.ops.nat.ToInt
  *      | import eu.timepit.refined.numeric.Greater
  *      | import shapeless.nat._5
  *
- * scala> refineMV[Greater[_5]](10)
- * res1: Int Refined Greater[_5] = 10
+ * scala> refineV[Greater[_5]](10)
+ * res1: Either[String, Int Refined Greater[_5]] = Right(10)
  *
- * scala> refineMV[Greater[W.`1.5`.T]](1.6)
- * res2: Double Refined Greater[W.`1.5`.T] = 1.6
+ * scala> refineV[Greater[W.`1.5`.T]](1.6)
+ * res2: Either[String, Double Refined Greater[W.`1.5`.T]] = Right(1.6)
  * }}}
  *
  * Note: `[[generic.Equal]]` can also be used for numeric types.

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/util/string.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/util/string.scala
@@ -11,23 +11,7 @@ import eu.timepit.refined.string._
  */
 object string {
 
-  /**
-   * Creates a `[[scala.util.matching.Regex]]` from a validated string.
-   *
-   * Example: {{{
-   * scala> import eu.timepit.refined.auto._
-   *      | import eu.timepit.refined.util.string.regex
-   *
-   * scala> regex(".*")
-   * res1: scala.util.matching.Regex = .*
-   *
-   * scala> regex("{")
-   * <console>:47: error: Regex predicate failed: Illegal repetition
-   * {
-   *        regex("{")
-   *              ^
-   * }}}
-   */
+  /** Creates a `[[scala.util.matching.Regex]]` from a validated string. */
   def regex(s: String Refined Regex): scala.util.matching.Regex =
     new scala.util.matching.Regex(s.value)
 


### PR DESCRIPTION
This will help a tiny bit porting refined to Dotty.