### PR TITLE
Added ValidBoolean predicate to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ The library comes with these predefined predicates:
 * `ValidDouble`: checks if a `String` is a parsable `Double`
 * `ValidBigInt`: checks if a `String` is a parsable `BigInt`
 * `ValidBigDecimal`: checks if a `String` is a parsable `BigDecimal`
+* `ValidBoolean`: checks if a `String` is a parsable `Boolean`
 * `Xml`: checks if a `String` is well-formed XML
 * `XPath`: checks if a `String` is a valid XPath expression
 * `Trimmed`: checks if a `String` has no leading or trailing whitespace

--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/string.scala
@@ -63,6 +63,9 @@ object string extends StringInference {
   /** Predicate that checks if a `String` is a parsable `BigDecimal`. */
   final case class ValidBigDecimal()
 
+  /** Predicate that checks if a `String` is a parsable `Boolean`. */
+  final case class ValidBoolean()
+
   /** Predicate that checks if a `String` is well-formed XML. */
   final case class Xml()
 
@@ -230,6 +233,11 @@ object string extends StringInference {
       Validate.fromPartial(BigDecimal(_), "ValidBigDecimal", ValidBigDecimal())
   }
 
+  object ValidBoolean {
+    implicit def validBooleanValidate: Validate.Plain[String, ValidBoolean] =
+      Validate.fromPartial(_.toBoolean, "ValidBoolean", ValidBoolean())
+  }
+
   object Xml {
     implicit def xmlValidate: Validate.Plain[String, Xml] =
       Validate.fromPartial(scala.xml.XML.loadString, "Xml", Xml())
@@ -298,6 +306,12 @@ private[refined] trait StringInference {
 
   implicit def validBigDecimalNonEmptyInference: ValidBigDecimal ==> NonEmpty =
     Inference.alwaysValid("validBigDecimalNonEmptyInference")
+
+  implicit def validBooleanNonEmptyInference: ValidBoolean ==> NonEmpty =
+    Inference.alwaysValid("validBooleanNonEmptyInference")
+
+  implicit def validBooleanTrimmedInference: ValidBoolean ==> Trimmed =
+    Inference.alwaysValid("validBooleanTrimmedInference")
 
   implicit def xmlNonEmptyInference: Xml ==> NonEmpty =
     Inference.alwaysValid("xmlNonEmptyInference")

--- a/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/string.scala
+++ b/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/string.scala
@@ -64,6 +64,9 @@ object string extends StringInference {
   /** Predicate that checks if a `String` is a parsable `BigDecimal`. */
   final case class ValidBigDecimal()
 
+  /** Predicate that checks if a `String` is a parsable `Boolean`. */
+  final case class ValidBoolean()
+
   /** Predicate that checks if a `String` is well-formed XML. */
   final case class Xml()
 
@@ -231,6 +234,11 @@ object string extends StringInference {
       Validate.fromPartial(BigDecimal(_), "ValidBigDecimal", ValidBigDecimal())
   }
 
+  object ValidBoolean {
+    implicit def validBooleanValidate: Validate.Plain[String, ValidBoolean] =
+      Validate.fromPartial(_.toBoolean, "ValidBoolean", ValidBoolean())
+  }
+
   object Xml {
     implicit def xmlValidate: Validate.Plain[String, Xml] =
       Validate.fromPartial(scala.xml.XML.loadString, "Xml", Xml())
@@ -300,6 +308,12 @@ private[refined] trait StringInference {
   implicit def validBigDecimalNonEmptyInference: ValidBigDecimal ==> NonEmpty =
     Inference.alwaysValid("validBigDecimalNonEmptyInference")
 
+  implicit def validBooleanNonEmptyInference: ValidBoolean ==> NonEmpty =
+    Inference.alwaysValid("validBooleanNonEmptyInference")
+
+  implicit def validBooleanTrimmedInference: ValidBoolean ==> Trimmed =
+    Inference.alwaysValid("validBooleanTrimmedInference")
+    
   implicit def xmlNonEmptyInference: Xml ==> NonEmpty =
     Inference.alwaysValid("xmlNonEmptyInference")
 

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
@@ -75,4 +75,12 @@ class StringInferenceSpec extends Properties("StringInference") {
     Inference[ValidBigDecimal, NonEmpty].isValid
   }
 
+  property("ValidBoolean ==> NonEmpty ") = secure {
+    Inference[ValidBoolean, NonEmpty].isValid
+  }
+
+  property("ValidBoolean ==> Trimmed ") = secure {
+    Inference[ValidBoolean, Trimmed].isValid
+  }
+
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringValidateSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringValidateSpec.scala
@@ -118,7 +118,7 @@ class StringValidateSpec extends Properties("StringValidate") {
     showResult[IPv6]("2001::0::1234") ?= "Predicate failed: 2001::0::1234 is a valid IPv6."
   }
 
-  private def validNumber[N: Arbitrary, P](name: String, invalidValue: String)(implicit
+  private def validType[N: Arbitrary, P](name: String, invalidValue: String)(implicit
       v: Validate[String, P]
   ) = {
     property(name) = secure {
@@ -132,12 +132,13 @@ class StringValidateSpec extends Properties("StringValidate") {
     }
   }
 
-  validNumber[Byte, ValidByte]("ValidByte", Short.MaxValue.toString)
-  validNumber[Short, ValidShort]("ValidShort", Int.MaxValue.toString)
-  validNumber[Int, ValidInt]("ValidInt", Long.MaxValue.toString)
-  validNumber[Long, ValidLong]("ValidLong", "1.0")
-  validNumber[Float, ValidFloat]("ValidFloat", "a")
-  validNumber[Double, ValidDouble]("ValidDouble", "a")
-  validNumber[BigInt, ValidBigInt]("ValidBigInt", "1.0")
-  validNumber[BigDecimal, ValidBigDecimal]("ValidBigDecimal", "a")
+  validType[Byte, ValidByte]("ValidByte", Short.MaxValue.toString)
+  validType[Short, ValidShort]("ValidShort", Int.MaxValue.toString)
+  validType[Int, ValidInt]("ValidInt", Long.MaxValue.toString)
+  validType[Long, ValidLong]("ValidLong", "1.0")
+  validType[Float, ValidFloat]("ValidFloat", "a")
+  validType[Double, ValidDouble]("ValidDouble", "a")
+  validType[BigInt, ValidBigInt]("ValidBigInt", "1.0")
+  validType[BigDecimal, ValidBigDecimal]("ValidBigDecimal", "a")
+  validType[Boolean, ValidBoolean]("ValidBoolean", "a")
 }


### PR DESCRIPTION
Added `ValidBoolean` predicate to string since I didn't find an existing predicate provided by core. Boolean is a common type.
Also renamed function in tests `validNumeric` to `validType` since it work not only for numerics.
Moreover, `toBoolean` infers `Trimmed`, probably the same for numeric predicates. 