### PR TITLE
in MiMa settings, don't blow up on Scala nightlies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -320,7 +320,7 @@ def moduleJvmSettings(name: String): Seq[Def.Setting[_]] =
     crossScalaVersions := moduleCrossScalaVersionsMatrix(name, JVMPlatform),
     mimaPreviousArtifacts := {
       val hasPredecessor = !unreleasedModules.value.contains(moduleName.value)
-      if (hasPredecessor && publishArtifact.value)
+      if (hasPredecessor && publishArtifact.value && !scalaBinaryVersion.value.contains("-bin-"))
         bincompatVersions.value(scalaBinaryVersion.value).map(v => groupId %% moduleName.value % v)
       else
         Set.empty


### PR DESCRIPTION
this turned up in the Scala community build, where of course we're testing nightlies