### PR TITLE
Do not use existential in RefType#unwrap to fix Dotty error

### DIFF
--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/api/RefType.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/api/RefType.scala
@@ -19,7 +19,7 @@ trait RefType[F[_, _]] extends Serializable {
 
   def unsafeWrap[T, P](t: T): F[T, P]
 
-  def unwrap[T](tp: F[T, _]): T
+  def unwrap[T, P](tp: F[T, P]): T
 
   def unsafeRewrap[T, A, B](ta: F[T, A]): F[T, B]
 
@@ -85,7 +85,7 @@ object RefType {
       override def unsafeWrap[T, P](t: T): Refined[T, P] =
         Refined.unsafeApply(t)
 
-      override def unwrap[T](tp: Refined[T, _]): T =
+      override def unwrap[T, P](tp: Refined[T, P]): T =
         tp.value
 
       override def unsafeRewrap[T, A, B](ta: Refined[T, A]): Refined[T, B] =
@@ -97,7 +97,7 @@ object RefType {
       override def unsafeWrap[T, P](t: T): T @@ P =
         t.asInstanceOf[T @@ P]
 
-      override def unwrap[T](tp: T @@ _): T =
+      override def unwrap[T, P](tp: T @@ P): T =
         tp
 
       override def unsafeRewrap[T, A, B](ta: T @@ A): T @@ B =

--- a/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/api/RefType.scala
+++ b/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/api/RefType.scala
@@ -20,7 +20,7 @@ trait RefType[F[_, _]] extends Serializable {
 
   def unsafeWrap[T, P](t: T): F[T, P]
 
-  def unwrap[T](tp: F[T, _]): T
+  def unwrap[T, P](tp: F[T, P]): T
 
   def unsafeRewrap[T, A, B](ta: F[T, A]): F[T, B]
 
@@ -155,7 +155,7 @@ object RefType {
       override def unsafeWrap[T, P](t: T): Refined[T, P] =
         Refined.unsafeApply(t)
 
-      override def unwrap[T](tp: Refined[T, _]): T =
+      override def unwrap[T, P](tp: Refined[T, P]): T =
         tp.value
 
       override def unsafeRewrap[T, A, B](ta: Refined[T, A]): Refined[T, B] =
@@ -167,7 +167,7 @@ object RefType {
       override def unsafeWrap[T, P](t: T): T @@ P =
         t.asInstanceOf[T @@ P]
 
-      override def unwrap[T](tp: T @@ _): T =
+      override def unwrap[T, P](tp: T @@ P): T =
         tp
 
       override def unsafeRewrap[T, A, B](ta: T @@ A): T @@ B =

--- a/modules/scalaz/shared/src/main/scala/eu/timepit/refined/scalaz/package.scala
+++ b/modules/scalaz/shared/src/main/scala/eu/timepit/refined/scalaz/package.scala
@@ -10,7 +10,7 @@ package object scalaz {
       override def unsafeWrap[T, P](t: T): T @@ P =
         t.asInstanceOf[T @@ P]
 
-      override def unwrap[T](tp: T @@ _): T =
+      override def unwrap[T, P](tp: T @@ P): T =
         tp.asInstanceOf[T]
 
       override def unsafeRewrap[T, A, B](ta: T @@ A): T @@ B =


### PR DESCRIPTION
The Dotty build currently fails with:
```
[error] -- [E043] Type Error: /home/travis/build/[secure]/refined/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/api/RefType.scala:22:20
[error] 22 |  def unwrap[T](tp: F[T, _]): T
[error]    |                    ^^^^^^^
[error]    |   unreducible application of higher-kinded type F to wildcard arguments
```
This change should fix it.