### PR TITLE
Modified singletonWitnessAs to use valueOf instead of constValue

### DIFF
--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/WitnessAs.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/WitnessAs.scala
@@ -35,8 +35,8 @@ object WitnessAs extends WitnessAs1 {
   ): WitnessAs[A, B] =
     WitnessAs(wa.value, nb.fromInt(ta.apply()))
 
-  inline given singletonWitnessAs[B, A <: B]: WitnessAs[A, B] = {
-    inline val a = constValue[A]
+  inline given singletonWitnessAs[B, A <: B: ValueOf]: WitnessAs[A, B] = {
+    val a = valueOf[A]
     WitnessAs(a, a)
   }
 }


### PR DESCRIPTION
This doesn't compile for Scala 3.0.1
```
import eu.timepit.refined.generic.Equal
import eu.timepit.refined.collection.Size
import eu.timepit.refined.refineV

val size = 2

val arr = refineV[Size[Equal[size.type]]](Array(1, 2))
```

Error message:
```
  |val arr = refineV[Size[Equal[size.type]]](Array(1, 2))
  |                                                      ^
  |                 not a constant type: (size : Int); cannot take constValue
  | This location contains code that was inlined from WitnessAs.scala:39
```

However, this does compile:

```
import eu.timepit.refined.generic.Equal
import eu.timepit.refined.collection.Size
import eu.timepit.refined.refineV
import eu.timepit.refined.internal.WitnessAs

inline given singletonWitnessAs[B, A <: B: ValueOf]: WitnessAs[A, B] = {
  val a = valueOf[A]
  WitnessAs(a, a)
}
val size = 2
val arr = refineV[Size[Equal[size.type]]](Array(1, 2))
```
Using refined with modified "signletonWitnessAs" also compiles. I don't know if this is correct fix for the issue, hope it is.