### PR TITLE
Disable Dottydoc to unblock publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -419,6 +419,10 @@ lazy val compileSettings = Def.settings(
 )
 
 lazy val scaladocSettings = Def.settings(
+  Compile / doc / sources := {
+    val result = (Compile / doc / sources).value
+    if (isDotty.value) Seq.empty else result
+  },
   Compile / doc / scalacOptions ++= {
     val tag = s"v${version.value}"
     val tree = if (isSnapshot.value) "master" else tag


### PR DESCRIPTION
It failed with:
```
java.lang.AssertionError: NoDenotation.owner while compiling eu.timepit.refined.BooleanInference0, eu.timepit.refined.BooleanInference1, eu.timepit.refined.BooleanInference2, eu.timepit.refined.CollectionInference, eu.timepit.refined.GenericInference, eu.timepit.refined.NumericInference, eu.timepit.refined.StringInference, eu.timepit.refined.api.Failed, eu.timepit.refined.api.Inference, eu.timepit.refined.api.LowPriorityMaxInstances, eu.timepit.refined.api.LowPriorityMinInstances, eu.timepit.refined.api.Max, eu.timepit.refined.api.MaxInstances, eu.timepit.refined.api.Min, eu.timepit.refined.api.MinInstances, eu.timepit.refined.api.Passed, eu.timepit.refined.api.RefType, eu.timepit.refined.api.Refined$package, eu.timepit.refined.api.RefinedType, eu.timepit.refined.api.RefinedTypeOps, eu.timepit.refined.api.Result, eu.timepit.refined.api.Validate, eu.timepit.refined.auto, eu.timepit.refined.boolean, eu.timepit.refined.char, eu.timepit.refined.collection, eu.timepit.refined.generic, eu.timepit.refined.internal.Adjacent, eu.timepit.refined.internal.ApplyRefPartiallyApplied, eu.timepit.refined.internal.BuildInfo, eu.timepit.refined.internal.RefinePartiallyApplied, eu.timepit.refined.internal.Resources, eu.timepit.refined.internal.WitnessAs, eu.timepit.refined.numeric, eu.timepit.refined.package, eu.timepit.refined.predicates.AllPredicates, eu.timepit.refined.predicates.AllPredicatesBinCompat1, eu.timepit.refined.predicates.AllPredicatesBinCompat2, eu.timepit.refined.predicates.BooleanPredicates, eu.timepit.refined.predicates.CharPredicates, eu.timepit.refined.predicates.CollectionPredicates, eu.timepit.refined.predicates.GenericPredicates, eu.timepit.refined.predicates.NumericPredicates, eu.timepit.refined.predicates.NumericPredicatesBinCompat1, eu.timepit.refined.predicates.StringPredicates, eu.timepit.refined.predicates.StringPredicatesBinCompat1, eu.timepit.refined.predicates.all, eu.timepit.refined.predicates.boolean, eu.timepit.refined.predicates.char, eu.timepit.refined.predicates.collection, eu.timepit.refined.predicates.generic, eu.timepit.refined.predicates.numeric, eu.timepit.refined.predicates.string, eu.timepit.refined.string, eu.timepit.refined.types.AllTypes, eu.timepit.refined.types.AllTypesBinCompat1, eu.timepit.refined.types.AllTypesBinCompat2, eu.timepit.refined.types.AllTypesBinCompat3, eu.timepit.refined.types.CharTypes, eu.timepit.refined.types.DigestTypes, eu.timepit.refined.types.NetTypes, eu.timepit.refined.types.NumericTypes, eu.timepit.refined.types.NumericTypesBinCompat1, eu.timepit.refined.types.NumericTypesBinCompat2, eu.timepit.refined.types.StringTypes, eu.timepit.refined.types.StringTypesBinCompat1, eu.timepit.refined.types.TimeTypes, eu.timepit.refined.types.all, eu.timepit.refined.types.char, eu.timepit.refined.types.digests, eu.timepit.refined.types.net, eu.timepit.refined.types.numeric, eu.timepit.refined.types.string, eu.timepit.refined.types.time, eu.timepit.refined.util.string
[error] stack trace is suppressed; run last coreJVM / Compile / doc for the full output
```