### PR TITLE
Adds Validate[F[T], Size[P]] for every F[_]: Foldable.

### DIFF
--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/derivation.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/derivation.scala
@@ -32,4 +32,5 @@ trait DerivationInstances {
       gt: G[T]
   ): G[F[T, P]] =
     m.flatMap(gt)(t => m.fromEither(rt.refine[P](t)))
+
 }

--- a/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/unorderedFoldable.scala
+++ b/modules/cats/shared/src/main/scala/eu/timepit/refined/cats/unorderedFoldable.scala
@@ -1,0 +1,39 @@
+package eu.timepit.refined.cats
+
+import cats.UnorderedFoldable
+import cats.syntax.unorderedFoldable._
+import eu.timepit.refined.api.Validate
+import eu.timepit.refined.collection.Size
+import eu.timepit.refined.internal.Resources
+
+/** Module for unorderedFoldable instances. */
+object unorderedFoldable extends UnorderedFoldableInstances
+
+trait UnorderedFoldableInstances {
+
+  /**
+   * `Validate` instance for `F` via `UnorderedFoldable[F]`.
+   *
+   * Examples: NonEmptyList, NonEmptyVector.
+   */
+  implicit def sizeValidateInstance[F[_]: UnorderedFoldable, T, P, RP](implicit
+      v: Validate.Aux[Long, P, RP]
+  ): Validate.Aux[F[T], Size[P], Size[v.Res]] =
+    new Validate[F[T], Size[P]] {
+      override type R = Size[v.Res]
+
+      override def validate(t: F[T]): Res = {
+        val r = v.validate(t.size)
+        r.as(Size(r))
+      }
+
+      override def showExpr(t: F[T]): String =
+        v.showExpr(t.size)
+
+      override def showResult(t: F[T], r: Res): String = {
+        val size = t.size
+        val nested = v.showResult(size, r.detail.p)
+        Resources.predicateTakingResultDetail(s"size($t) = $size", r, nested)
+      }
+    }
+}

--- a/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/UnorderedFoldableSpec.scala
+++ b/modules/cats/shared/src/test/scala/eu/timepit/refined/cats/UnorderedFoldableSpec.scala
@@ -1,0 +1,32 @@
+package eu.timepit.refined.cats
+
+import cats.data.NonEmptyList
+import eu.timepit.refined.api.Validate
+import eu.timepit.refined.collection.MinSize
+import eu.timepit.refined.{W, refineV}
+import org.scalacheck.Prop.{AnyOperators, secure}
+import org.scalacheck.Properties
+
+class UnorderedFoldableSpec extends Properties("unorderedFoldable") {
+
+  property("Size validate for NonEmptyList") = secure {
+    import eu.timepit.refined.cats.unorderedFoldable.sizeValidateInstance
+    val nel = NonEmptyList.of(1, 2)
+    refineV[MinSize[W.`2`.T]](nel) ?= Right(refineV[MinSize[W.`2`.T]].unsafeFrom(nel))
+  }
+
+  property("Failing Size validate for NonEmptyList") = secure {
+    import eu.timepit.refined.cats.unorderedFoldable.sizeValidateInstance
+    val nel = NonEmptyList.of(1, 2)
+    refineV[MinSize[W.`3`.T]](nel) ?= Left(
+      "Predicate taking size(NonEmptyList(1, 2)) = 2 failed: Predicate (2 < 3) did not fail."
+    )
+  }
+
+  property("showExpr for NonEmptyList") = secure {
+    import eu.timepit.refined.cats.unorderedFoldable.sizeValidateInstance
+    val nel = NonEmptyList.of(1, 2)
+    Validate[NonEmptyList[Int], MinSize[W.`3`.T]].showExpr(nel) ?= "!(2 < 3)"
+  }
+
+}


### PR DESCRIPTION
This allows refining NonEmptyList et.al. which do not implement Iterable.

For some Foldables there of course exist higher performance implementations. However this implementation is very general and for NonEmptyList / NonEmptyChain at least is very similar with regard of performance.

Concerning the tests: I am not very happy with them because they also test logic outside of my implementation and rely on the String representations of predicates. Ideas welcome.