### PR TITLE
Experiment: refine macro in Scala 3

### DIFF
--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/package.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/package.scala
@@ -14,6 +14,28 @@ package object refined {
    */
   def refineV[P]: RefinePartiallyApplied[Refined, P] = RefType.refinedRefType.refine[P]
 
+  trait Predicate[T, P] {
+    inline def isValid(inline t: T): Boolean
+  }
+
+  class Positive1
+  object Positive1 {
+    inline given Predicate[Int, Positive1] with
+      inline def isValid(inline t: Int): Boolean = t > 0
+  }
+
+  class NonEmpty1
+  object NonEmpty1 {
+    inline given Predicate[String, NonEmpty1] with
+      inline def isValid(inline s: String): Boolean = !(s == "")
+    // If we use !s.isEmpty here, we get the following compile error:
+    // |Cannot reduce `inline if` because its condition is not a constant value: "hello".isEmpty().unary_! :Boolean
+  }
+
+  inline def refineMV[T, P](inline t: T)(using inline p: Predicate[T, P]): Refined[T, P] = {
+    inline if (p.isValid(t)) Refined.unsafeApply(t) else scala.compiletime.error("no")
+  }
+
   /**
    * Alias for `[[api.RefType.refine]][P]` with `shapeless.tag.@@` as type
    * parameter for `[[api.RefType]]`.


### PR DESCRIPTION
This works with inline type classes and conditions that can be evaluated
at compile-time like `>`, `!`, and `==`:
```scala
scala> refineMV[Int, Positive1](5)
val res1: eu.timepit.refined.api.Refined[Int, eu.timepit.refined.Positive1] = 5

scala> refineMV[Int, Positive1](-5)
1 |refineMV[Int, Positive1](-5)
  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |no

scala> refineMV[String, NonEmpty1]("hello")
val res2: eu.timepit.refined.api.Refined[String, eu.timepit.refined.NonEmpty1] = hello

scala> refineMV[String, NonEmpty1]("")
1 |refineMV[String, NonEmpty1]("")
  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |no
```