### PR TITLE
Add scallop module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
       - name: Compress target directories
-        run: tar cf targets.tar modules/jsonpath/jvm/target modules/shapeless/js/target target modules/docs/target modules/pureconfig/jvm/target modules/core/js/target modules/core/jvm/target modules/scodec/jvm/target modules/scodec/js/target modules/shapeless/jvm/target modules/cats/js/target modules/cats/jvm/target modules/eval/jvm/target modules/scopt/jvm/target modules/scalaz/jvm/target modules/scalacheck/jvm/target modules/scalacheck/js/target modules/benchmark/target project/target
+        run: tar cf targets.tar modules/jsonpath/jvm/target modules/shapeless/js/target target modules/scallop/jvm/target modules/docs/target modules/pureconfig/jvm/target modules/core/js/target modules/core/jvm/target modules/scallop/js/target modules/scodec/jvm/target modules/scodec/js/target modules/shapeless/jvm/target modules/cats/js/target modules/cats/jvm/target modules/eval/jvm/target modules/scopt/jvm/target modules/scalaz/jvm/target modules/scalacheck/jvm/target modules/scalacheck/js/target modules/benchmark/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ val shapelessVersion = "2.3.3"
 val scalaCheckVersion = "1.15.1"
 val scalaXmlVersion = "1.3.0"
 val scalazVersion = "7.3.2"
+val scallopVersion = "4.0.0"
 val scodecVersion = "1.11.7"
 val scoptVersion = "4.0.0"
 
@@ -48,9 +49,10 @@ val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
   "pureconfig" -> List(JVMPlatform),
   "scalacheck" -> List(JVMPlatform, JSPlatform),
   "scalaz" -> List(JVMPlatform),
+  "scallop" -> List(JVMPlatform, JSPlatform),
   "scodec" -> List(JVMPlatform, JSPlatform),
   "scopt" -> List(JVMPlatform),
-  "shapeless" -> List(JVMPlatform, JSPlatform)
+  "shapeless" -> List(JVMPlatform, JSPlatform),
 )
 
 val moduleCrossScalaVersionsMatrix: (String, Platform) => List[String] = {
@@ -252,6 +254,17 @@ lazy val scalaz = myCrossProject("scalaz")
   )
 
 lazy val scalazJVM = scalaz.jvm
+
+lazy val scallop = myCrossProject("scallop")
+  .dependsOn(core % "compile->compile;test->test")
+  .settings(
+    libraryDependencies ++= macroParadise(Test).value ++ Seq(
+      "org.rogach" %%% "scallop" % scallopVersion
+    )
+  )
+
+lazy val scallopJVM = scallop.jvm
+lazy val scallopJS = scallop.js
 
 lazy val scodec = myCrossProject("scodec")
   .dependsOn(core % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
   "scallop" -> List(JVMPlatform, JSPlatform),
   "scodec" -> List(JVMPlatform, JSPlatform),
   "scopt" -> List(JVMPlatform),
-  "shapeless" -> List(JVMPlatform, JSPlatform),
+  "shapeless" -> List(JVMPlatform, JSPlatform)
 )
 
 val moduleCrossScalaVersionsMatrix: (String, Platform) => List[String] = {

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -37,4 +37,5 @@ bincompatVersions in ThisBuild := Map(
 unreleasedModules in ThisBuild := Set(
   // Example:
   // "refined-eval"
+  "refined-scallop"
 )

--- a/modules/scallop/shared/src/main/scala/eu/timepit/refined/scallop/package.scala
+++ b/modules/scallop/shared/src/main/scala/eu/timepit/refined/scallop/package.scala
@@ -5,11 +5,10 @@ import eu.timepit.refined.api.{RefType, Validate}
 
 package object scallop {
 
-  implicit def refTypeConverter[F[_, _], T, P](
-    implicit
-    converter: ValueConverter[T],
-    refType: RefType[F],
-    validate: Validate[T, P]
+  implicit def refTypeConverter[F[_, _], T, P](implicit
+      converter: ValueConverter[T],
+      refType: RefType[F],
+      validate: Validate[T, P]
   ): ValueConverter[F[T, P]] = converter.map(t => refType.refine[P].unsafeFrom(t))
 
 }

--- a/modules/scallop/shared/src/main/scala/eu/timepit/refined/scallop/package.scala
+++ b/modules/scallop/shared/src/main/scala/eu/timepit/refined/scallop/package.scala
@@ -1,0 +1,15 @@
+package eu.timepit.refined
+
+import _root_.org.rogach.scallop.ValueConverter
+import eu.timepit.refined.api.{RefType, Validate}
+
+package object scallop {
+
+  implicit def refTypeConverter[F[_, _], T, P](
+    implicit
+    converter: ValueConverter[T],
+    refType: RefType[F],
+    validate: Validate[T, P]
+  ): ValueConverter[F[T, P]] = converter.map(t => refType.refine[P].unsafeFrom(t))
+
+}

--- a/modules/scallop/shared/src/test/scala/eu/timepit/refined/scallop/RefTypeReadSpec.scala
+++ b/modules/scallop/shared/src/test/scala/eu/timepit/refined/scallop/RefTypeReadSpec.scala
@@ -1,0 +1,36 @@
+package eu.timepit.refined.scallop
+
+import eu.timepit.refined.types.numeric.PosInt
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+import org.rogach.scallop._
+import org.rogach.scallop.exceptions._
+import scala.util.{Try, Success, Failure}
+
+class RefTypeReadSpec extends Properties("RefTypeRead") {
+  org.rogach.scallop.throwError.value = true
+
+  class Config(args: Seq[String]) extends ScallopConf(args) {
+    val foo = trailArg[PosInt](descr = "foo is a positive integer property")
+    verify()
+  }
+
+  property("load success") = secure {
+    loadConfigWithValue("10").map(_.foo()) =?
+      Success(PosInt.unsafeFrom(10))
+  }
+
+  property("load failure (predicate)") = secure {
+    loadConfigWithValue("0") =?
+      Failure(WrongOptionFormat("foo", "0", "java.lang.IllegalArgumentException: Predicate failed: (0 > 0)."))
+  }
+
+  property("load failure (wrong type)") = secure {
+    loadConfigWithValue("abc") =?
+      Failure(WrongOptionFormat("foo", "abc", "bad Int value"))
+  }
+
+  def loadConfigWithValue(value: String): Try[Config] =
+    Try(new Config(Seq(value)))
+
+}

--- a/modules/scallop/shared/src/test/scala/eu/timepit/refined/scallop/RefTypeReadSpec.scala
+++ b/modules/scallop/shared/src/test/scala/eu/timepit/refined/scallop/RefTypeReadSpec.scala
@@ -22,7 +22,13 @@ class RefTypeReadSpec extends Properties("RefTypeRead") {
 
   property("load failure (predicate)") = secure {
     loadConfigWithValue("0") =?
-      Failure(WrongOptionFormat("foo", "0", "java.lang.IllegalArgumentException: Predicate failed: (0 > 0)."))
+      Failure(
+        WrongOptionFormat(
+          "foo",
+          "0",
+          "java.lang.IllegalArgumentException: Predicate failed: (0 > 0)."
+        )
+      )
   }
 
   property("load failure (wrong type)") = secure {

--- a/modules/scallop/shared/src/test/scala/eu/timepit/refined/scallop/RefTypeReadSpec.scala
+++ b/modules/scallop/shared/src/test/scala/eu/timepit/refined/scallop/RefTypeReadSpec.scala
@@ -11,7 +11,7 @@ class RefTypeReadSpec extends Properties("RefTypeRead") {
   org.rogach.scallop.throwError.value = true
 
   class Config(args: Seq[String]) extends ScallopConf(args) {
-    val foo = trailArg[PosInt](descr = "foo is a positive integer property")
+    val foo = trailArg[PosInt]("foo", descr = "foo is a positive integer property")
     verify()
   }
 


### PR DESCRIPTION
I'm submitting this PR on behalf of [scallop#194](https://github.com/scallop/scallop/issues/194). Scallop is a CLI parser library, similar to scopt. Implementation of refined is also very similar to scopt's implementation.