### PR TITLE
Inferences for various String refinement that are always non empty

### DIFF
--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/string.scala
@@ -2,6 +2,7 @@ package eu.timepit.refined
 
 import eu.timepit.refined.api.{Inference, Validate}
 import eu.timepit.refined.api.Inference.==>
+import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.string._
 
 /**
@@ -262,4 +263,41 @@ private[refined] trait StringInference {
       wb: ValueOf[B]
   ): StartsWith[A] ==> StartsWith[B] =
     Inference(wa.value.startsWith(wb.value), s"startsWithInference(${wa.value}, ${wb.value})")
+
+
+  implicit def urlNonEmptyInference: Url ==> NonEmpty =
+    Inference.alwaysValid("urlNonEmptyInference")
+
+  implicit def uuidNonEmptyInference: Uuid ==> NonEmpty =
+    Inference.alwaysValid("uuidNonEmptyInference")
+
+  implicit def validByteNonEmptyInference: ValidByte ==> NonEmpty =
+    Inference.alwaysValid("validByteNonEmptyInference")
+
+  implicit def validShortNonEmptyInference: ValidShort ==> NonEmpty =
+    Inference.alwaysValid("validShortNonEmptyInference")
+
+  implicit def validLongNonEmptyInference: ValidLong ==> NonEmpty =
+    Inference.alwaysValid("validLongNonEmptyInference")
+
+  implicit def validFloatNonEmptyInference: ValidFloat ==> NonEmpty =
+    Inference.alwaysValid("validFloatNonEmptyInference")
+
+  implicit def validDoubleNonEmptyInference: ValidDouble ==> NonEmpty =
+    Inference.alwaysValid("validDoubleNonEmptyInference")
+
+  implicit def validIntNonEmptyInference: ValidInt ==> NonEmpty =
+    Inference.alwaysValid("validIntNonEmptyInference")
+
+  implicit def validBigIntNonEmptyInference: ValidBigInt ==> NonEmpty =
+    Inference.alwaysValid("validBigIntNonEmptyInference")
+
+  implicit def validBigDecimalNonEmptyInference: ValidBigDecimal ==> NonEmpty =
+    Inference.alwaysValid("validBigDecimalNonEmptyInference")
+
+  implicit def xmlNonEmptyInference: Xml ==> NonEmpty =
+    Inference.alwaysValid("xmlNonEmptyInference")
+
+  implicit def xPathNonEmptyInference: XPath ==> NonEmpty =
+    Inference.alwaysValid("xPathNonEmptyInference")
 }

--- a/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/string.scala
@@ -2,6 +2,7 @@ package eu.timepit.refined
 
 import eu.timepit.refined.api.{Inference, Validate}
 import eu.timepit.refined.api.Inference.==>
+import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.string._
 import shapeless.Witness
 
@@ -263,4 +264,40 @@ private[refined] trait StringInference {
       wb: Witness.Aux[B]
   ): StartsWith[A] ==> StartsWith[B] =
     Inference(wa.value.startsWith(wb.value), s"startsWithInference(${wa.value}, ${wb.value})")
+
+  implicit def urlNonEmptyInference: Url ==> NonEmpty =
+    Inference.alwaysValid("urlNonEmptyInference")
+
+  implicit def uuidNonEmptyInference: Uuid ==> NonEmpty =
+    Inference.alwaysValid("uuidNonEmptyInference")
+
+  implicit def validByteNonEmptyInference: ValidByte ==> NonEmpty =
+    Inference.alwaysValid("validByteNonEmptyInference")
+
+  implicit def validShortNonEmptyInference: ValidShort ==> NonEmpty =
+    Inference.alwaysValid("validShortNonEmptyInference")
+
+  implicit def validLongNonEmptyInference: ValidLong ==> NonEmpty =
+    Inference.alwaysValid("validLongNonEmptyInference")
+
+  implicit def validFloatNonEmptyInference: ValidFloat ==> NonEmpty =
+    Inference.alwaysValid("validFloatNonEmptyInference")
+
+  implicit def validDoubleNonEmptyInference: ValidDouble ==> NonEmpty =
+    Inference.alwaysValid("validDoubleNonEmptyInference")
+
+  implicit def validIntNonEmptyInference: ValidInt ==> NonEmpty =
+    Inference.alwaysValid("validIntNonEmptyInference")
+
+  implicit def validBigIntNonEmptyInference: ValidBigInt ==> NonEmpty =
+    Inference.alwaysValid("validBigIntNonEmptyInference")
+
+  implicit def validBigDecimalNonEmptyInference: ValidBigDecimal ==> NonEmpty =
+    Inference.alwaysValid("validBigDecimalNonEmptyInference")
+
+  implicit def xmlNonEmptyInference: Xml ==> NonEmpty =
+    Inference.alwaysValid("xmlNonEmptyInference")
+
+  implicit def xPathNonEmptyInference: XPath ==> NonEmpty =
+    Inference.alwaysValid("xPathNonEmptyInference")
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
@@ -67,5 +67,4 @@ class StringInferenceSpec extends Properties("StringInference") {
     Inference[ValidBigDecimal, NonEmpty].isValid
   }
 
-
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
@@ -4,7 +4,7 @@ import eu.timepit.refined.api.Inference
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.string._
 import org.scalacheck.Prop._
-import org.scalacheck.{Arbitrary, Properties}
+import org.scalacheck.Properties
 
 class StringInferenceSpec extends Properties("StringInference") {
 

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
@@ -1,9 +1,10 @@
 package eu.timepit.refined
 
 import eu.timepit.refined.api.Inference
+import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.string._
 import org.scalacheck.Prop._
-import org.scalacheck.Properties
+import org.scalacheck.{Arbitrary, Properties}
 
 class StringInferenceSpec extends Properties("StringInference") {
 
@@ -22,4 +23,49 @@ class StringInferenceSpec extends Properties("StringInference") {
   property("StartsWith =!> StartsWith") = secure {
     Inference[StartsWith[W.`"cde"`.T], StartsWith[W.`"de"`.T]].notValid
   }
+
+  property("UUID ==> NonEmpty ") = secure {
+    Inference[Uuid, NonEmpty].isValid
+  }
+
+  property("Url ==> NonEmpty ") = secure {
+    Inference[Url, NonEmpty].isValid
+  }
+
+  property("Xml ==> NonEmpty ") = secure {
+    Inference[Xml, NonEmpty].isValid
+  }
+
+  property("ValidByte ==> NonEmpty ") = secure {
+    Inference[ValidByte, NonEmpty].isValid
+  }
+
+  property("ValidShort ==> NonEmpty ") = secure {
+    Inference[ValidShort, NonEmpty].isValid
+  }
+
+  property("ValidInt ==> NonEmpty ") = secure {
+    Inference[ValidInt, NonEmpty].isValid
+  }
+  property("ValidLong ==> NonEmpty ") = secure {
+    Inference[ValidLong, NonEmpty].isValid
+  }
+
+  property("ValidFloat ==> NonEmpty ") = secure {
+    Inference[ValidFloat, NonEmpty].isValid
+  }
+
+  property("ValidDouble ==> NonEmpty ") = secure {
+    Inference[ValidDouble, NonEmpty].isValid
+  }
+
+  property("ValidBigInt ==> NonEmpty ") = secure {
+    Inference[ValidBigInt, NonEmpty].isValid
+  }
+
+  property("ValidBigDecimal ==> NonEmpty ") = secure {
+    Inference[ValidBigDecimal, NonEmpty].isValid
+  }
+
+
 }


### PR DESCRIPTION
Resolves my original issue #917 of unnecessary need of having `NonEmpty And ValidLong` once we know `ValidLong` is always non empty string.