### PR TITLE
Prepare tests for deprecating support of Nat

### DIFF
--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/BooleanInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/BooleanInferenceSpec.scala
@@ -7,14 +7,13 @@ import eu.timepit.refined.char.{Digit, Letter, UpperCase, Whitespace}
 import eu.timepit.refined.numeric._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.nat._
 import shapeless.test.illTyped
 
 class BooleanInferenceSpec extends Properties("BooleanInference") {
 
   property("double negation elimination with Greater") = secure {
-    Inference[Not[Not[Greater[_5]]], Greater[_4]] ?=
-      Inference(5 > 4, "doubleNegationElimination(greaterInferenceNat(5, 4))")
+    Inference[Not[Not[Greater[W.`5`.T]]], Greater[W.`4`.T]] ?=
+      Inference(5 > 4, "doubleNegationElimination(greaterInference(5, 4))")
   }
 
   property("double negation elimination") = secure {
@@ -34,7 +33,7 @@ class BooleanInferenceSpec extends Properties("BooleanInference") {
   }
 
   property("double negation introduction with Greater") = secure {
-    Inference[Greater[_5], Not[Not[Greater[_4]]]].isValid
+    Inference[Greater[W.`5`.T], Not[Not[Greater[W.`4`.T]]]].isValid
   }
 
   property("double negation introduction") = secure {

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/BooleanValidateSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/BooleanValidateSpec.scala
@@ -8,7 +8,6 @@ import eu.timepit.refined.numeric.{Greater, Less}
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import shapeless.{::, HNil}
-import shapeless.nat._
 
 class BooleanValidateSpec extends Properties("BooleanValidate") {
 
@@ -141,11 +140,11 @@ class BooleanValidateSpec extends Properties("BooleanValidate") {
   }
 
   property("AllOf.isValid") = forAll { (i: Int) =>
-    isValid[AllOf[Greater[_0] :: Less[_10] :: HNil]](i) ?= (i > 0 && i < 10)
+    isValid[AllOf[Greater[W.`0`.T] :: Less[W.`10`.T] :: HNil]](i) ?= (i > 0 && i < 10)
   }
 
   property("AllOf.showExpr") = secure {
-    showExpr[AllOf[Greater[_0] :: Less[_10] :: HNil]](5) ?=
+    showExpr[AllOf[Greater[W.`0`.T] :: Less[W.`10`.T] :: HNil]](5) ?=
       "((5 > 0) && (5 < 10) && true)"
   }
 

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/CollectionInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/CollectionInferenceSpec.scala
@@ -37,7 +37,7 @@ class CollectionInferenceSpec extends Properties("CollectionInference") {
   }
 
   property("Index[N, A] ==> Index[N, B]") = secure {
-    Inference[Index[_1, Letter], Index[_1, LetterOrDigit]].isValid
+    Inference[Index[W.`1`.T, Letter], Index[W.`1`.T, LetterOrDigit]].isValid
   }
 
   property("Index ==> Exists") = secure {
@@ -61,7 +61,7 @@ class CollectionInferenceSpec extends Properties("CollectionInference") {
   }
 
   property("Size[A] ==> Size[B]") = secure {
-    Inference[Size[Greater[_5]], Size[Greater[_4]]].isValid
+    Inference[Size[Greater[W.`5`.T]], Size[Greater[W.`4`.T]]].isValid
   }
 
   property("Size[Greater[_1]] ==> NonEmpty") = secure {

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/CollectionValidateSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/CollectionValidateSpec.scala
@@ -7,7 +7,6 @@ import eu.timepit.refined.collection._
 import eu.timepit.refined.numeric._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.nat._
 
 class CollectionValidateSpec extends Properties("CollectionValidate") {
 
@@ -28,20 +27,20 @@ class CollectionValidateSpec extends Properties("CollectionValidate") {
   }
 
   property("Count.isValid") = forAll { (l: List[Char]) =>
-    isValid[Count[LowerCase, Greater[_2]]](l) ?= (l.count(_.isLower) > 2)
+    isValid[Count[LowerCase, Greater[W.`2`.T]]](l) ?= (l.count(_.isLower) > 2)
   }
 
   property("Count.showExpr") = secure {
-    showExpr[Count[LowerCase, Greater[_2]]](List('a', 'B')) ?= "(1 > 2)"
+    showExpr[Count[LowerCase, Greater[W.`2`.T]]](List('a', 'B')) ?= "(1 > 2)"
   }
 
   property("Count.showResult") = secure {
-    showResult[Count[LowerCase, Greater[_2]]](List('a', 'B')) ?=
+    showResult[Count[LowerCase, Greater[W.`2`.T]]](List('a', 'B')) ?=
       "Predicate taking count(isLower('a'), isLower('B')) = 1 failed: Predicate failed: (1 > 2)."
   }
 
   property("Count.String.isValid") = forAll { (s: String) =>
-    isValid[Count[LowerCase, Greater[_2]]](s) ?= (s.count(_.isLower) > 2)
+    isValid[Count[LowerCase, Greater[W.`2`.T]]](s) ?= (s.count(_.isLower) > 2)
   }
 
   property("Empty.isValid") = forAll((l: List[Int]) => isValid[Empty](l) ?= l.isEmpty)
@@ -57,11 +56,11 @@ class CollectionValidateSpec extends Properties("CollectionValidate") {
   }
 
   property("Exists.isValid") = forAll { (l: List[Int]) =>
-    isValid[Exists[Less[_1]]](l) ?= l.exists(_ < 1)
+    isValid[Exists[Less[W.`1`.T]]](l) ?= l.exists(_ < 1)
   }
 
   property("Exists.showExpr") = secure {
-    showExpr[Exists[Less[_1]]](List(1, 2, 3)) ?= "!(!(1 < 1) && !(2 < 1) && !(3 < 1))"
+    showExpr[Exists[Less[W.`1`.T]]](List(1, 2, 3)) ?= "!(!(1 < 1) && !(2 < 1) && !(3 < 1))"
   }
 
   property("Forall.String.isValid") = forAll { (s: String) =>
@@ -119,15 +118,15 @@ class CollectionValidateSpec extends Properties("CollectionValidate") {
   }
 
   property("Last.isValid") = forAll { (l: List[Int]) =>
-    isValid[Last[Greater[_5]]](l) ?= l.lastOption.fold(false)(_ > 5)
+    isValid[Last[Greater[W.`5`.T]]](l) ?= l.lastOption.fold(false)(_ > 5)
   }
 
   property("Last.showExpr") = secure {
-    showExpr[Last[Greater[_5]]](List(1, 2, 3)) ?= "(3 > 5)"
+    showExpr[Last[Greater[W.`5`.T]]](List(1, 2, 3)) ?= "(3 > 5)"
   }
 
   property("Last.showResult") = secure {
-    showResult[Last[Greater[_5]]](List(1, 2, 3)) ?=
+    showResult[Last[Greater[W.`5`.T]]](List(1, 2, 3)) ?=
       "Predicate taking last(List(1, 2, 3)) = 3 failed: Predicate failed: (3 > 5)."
   }
 
@@ -164,7 +163,7 @@ class CollectionValidateSpec extends Properties("CollectionValidate") {
   }
 
   property("MinSize.String.isValid") = forAll { (s: String) =>
-    isValid[MinSize[_5]](s) ?= (s.length >= 5)
+    isValid[MinSize[W.`5`.T]](s) ?= (s.length >= 5)
   }
 
   property("NonEmpty.String.isValid") = forAll((s: String) => isValid[NonEmpty](s) ?= s.nonEmpty)
@@ -174,18 +173,18 @@ class CollectionValidateSpec extends Properties("CollectionValidate") {
   }
 
   property("Size.isValid") = forAll { (l: List[Int]) =>
-    isValid[Size[Greater[_5]]](l) ?= (l.size > 5)
+    isValid[Size[Greater[W.`5`.T]]](l) ?= (l.size > 5)
   }
 
   property("Size.showExpr") = secure {
-    showExpr[Size[Greater[_5]]](List(1, 2, 3)) ?= "(3 > 5)"
+    showExpr[Size[Greater[W.`5`.T]]](List(1, 2, 3)) ?= "(3 > 5)"
   }
 
   property("Size.String.isValid") = forAll { (s: String) =>
-    isValid[Size[LessEqual[_10]]](s) ?= (s.length <= 10)
+    isValid[Size[LessEqual[W.`10`.T]]](s) ?= (s.length <= 10)
   }
 
   property("Size.String.showExpr") = secure {
-    showExpr[Size[Greater[_5] And LessEqual[_10]]]("test") ?= "((4 > 5) && !(4 > 10))"
+    showExpr[Size[Greater[W.`5`.T] And LessEqual[W.`10`.T]]]("test") ?= "((4 > 5) && !(4 > 10))"
   }
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/GenericInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/GenericInferenceSpec.scala
@@ -6,23 +6,22 @@ import eu.timepit.refined.numeric.Greater
 import eu.timepit.refined.string.StartsWith
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.Nat
 
 class GenericInferenceSpec extends Properties("GenericInference") {
 
-  property("Equal[S1] ==> StartsWith[S2]") = secure {
+  property("""Equal["abcd"] ==> StartsWith["ab"]""") = secure {
     Inference[Equal[W.`"abcd"`.T], StartsWith[W.`"ab"`.T]].isValid
   }
 
-  property("Equal[S1] =!> StartsWith[S2]") = secure {
+  property("""Equal["abcd"] =!> StartsWith["cd"]""") = secure {
     Inference[Equal[W.`"abcd"`.T], StartsWith[W.`"cd"`.T]].notValid
   }
 
-  property("Equal[Nat] ==> Greater[I]") = secure {
-    Inference[Equal[Nat._10], Greater[W.`5`.T]].isValid
+  property("Equal[10] ==> Greater[5]") = secure {
+    Inference[Equal[W.`10`.T], Greater[W.`5`.T]].isValid
   }
 
-  property("Equal[Nat] =!> Greater[I]") = secure {
-    Inference[Equal[Nat._5], Greater[W.`10`.T]].notValid
+  property("Equal[5] =!> Greater[10]") = secure {
+    Inference[Equal[W.`5`.T], Greater[W.`10`.T]].notValid
   }
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/GenericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/GenericValidateSpec.scala
@@ -4,40 +4,39 @@ import eu.timepit.refined.TestUtils._
 import eu.timepit.refined.generic._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.Nat._
 
 class GenericValidateSpec extends Properties("GenericValidate") {
 
-  property("Equal.isValid") = secure {
+  property("isValid[Equal[1.4]](1.4)") = secure {
     isValid[Equal[W.`1.4`.T]](1.4)
   }
 
-  property("Equal.notValid") = secure {
+  property("notValid[Equal[1.4]](2.4)") = secure {
     notValid[Equal[W.`1.4`.T]](2.4)
   }
 
-  property("Equal.showExpr") = secure {
+  property("showExpr[Equal[1.4]](0.4)") = secure {
     showExpr[Equal[W.`1.4`.T]](0.4) ?= "(0.4 == 1.4)"
   }
 
-  property("Equal.object.isValid") = secure {
+  property("isValid[Equal[Foo.type]](Foo)") = secure {
     object Foo
     isValid[Equal[Foo.type]](Foo)
   }
 
-  property("Equal.Nat.Int.isValid") = forAll((i: Int) => isValid[Equal[_0]](i) ?= (i == 0))
-
-  property("Equal.Nat.Long.isValid") = forAll((l: Long) => isValid[Equal[_0]](l) ?= (l == 0L))
-
-  property("Equal.Nat.Double.isValid") = forAll { (d: Double) =>
-    isValid[Equal[_0]](d) ?= (d == 0.0)
+  property("isValid[Equal[0]](i: Int)") = forAll { (i: Int) =>
+    isValid[Equal[W.`0`.T]](i) ?= (i == 0)
   }
 
-  property("Equal.Nat.showExpr") = secure {
-    showExpr[Equal[_5]](0) ?= "(0 == 5)"
+  property("isValid[Equal[0]](l: Long)") = forAll { (l: Long) =>
+    isValid[Equal[W.`0`.T]](l) ?= (l == 0L)
   }
 
-  property("Equal.Nat ~= Equal.Int") = forAll { (i: Int) =>
-    showResult[Equal[_1]](i) ?= showResult[Equal[W.`1`.T]](i)
+  property("isValid[Equal[0]](d: Double)") = forAll { (d: Double) =>
+    isValid[Equal[W.`0`.T]](d) ?= (d == 0.0)
+  }
+
+  property("showExpr[Equal[5]](0)") = secure {
+    showExpr[Equal[W.`5`.T]](0) ?= "(0 == 5)"
   }
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/MaxSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/MaxSpec.scala
@@ -6,49 +6,48 @@ import eu.timepit.refined.numeric._
 import eu.timepit.refined.types.numeric._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.nat._
 import shapeless.tag.@@
 
 class MaxSpec extends Properties("Max") {
 
-  property("Max[Int Refined Less[W.`1`.T]]") = secure {
+  property("Max[Int Refined Less[1]]") = secure {
     Max[Int Refined Less[W.`1`.T]].max.value ?= 0
   }
 
-  property("Max[Int Refined Less[_0]]") = secure {
-    Max[Int Refined Less[_0]].max.value ?= -1
+  property("Max[Int Refined Less[0]]") = secure {
+    Max[Int Refined Less[W.`0`.T]].max.value ?= -1
   }
 
-  property("Max[Long Refined Less[_5]]") = secure {
-    Max[Long Refined Less[_5]].max.value ?= 4L
+  property("Max[Long Refined Less[5]]") = secure {
+    Max[Long Refined Less[W.`5`.T]].max.value ?= 4L
   }
 
-  property("Max[Float Refined Less[_5]]") = secure {
-    Max[Float Refined Less[_5]].max.value ?= 4.9999995f
+  property("Max[Float Refined Less[5]]") = secure {
+    Max[Float Refined Less[W.`5`.T]].max.value ?= 4.9999995f
   }
 
-  property("Max[Byte Refined Greater[_0]]") = secure {
-    Max[Byte Refined Greater[_0]].max.value ?= Byte.MaxValue
+  property("Max[Byte Refined Greater[0]]") = secure {
+    Max[Byte Refined Greater[W.`0`.T]].max.value ?= Byte.MaxValue
   }
 
-  property("Max[Short Refined Greater[_0]]") = secure {
-    Max[Short Refined Greater[_0]].max.value ?= Short.MaxValue
+  property("Max[Short Refined Greater[0]]") = secure {
+    Max[Short Refined Greater[W.`0`.T]].max.value ?= Short.MaxValue
   }
 
-  property("Max[Int Refined Greater[_0]]") = secure {
-    Max[Int Refined Greater[_0]].max.value ?= Int.MaxValue
+  property("Max[Int Refined Greater[0]]") = secure {
+    Max[Int Refined Greater[W.`0`.T]].max.value ?= Int.MaxValue
   }
 
-  property("Max[Long Refined Greater[_0]]") = secure {
-    Max[Long Refined Greater[_0]].max.value ?= Long.MaxValue
+  property("Max[Long Refined Greater[0]]") = secure {
+    Max[Long Refined Greater[W.`0`.T]].max.value ?= Long.MaxValue
   }
 
-  property("Max[Float Refined Greater[_0]]") = secure {
-    Max[Float Refined Greater[_0]].max.value ?= Float.MaxValue
+  property("Max[Float Refined Greater[0]]") = secure {
+    Max[Float Refined Greater[W.`0`.T]].max.value ?= Float.MaxValue
   }
 
-  property("Max[Double Refined Greater[_0]]") = secure {
-    Max[Double Refined Greater[_0]].max.value ?= Double.MaxValue
+  property("Max[Double Refined Greater[0]]") = secure {
+    Max[Double Refined Greater[W.`0`.T]].max.value ?= Double.MaxValue
   }
 
   property("Max[Int Refined NonNegative]") = secure {
@@ -67,31 +66,31 @@ class MaxSpec extends Properties("Max") {
     Max[Double Refined NonPositive].max.value ?= 0d
   }
 
-  property("Max[Int Refined Not[Greater[W.`-5`.T]]]") = secure {
+  property("Max[Int Refined Not[Greater[-5]]]") = secure {
     Max[Int Refined Not[Greater[W.`-5`.T]]].max.value ?= -5
   }
 
-  property("Max[Int Refined Interval.Open[_1, _4]]") = secure {
-    Max[Int Refined Interval.Open[_1, _4]].max.value ?= 3
+  property("Max[Int Refined Interval.Open[1, 4]]") = secure {
+    Max[Int Refined Interval.Open[W.`1`.T, W.`4`.T]].max.value ?= 3
   }
 
-  property("Max[Double Refined Interval.Open[_1, _4]]") = secure {
-    Max[Double Refined Interval.Open[_1, _4]].max.value ?= 3.9999999999999996
+  property("Max[Double Refined Interval.Open[1, 4]]") = secure {
+    Max[Double Refined Interval.Open[W.`1`.T, W.`4`.T]].max.value ?= 3.9999999999999996
   }
 
-  property("Max[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
+  property("Max[Int Refined Interval.Closed[-20, 10]]") = secure {
     Max[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]].max.value ?= 10
   }
 
-  property("Max[Int @@ Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
+  property("Max[Int @@ Interval.Closed[-20, 10]]") = secure {
     Max[Int @@ Interval.Closed[W.`-20`.T, W.`10`.T]].max.asInstanceOf[Int] ?= 10
   }
 
-  property("Max[Double Refined Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
+  property("Max[Double Refined Interval.Closed[-20d, 10.99991d]]") = secure {
     Max[Double Refined Interval.Closed[W.`-20d`.T, W.`10.99991d`.T]].max.value ?= 10.99991d
   }
 
-  property("Max[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]]") = secure {
+  property("Max[Char Refined Interval.Closed['A', 'Z']]") = secure {
     Max[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]].max.value ?= 'Z'
   }
 
@@ -99,19 +98,19 @@ class MaxSpec extends Properties("Max") {
     Max[Int Refined Even].max.value ?= 2147483646
   }
 
-  property("Max[Int Refined Divisible[_5]]") = secure {
-    Max[Int Refined Divisible[_5]].max.value ?= 2147483645
+  property("Max[Int Refined Divisible[5]]") = secure {
+    Max[Int Refined Divisible[W.`5`.T]].max.value ?= 2147483645
   }
 
   property("Max[Int Refined (Negative And Even)]") = secure {
     Max[Int Refined (Negative And Even)].max.value ?= -2
   }
 
-  property("CompanionObject.max - Negative - Long") = secure {
+  property("NegLong.MaxValue") = secure {
     NegLong.MaxValue ?= NegLong.unsafeFrom(-1)
   }
 
-  property("CompanionObject.max - Positive - Float") = secure {
+  property("PosFloat.MaxValue") = secure {
     PosFloat.MaxValue ?= PosFloat.unsafeFrom(Float.MaxValue)
   }
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/MinSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/MinSpec.scala
@@ -6,49 +6,48 @@ import eu.timepit.refined.numeric._
 import eu.timepit.refined.types.numeric._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.nat._
 import shapeless.tag.@@
 
 class MinSpec extends Properties("Min") {
 
-  property("Min[Int Refined Greater[W.`1`.T]]") = secure {
+  property("Min[Int Refined Greater[1]]") = secure {
     Min[Int Refined Greater[W.`1`.T]].min.value ?= 2
   }
 
-  property("Min[Int Refined Greater[_0]]") = secure {
-    Min[Int Refined Greater[_0]].min.value ?= 1
+  property("Min[Int Refined Greater[0]]") = secure {
+    Min[Int Refined Greater[W.`0`.T]].min.value ?= 1
   }
 
-  property("Min[Long Refined Greater[_0]]") = secure {
-    Min[Long Refined Greater[_0]].min.value ?= 1L
+  property("Min[Long Refined Greater[0]]") = secure {
+    Min[Long Refined Greater[W.`0`.T]].min.value ?= 1L
   }
 
-  property("Min[Float Refined Greater[_0]]") = secure {
+  property("Min[Float Refined Greater[0]]") = secure {
     Min[Float Refined Greater[W.`0f`.T]].min.value ?= "1.4E-45".toFloat
   }
 
-  property("Min[Byte Refined Less[_0]]") = secure {
-    Min[Byte Refined Less[_0]].min.value ?= Byte.MinValue
+  property("Min[Byte Refined Less[0]]") = secure {
+    Min[Byte Refined Less[W.`0`.T]].min.value ?= Byte.MinValue
   }
 
-  property("Min[Short Refined Less[_0]]") = secure {
-    Min[Short Refined Less[_0]].min.value ?= Short.MinValue
+  property("Min[Short Refined Less[0]]") = secure {
+    Min[Short Refined Less[W.`0`.T]].min.value ?= Short.MinValue
   }
 
-  property("Min[Int Refined Less[_0]]") = secure {
-    Min[Int Refined Less[_0]].min.value ?= Int.MinValue
+  property("Min[Int Refined Less[0]]") = secure {
+    Min[Int Refined Less[W.`0`.T]].min.value ?= Int.MinValue
   }
 
-  property("Min[Long Refined Less[_0]]") = secure {
-    Min[Long Refined Less[_0]].min.value ?= Long.MinValue
+  property("Min[Long Refined Less[0]]") = secure {
+    Min[Long Refined Less[W.`0`.T]].min.value ?= Long.MinValue
   }
 
-  property("Min[Float Refined Less[_0]]") = secure {
-    Min[Float Refined Less[_0]].min.value ?= Float.MinValue
+  property("Min[Float Refined Less[0]]") = secure {
+    Min[Float Refined Less[W.`0`.T]].min.value ?= Float.MinValue
   }
 
-  property("Min[Double Refined Less[_0]]") = secure {
-    Min[Double Refined Less[_0]].min.value ?= Double.MinValue
+  property("Min[Double Refined Less[0]]") = secure {
+    Min[Double Refined Less[W.`0`.T]].min.value ?= Double.MinValue
   }
 
   property("Min[Int Refined NonPositive]") = secure {
@@ -67,31 +66,31 @@ class MinSpec extends Properties("Min") {
     Min[Double Refined NonNegative].min.value ?= 0f
   }
 
-  property("Min[Int Refined Not[Less[W.`-5`.T]]]") = secure {
+  property("Min[Int Refined Not[Less[-5]]]") = secure {
     Min[Int Refined Not[Less[W.`-5`.T]]].min.value ?= -5
   }
 
-  property("Min[Int Refined Interval.Open[_1, _4]]") = secure {
-    Min[Int Refined Interval.Open[_1, _4]].min.value ?= 2
+  property("Min[Int Refined Interval.Open[1, 4]]") = secure {
+    Min[Int Refined Interval.Open[W.`1`.T, W.`4`.T]].min.value ?= 2
   }
 
-  property("Min[Int @@ Interval.Open[_1, _4]]") = secure {
-    Min[Int @@ Interval.Open[_1, _4]].min.asInstanceOf[Int] ?= 2
+  property("Min[Int @@ Interval.Open[1, 4]]") = secure {
+    Min[Int @@ Interval.Open[W.`1`.T, W.`4`.T]].min.asInstanceOf[Int] ?= 2
   }
 
-  property("Min[Double Refined Interval.Open[_1, _4]]") = secure {
-    Min[Double Refined Interval.Open[_1, _4]].min.value ?= 1.0000000000000002
+  property("Min[Double Refined Interval.Open[1, 4]]") = secure {
+    Min[Double Refined Interval.Open[W.`1`.T, W.`4`.T]].min.value ?= 1.0000000000000002
   }
 
-  property("Min[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]]") = secure {
+  property("Min[Int Refined Interval.Closed[-20, 10]]") = secure {
     Min[Int Refined Interval.Closed[W.`-20`.T, W.`10`.T]].min.value ?= -20
   }
 
-  property("Min[Double Refined Interval.Closed[W.`-20.001d`.T, W.`0d`.T]]") = secure {
+  property("Min[Double Refined Interval.Closed[-20.001d, 0d]]") = secure {
     Min[Double Refined Interval.Closed[W.`-20.001d`.T, W.`0d`.T]].min.value ?= -20.001d
   }
 
-  property("Min[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]]") = secure {
+  property("Min[Char Refined Interval.Closed['A', 'Z']]") = secure {
     Min[Char Refined Interval.Closed[W.`'A'`.T, W.`'Z'`.T]].min.value ?= 'A'
   }
 
@@ -99,19 +98,19 @@ class MinSpec extends Properties("Min") {
     Min[Int Refined Even].min.value ?= Int.MinValue
   }
 
-  property("Min[Int Refined Divisible[_5]]") = secure {
-    Min[Int Refined Divisible[_5]].min.value ?= -2147483645
+  property("Min[Int Refined Divisible[5]]") = secure {
+    Min[Int Refined Divisible[W.`5`.T]].min.value ?= -2147483645
   }
 
   property("Min[Int Refined (Positive And Even)]") = secure {
     Min[Int Refined (Positive And Even)].min.value ?= 2
   }
 
-  property("CompanionObject.min - Positive - Long") = secure {
+  property("PosLong.MinValue") = secure {
     PosLong.MinValue ?= PosLong.unsafeFrom(1)
   }
 
-  property("CompanionObject.min - Negative - Float") = secure {
+  property("NegFloat.MinValue") = secure {
     NegFloat.MinValue ?= NegFloat.unsafeFrom(Float.MinValue)
   }
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/NumericInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/NumericInferenceSpec.scala
@@ -5,111 +5,74 @@ import eu.timepit.refined.boolean._
 import eu.timepit.refined.numeric._
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.nat._
 
 class NumericInferenceSpec extends Properties("NumericInference") {
 
-  property("Less[A] ==> Less[B]") = secure {
+  property("Less[5] ==> Less[10]") = secure {
+    Inference[Less[W.`5`.T], Less[W.`10`.T]].isValid
+  }
+
+  property("Less[10] =!> Less[5]") = secure {
+    Inference[Less[W.`10`.T], Less[W.`5`.T]].notValid
+  }
+
+  property("Less[7.2] ==> Less[7.5]") = secure {
     Inference[Less[W.`7.2`.T], Less[W.`7.5`.T]].isValid
   }
 
-  property("Less[A] =!> Less[B]") = secure {
+  property("Less[7.5] =!> Less[7.2]") = secure {
     Inference[Less[W.`7.5`.T], Less[W.`7.2`.T]].notValid
   }
 
-  property("LessEqual[A] ==> LessEqual[B]") = secure {
+  property("LessEqual[1] ==> LessEqual[1]") = secure {
+    Inference[LessEqual[W.`1`.T], LessEqual[W.`1`.T]].isValid
+  }
+
+  property("LessEqual[7.2] ==> LessEqual[7.5]") = secure {
     Inference[LessEqual[W.`7.2`.T], LessEqual[W.`7.5`.T]].isValid
   }
 
-  // Does not compile on 2.10 without a warning.
-  /*
-  property("LessEqual[A] ==> LessEqual[A]") = secure {
-    Inference[LessEqual[W.`1`.T], LessEqual[W.`1`.T]].isValid
-  }
-   */
-
-  property("LessEqual[A] =!> LessEqual[B]") = secure {
+  property("LessEqual[7.5] =!> LessEqual[7.2]") = secure {
     Inference[LessEqual[W.`7.5`.T], LessEqual[W.`7.2`.T]].notValid
   }
 
-  property("Greater[A] ==> Greater[B]") = secure {
+  property("Greater[10] ==> Greater[5]") = secure {
+    Inference[Greater[W.`10`.T], Greater[W.`5`.T]].isValid
+  }
+
+  property("Greater[5] =!> Greater[10]") = secure {
+    Inference[Greater[W.`5`.T], Greater[W.`10`.T]].notValid
+  }
+
+  property("Greater[7.5] ==> Greater[7.2]") = secure {
     Inference[Greater[W.`7.5`.T], Greater[W.`7.2`.T]].isValid
   }
 
-  property("Greater[A] =!> Greater[B]") = secure {
+  property("Greater[7.2] =!> Greater[7.5]") = secure {
     Inference[Greater[W.`7.2`.T], Greater[W.`7.5`.T]].notValid
   }
 
-  property("GreaterEqual[A] ==> GreaterEqual[B]") = secure {
+  property("GreaterEqual[1] ==> GreaterEqual[1]") = secure {
+    Inference[GreaterEqual[W.`1`.T], GreaterEqual[W.`1`.T]].isValid
+  }
+
+  property("GreaterEqual[7.5] ==> GreaterEqual[7.2]") = secure {
     Inference[GreaterEqual[W.`7.5`.T], GreaterEqual[W.`7.2`.T]].isValid
   }
 
-  // Does not compile on 2.10 without a warning.
-  /*
-  property("GreaterEqual[A] ==> GreaterEqual[A]") = secure {
-    Inference[GreaterEqual[W.`1`.T], GreaterEqual[W.`1`.T]].isValid
-  }
-   */
-
-  property("GreaterEqual[A] =!> GreaterEqual[B]") = secure {
+  property("GreaterEqual[7.2] =!> GreaterEqual[7.5]") = secure {
     Inference[GreaterEqual[W.`7.2`.T], GreaterEqual[W.`7.5`.T]].notValid
   }
 
-  property("Less[Nat] ==> Less[Nat]") = secure {
-    Inference[Less[_5], Less[_10]].isValid
-  }
-
-  property("Less[Nat] =!> Less[Nat]") = secure {
-    Inference[Less[_10], Less[_5]].notValid
-  }
-
-  property("Less[A] ==> Less[Nat]") = secure {
-    Inference[Less[W.`5`.T], Less[_10]].isValid
-  }
-
-  property("Less[A] =!> Less[Nat]") = secure {
-    Inference[Less[W.`10`.T], Less[_5]].notValid
-  }
-
-  property("Greater[Nat] ==> Greater[Nat]") = secure {
-    Inference[Greater[_10], Greater[_5]].isValid
-  }
-
-  property("Greater[Nat] =!> Greater[Nat]") = secure {
-    Inference[Greater[_5], Greater[_10]].notValid
-  }
-
-  property("Greater[A] ==> Greater[Nat]") = secure {
-    Inference[Greater[W.`10`.T], Greater[_5]].isValid
-  }
-
-  property("Greater[A] =!> Greater[Nat]") = secure {
-    Inference[Greater[W.`5`.T], Greater[_10]].notValid
-  }
-
-  property("Interval[Nat] ==> LessEqual[Nat]") = secure {
-    Inference[Interval.Closed[_5, _10], LessEqual[_11]].isValid
-  }
-
-  property("Greater[A] ==> GreaterEqual[A]") = secure {
+  property("Greater[0] ==> GreaterEqual[0]") = secure {
     Inference[Greater[W.`0`.T], GreaterEqual[W.`0`.T]].isValid
   }
 
-  property("Less[A] ==> LessEqual[A]") = secure {
+  property("Less[0] ==> LessEqual[0]") = secure {
     Inference[Less[W.`0`.T], LessEqual[W.`0`.T]].isValid
   }
 
-  /*
-  property("Interval.Closed[Nat] ==> GreaterEqual[Nat]") = secure {
-    Inference[Interval.Closed[_5, _10], GreaterEqual[_4]].isValid
+  property("Interval.Closed[5, 10] ==> LessEqual[11]") = secure {
+    Inference[Interval.Closed[W.`5`.T, W.`10`.T], LessEqual[W.`11`.T]].isValid
   }
-
-  property("Equal[Nat] ==> Greater[A]") = secure {
-    Inference[Equal[_10], Greater[W.`5`.T]].isValid
-  }
-
-  property("Equal[Nat] =!> Greater[A]") = secure {
-    Inference[Equal[_5], Greater[W.`10`.T]].notValid
-  }
-   */
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/NumericValidateSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/NumericValidateSpec.scala
@@ -2,9 +2,8 @@ package eu.timepit.refined
 
 import eu.timepit.refined.TestUtils._
 import eu.timepit.refined.numeric._
-import org.scalacheck.{Arbitrary, Gen, Properties}
 import org.scalacheck.Prop._
-import shapeless.nat._
+import org.scalacheck.{Arbitrary, Gen, Properties}
 
 class NumericValidateSpec extends Properties("NumericValidate") {
 
@@ -20,24 +19,20 @@ class NumericValidateSpec extends Properties("NumericValidate") {
     isValid[Less[W.`1.0`.T]](d) ?= (d < 1.0)
   }
 
+  property("showExpr[Less[5]](0)") = secure {
+    showExpr[Less[W.`5`.T]](0) ?= "(0 < 5)"
+  }
+
   property("showExpr[Less[1.1]](0.1)") = secure {
     showExpr[Less[W.`1.1`.T]](0.1) ?= "(0.1 < 1.1)"
   }
 
-  property("Less.Nat.isValid") = forAll((i: Int) => isValid[Less[_5]](i) ?= (i < 5))
-
-  property("Less.Nat.showExpr") = secure {
-    showExpr[Less[_5]](0) ?= "(0 < 5)"
+  property("isValid[LessEqual[5]](i: Int)") = forAll { (i: Int) =>
+    isValid[LessEqual[W.`5`.T]](i) ?= (i <= 5)
   }
 
-  property("LessEqual.Nat.isValid") = forAll((i: Int) => isValid[LessEqual[_5]](i) ?= (i <= 5))
-
-  property("LessEqual.Nat.showExpr") = secure {
-    showExpr[LessEqual[_5]](0) ?= "!(0 > 5)"
-  }
-
-  property("Less.Nat ~= Less.Int") = forAll { (i: Int) =>
-    showResult[Less[_5]](i) ?= showResult[Less[W.`5`.T]](i)
+  property("showExpr[LessEqual[5]](0)") = secure {
+    showExpr[LessEqual[W.`5`.T]](0) ?= "!(0 > 5)"
   }
 
   property("isValid[Greater[1.0]](b: Byte)") = forAll { (b: Byte) =>
@@ -48,158 +43,126 @@ class NumericValidateSpec extends Properties("NumericValidate") {
     isValid[Greater[W.`1.0`.T]](d) ?= (d > 1.0)
   }
 
-  property("Greater.showExpr") = secure {
+  property("showExpr[Greater[1.1]](0.1)") = secure {
     showExpr[Greater[W.`1.1`.T]](0.1) ?= "(0.1 > 1.1)"
   }
 
-  property("Greater.Nat.isValid") = forAll((i: Int) => isValid[Greater[_5]](i) ?= (i > 5))
-
-  property("Greater.Nat.showExpr") = secure {
-    showExpr[Greater[_5]](0) ?= "(0 > 5)"
+  property("isValid[GreaterEqual[5L]](l: Long)") = forAll { (l: Long) =>
+    isValid[GreaterEqual[W.`5L`.T]](l) ?= (l >= 5L)
   }
 
-  property("GreaterEqual.Nat.isValid") = forAll { (i: Int) =>
-    isValid[GreaterEqual[_5]](i) ?= (i >= 5)
+  property("showExpr[GreaterEqual[5]](0)") = secure {
+    showExpr[GreaterEqual[W.`5`.T]](0) ?= "!(0 < 5)"
   }
 
-  property("GreaterEqual.Nat.showExpr") = secure {
-    showExpr[GreaterEqual[_5]](0) ?= "!(0 < 5)"
+  property("isValid[Modulo[2, 0]](b: Byte)") = forAll { (b: Byte) =>
+    isValid[Modulo[W.`2`.T, W.`0`.T]](b) ?= (b % 2 == 0)
   }
 
-  property("Greater.Nat ~= Greater.Int") = forAll { (i: Int) =>
-    showResult[Greater[_5]](i) ?= showResult[Greater[W.`5`.T]](i)
+  property("isValid[Modulo[2, 0]](s: Short)") = forAll { (s: Short) =>
+    isValid[Modulo[W.`2`.T, W.`0`.T]](s) ?= (s % 2 == 0)
   }
 
-  property("Modulo.isValid - Nat - Byte") = forAll { (b: Byte) =>
-    isValid[Modulo[_2, _0]](b) ?= (b % 2 == 0)
-  }
-
-  property("Modulo.isValid - Nat - Short") = forAll { (s: Short) =>
-    isValid[Modulo[_2, _0]](s) ?= (s % 2 == 0)
-  }
-
-  property("Modulo.isValid - Nat - Int") = forAll { (i: Int) =>
-    isValid[Modulo[_2, _0]](i) ?= (i % 2 == 0)
-  }
-
-  property("Modulo.isValid - Wit - Int") = forAll { (i: Int) =>
+  property("isValid[Modulo[2, 0]](i: Int)") = forAll { (i: Int) =>
     isValid[Modulo[W.`2`.T, W.`0`.T]](i) ?= (i % 2 == 0)
   }
 
-  property("Modulo.isValid - Nat - Long") = forAll { (l: Long) =>
-    isValid[Modulo[_2, _0]](l) ?= (l % 2 == 0)
+  property("isValid[Modulo[2, 0]](l: Long)") = forAll { (l: Long) =>
+    isValid[Modulo[W.`2`.T, W.`0`.T]](l) ?= (l % 2 == 0)
   }
 
-  property("Modulo.isValid - Wit - Long") = forAll { (l: Long) =>
+  property("isValid[Modulo[2L, 0L]](l: Long)") = forAll { (l: Long) =>
     isValid[Modulo[W.`2L`.T, W.`0L`.T]](l) ?= (l % 2 == 0)
   }
 
-  property("Modulo.showExpr") = secure {
+  property("showExpr[Modulo[2, 0]](4)") = secure {
     showExpr[Modulo[W.`2`.T, W.`0`.T]](4) ?= s"(${4} % ${2} == ${0})"
   }
 
-  property("Modulo.Nat.isValid") = forAll((i: Int) => isValid[Modulo[_2, _0]](i) ?= (i % 2 == 0))
-
-  property("Modulo.Nat.showExpr") = secure {
-    showExpr[Modulo[_2, _0]](4) ?= "(4 % 2 == 0)"
-  }
-
-  property("Modulo.Nat ~= Modulo.Int") = forAll { (i: Int) =>
-    showResult[Modulo[_5, _2]](i) ?= showResult[Modulo[W.`5`.T, W.`2`.T]](i)
-  }
-
-  property("Divisible.Nat.isValid") = forAll { (i: Int) =>
-    isValid[Divisible[_2]](i) ?= (i % 2 == 0)
-  }
-
-  property("Divisible.Int.isValid") = forAll { (i: Int) =>
+  property("isValid[Divisible[2]](i: Int)") = forAll { (i: Int) =>
     isValid[Divisible[W.`2`.T]](i) ?= (i % 2 == 0)
   }
 
-  property("Divisible.Nat.showExpr") = secure {
-    showExpr[Divisible[_2]](4) ?= "(4 % 2 == 0)"
-  }
-
-  property("Divisible.Int.showExpr") = secure {
+  property("showExpr[Divisible[2]](4)") = secure {
     showExpr[Divisible[W.`2`.T]](4) ?= "(4 % 2 == 0)"
   }
 
-  property("NonDivisible.isValid") = forAll { (i: Int) =>
-    isValid[NonDivisible[_2]](i) ?= (i % 2 != 0)
+  property("isValid[NonDivisible[2]](i: Int)") = forAll { (i: Int) =>
+    isValid[NonDivisible[W.`2`.T]](i) ?= (i % 2 != 0)
   }
 
-  property("NonDivisible.showExpr") = secure {
-    showExpr[NonDivisible[_2]](4) ?= "!(4 % 2 == 0)"
+  property("showExpr[NonDivisible[2]](4)") = secure {
+    showExpr[NonDivisible[W.`2`.T]](4) ?= "!(4 % 2 == 0)"
   }
 
-  property("Even.isValid") = forAll { (i: Int) =>
+  property("isValid[Even](i: Int)") = forAll { (i: Int) =>
     isValid[Even](i) ?= (i % 2 == 0)
   }
 
-  property("Even.showExpr") = secure {
+  property("showExpr[Even](4)") = secure {
     showExpr[Even](4) ?= "(4 % 2 == 0)"
   }
 
-  property("Odd.isValid") = forAll { (i: Int) =>
+  property("isValid[Odd](i: Int)") = forAll { (i: Int) =>
     isValid[Odd](i) ?= (i % 2 != 0)
   }
 
-  property("Odd.showExpr") = secure {
+  property("showExpr[Odd](4)") = secure {
     showExpr[Odd](4) ?= "!(4 % 2 == 0)"
   }
 
-  property("Interval.Open.isValid") = forAll { (d: Double) =>
-    isValid[Interval.Open[_0, _1]](d) ?= (d > 0.0 && d < 1.0)
+  property("isValid[Interval.Open[0, 1]](d: Double)") = forAll { (d: Double) =>
+    isValid[Interval.Open[W.`0`.T, W.`1`.T]](d) ?= (d > 0.0 && d < 1.0)
   }
 
-  property("Interval.Open.showExpr") = secure {
-    val s = showExpr[Interval.Open[_0, _1]](0.5)
+  property("showExpr[Interval.Open[0, 1]](0.5)") = secure {
+    val s = showExpr[Interval.Open[W.`0`.T, W.`1`.T]](0.5)
     (s ?= "((0.5 > 0) && (0.5 < 1))") || (s ?= "((0.5 > 0.0) && (0.5 < 1.0))")
   }
 
-  property("Interval.OpenClosed.isValid") = forAll { (d: Double) =>
-    isValid[Interval.OpenClosed[_0, _1]](d) ?= (d > 0.0 && d <= 1.0)
+  property("isValid[Interval.OpenClosed[0, 1]](d: Double)") = forAll { (d: Double) =>
+    isValid[Interval.OpenClosed[W.`0`.T, W.`1`.T]](d) ?= (d > 0.0 && d <= 1.0)
   }
 
-  property("Interval.OpenClosed.showExpr") = secure {
-    val s = showExpr[Interval.OpenClosed[_0, _1]](0.5)
+  property("showExpr[Interval.OpenClosed[0, 1]](0.5)") = secure {
+    val s = showExpr[Interval.OpenClosed[W.`0`.T, W.`1`.T]](0.5)
     (s ?= "((0.5 > 0) && !(0.5 > 1))") || (s ?= "((0.5 > 0.0) && !(0.5 > 1.0))")
   }
 
-  property("Interval.ClosedOpen.isValid") = forAll { (d: Double) =>
-    isValid[Interval.ClosedOpen[_0, _1]](d) ?= (d >= 0.0 && d < 1.0)
+  property("isValid[Interval.ClosedOpen[0, 1]](d: Double)") = forAll { (d: Double) =>
+    isValid[Interval.ClosedOpen[W.`0`.T, W.`1`.T]](d) ?= (d >= 0.0 && d < 1.0)
   }
 
-  property("Interval.ClosedOpen.showExpr") = secure {
-    val s = showExpr[Interval.ClosedOpen[_0, _1]](0.5)
+  property("showExpr[Interval.ClosedOpen[0, 1]](0.5)") = secure {
+    val s = showExpr[Interval.ClosedOpen[W.`0`.T, W.`1`.T]](0.5)
     (s ?= "(!(0.5 < 0) && (0.5 < 1))") || (s ?= "(!(0.5 < 0.0) && (0.5 < 1.0))")
   }
 
-  property("Interval.Closed.isValid") = forAll { (d: Double) =>
-    isValid[Interval.Closed[_0, _1]](d) ?= (d >= 0.0 && d <= 1.0)
+  property("isValid[Interval.Closed[0, 1]](d: Double)") = forAll { (d: Double) =>
+    isValid[Interval.Closed[W.`0`.T, W.`1`.T]](d) ?= (d >= 0.0 && d <= 1.0)
   }
 
-  property("Interval.Closed.showExpr") = secure {
-    val s = showExpr[Interval.Closed[_0, _1]](0.5)
+  property("showExpr[Interval.Closed[0, 1]](0.5)") = secure {
+    val s = showExpr[Interval.Closed[W.`0`.T, W.`1`.T]](0.5)
     (s ?= "(!(0.5 < 0) && !(0.5 > 1))") || (s ?= "(!(0.5 < 0.0) && !(0.5 > 1.0))")
   }
 
   val floatWithNaN: Gen[Float] = Gen.frequency(8 -> Arbitrary.arbitrary[Float], 2 -> Float.NaN)
   val doubleWithNaN: Gen[Double] = Gen.frequency(8 -> Arbitrary.arbitrary[Double], 2 -> Double.NaN)
 
-  property("NonNaN.Float.isValid") = forAll(floatWithNaN) { (d: Float) =>
-    isValid[NonNaN](d) ?= !d.isNaN
+  property("isValid[NonNaN](f: Float)") = forAll(floatWithNaN) { (f: Float) =>
+    isValid[NonNaN](f) ?= !f.isNaN
   }
 
-  property("NonNaN.Float.showExpr") = secure {
+  property("showExpr[NonNaN](Float.NaN)") = secure {
     showExpr[NonNaN](Float.NaN) ?= "(NaN != NaN)"
   }
 
-  property("NonNaN.Double.isValid") = forAll(doubleWithNaN) { (d: Double) =>
+  property("isValid[NonNaN](d: Double)") = forAll(doubleWithNaN) { (d: Double) =>
     isValid[NonNaN](d) ?= !d.isNaN
   }
 
-  property("NonNaN.Double.showExpr") = secure {
+  property("showExpr[NonNaN](Double.NaN)") = secure {
     showExpr[NonNaN](Double.NaN) ?= "(NaN != NaN)"
   }
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/RefineMSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/RefineMSpec.scala
@@ -8,7 +8,6 @@ import eu.timepit.refined.numeric._
 import eu.timepit.refined.string.MatchesRegex
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import shapeless.nat._
 import shapeless.tag.@@
 import shapeless.test.illTyped
 
@@ -28,14 +27,14 @@ class RefineMSpec extends Properties("refineM") {
   }
 
   property("refineM with Greater") = wellTyped {
-    def ignore1: Int Refined Greater[_10] = refineMV[Greater[_10]](15)
-    def ignore2: Int @@ Greater[_10] = refineMT[Greater[_10]](15)
-    illTyped("""refineMV[Greater[_10]](5)""", "Predicate.*fail.*")
-    illTyped("""refineMT[Greater[_10]](5)""", "Predicate.*fail.*")
+    def ignore1: Int Refined Greater[W.`10`.T] = refineMV[Greater[W.`10`.T]](15)
+    def ignore2: Int @@ Greater[W.`10`.T] = refineMT[Greater[W.`10`.T]](15)
+    illTyped("""refineMV[Greater[W.`10`.T]](5)""", "Predicate.*fail.*")
+    illTyped("""refineMT[Greater[W.`10`.T]](5)""", "Predicate.*fail.*")
   }
 
   property("refineM with Size") = wellTyped {
-    type ShortString = Size[LessEqual[_10]]
+    type ShortString = Size[LessEqual[W.`10`.T]]
     def ignore1: String Refined ShortString = refineMV[ShortString]("abc")
     def ignore2: String @@ ShortString = refineMT[ShortString]("abc")
     illTyped("""refineMV[ShortString]("abcdefghijklmnopqrstuvwxyz")""", "Predicate.*fail.*")

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/api/RefTypeSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/api/RefTypeSpec.scala
@@ -11,7 +11,6 @@ import eu.timepit.refined.string.MatchesRegex
 import org.scalacheck.Prop._
 import org.scalacheck.Properties
 import shapeless.<:!<
-import shapeless.nat._
 import shapeless.tag.@@
 import shapeless.test.illTyped
 
@@ -36,10 +35,6 @@ abstract class RefTypeSpec[F[_, _]](name: String)(implicit rt: RefType[F])
 
   property("refine success with Less") = secure {
     rt.refine[Less[W.`100`.T]](-100).isRight
-  }
-
-  property("refine success with Greater") = secure {
-    rt.refine[Greater[_5]](6).isRight
   }
 
   property("refine failure with Interval.Closed") = secure {


### PR DESCRIPTION
This removes almost all usages of `shapeless.Nat` in tests to make
deprecating support of `Nat` easier.