### PR TITLE
Restore some Native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,17 +56,17 @@ jobs:
 
       - name: Build project (Scala 2)
         if: matrix.scala == '2.12.16' || matrix.scala == '2.13.8'
-        run: sbt ++${{ matrix.scala }} validateJVM validateJS
+        run: sbt ++${{ matrix.scala }} validateJVM validateJS validateNative
 
       - name: Build project (Scala 3)
         if: matrix.scala == '3.1.2'
-        run: sbt ++${{ matrix.scala }} validateJVM30 validateJS30
+        run: sbt ++${{ matrix.scala }} validateJVM30 validateJS30 validateNative30
 
       - name: Codecov
         uses: codecov/codecov-action@v1
 
       - name: Compress target directories
-        run: tar cf targets.tar modules/jsonpath/jvm/target modules/shapeless/js/target target modules/docs/target modules/pureconfig/jvm/target modules/core/js/target modules/core/jvm/target modules/scodec/jvm/target modules/scodec/js/target modules/shapeless/jvm/target modules/cats/js/target modules/cats/jvm/target modules/eval/jvm/target modules/scopt/jvm/target modules/scalaz/jvm/target modules/scalacheck/jvm/target modules/scalacheck/js/target modules/benchmark/target project/target
+        run: tar cf targets.tar modules/jsonpath/jvm/target modules/shapeless/js/target modules/scalacheck/native/target target modules/cats/native/target modules/core/native/target modules/docs/target modules/pureconfig/jvm/target modules/core/js/target modules/shapeless/native/target modules/core/jvm/target modules/scodec/jvm/target modules/scodec/js/target modules/shapeless/jvm/target modules/cats/js/target modules/cats/jvm/target modules/eval/jvm/target modules/scopt/jvm/target modules/scalaz/jvm/target modules/scalacheck/jvm/target modules/scalacheck/js/target modules/benchmark/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
       - name: Compress target directories
-        run: tar cf targets.tar modules/jsonpath/jvm/target modules/shapeless/js/target modules/scalacheck/native/target target modules/cats/native/target modules/core/native/target modules/docs/target modules/pureconfig/jvm/target modules/core/js/target modules/shapeless/native/target modules/core/jvm/target modules/scodec/jvm/target modules/scodec/js/target modules/shapeless/jvm/target modules/cats/js/target modules/cats/jvm/target modules/eval/jvm/target modules/scopt/jvm/target modules/scalaz/jvm/target modules/scalacheck/jvm/target modules/scalacheck/js/target modules/benchmark/target project/target
+        run: tar cf targets.tar modules/jsonpath/jvm/target modules/shapeless/js/target modules/scalacheck/native/target target modules/core/native/target modules/docs/target modules/pureconfig/jvm/target modules/core/js/target modules/shapeless/native/target modules/core/jvm/target modules/scodec/jvm/target modules/scodec/js/target modules/shapeless/jvm/target modules/cats/js/target modules/cats/jvm/target modules/eval/jvm/target modules/scopt/jvm/target modules/scalaz/jvm/target modules/scalacheck/jvm/target modules/scalacheck/js/target modules/benchmark/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,1 +1,2 @@
 -XX:+UseG1GC
+-Xmx4G

--- a/build.sbt
+++ b/build.sbt
@@ -40,16 +40,16 @@ def macroParadise(configuration: Configuration): Def.Initialize[Seq[ModuleID]] =
   }
 
 val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
-  "cats" -> List(JVMPlatform, JSPlatform),
-  "core" -> List(JVMPlatform, JSPlatform),
+  "cats" -> List(JVMPlatform, JSPlatform, NativePlatform),
+  "core" -> List(JVMPlatform, JSPlatform, NativePlatform),
   "eval" -> List(JVMPlatform),
   "jsonpath" -> List(JVMPlatform),
   "pureconfig" -> List(JVMPlatform),
-  "scalacheck" -> List(JVMPlatform, JSPlatform),
+  "scalacheck" -> List(JVMPlatform, JSPlatform, NativePlatform),
   "scalaz" -> List(JVMPlatform),
   "scodec" -> List(JVMPlatform, JSPlatform),
   "scopt" -> List(JVMPlatform),
-  "shapeless" -> List(JVMPlatform, JSPlatform)
+  "shapeless" -> List(JVMPlatform, JSPlatform, NativePlatform)
 )
 
 val moduleCrossScalaVersionsMatrix: (String, Platform) => List[String] = {
@@ -75,6 +75,7 @@ val allSubprojectsJVM30 = allSubprojectsOf(JVMPlatform, Set(Scala_3))
 val allSubprojectsJS = allSubprojectsOf(JSPlatform)
 val allSubprojectsJS30 = allSubprojectsOf(JSPlatform, Set(Scala_3))
 val allSubprojectsNative = allSubprojectsOf(NativePlatform)
+val allSubprojectsNative30 = allSubprojectsOf(NativePlatform, Set(Scala_3))
 
 /// sbt-github-actions configuration
 
@@ -100,12 +101,12 @@ ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Adopt, "8"))
 ThisBuild / githubWorkflowBuild :=
   Seq(
     WorkflowStep.Sbt(
-      List("validateJVM", "validateJS"),
+      List("validateJVM", "validateJS", "validateNative"),
       name = Some("Build project (Scala 2)"),
       cond = Some(s"matrix.scala == '$Scala_2_12' || matrix.scala == '$Scala_2_13'")
     ),
     WorkflowStep.Sbt(
-      List("validateJVM30", "validateJS30"),
+      List("validateJVM30", "validateJS30", "validateNative30"),
       name = Some("Build project (Scala 3)"),
       cond = Some(s"matrix.scala == '$Scala_3'")
     ),
@@ -515,10 +516,11 @@ addCommandsAlias(
   )
 )
 
-addCommandsAlias("compileNative", allSubprojectsNative.map(_ + "/compile"))
+addCommandsAlias("testNative", allSubprojectsNative.map(_ + "/test"))
 addCommandsAlias("testJS", allSubprojectsJS.map(_ + "/test"))
 addCommandsAlias("testJVM", allSubprojectsJVM.map(_ + "/test"))
 
+addCommandsAlias("testNative30", allSubprojectsNative30.map(_ + "/test"))
 addCommandsAlias("testJS30", allSubprojectsJS30.map(_ + "/test"))
 addCommandsAlias("testJVM30", allSubprojectsJVM30.map(_ + "/test"))
 
@@ -547,7 +549,7 @@ addCommandsAlias(
 addCommandsAlias(
   "validateNative",
   Seq(
-    "compileNative"
+    "testNative"
   )
 )
 
@@ -563,5 +565,12 @@ addCommandsAlias(
   "validateJS30",
   Seq(
     "testJS30"
+  )
+)
+
+addCommandsAlias(
+  "validateNative30",
+  Seq(
+    "testNative30"
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ def macroParadise(configuration: Configuration): Def.Initialize[Seq[ModuleID]] =
   }
 
 val moduleCrossPlatformMatrix: Map[String, List[Platform]] = Map(
-  "cats" -> List(JVMPlatform, JSPlatform, NativePlatform),
+  "cats" -> List(JVMPlatform, JSPlatform),
   "core" -> List(JVMPlatform, JSPlatform, NativePlatform),
   "eval" -> List(JVMPlatform),
   "jsonpath" -> List(JVMPlatform),
@@ -144,7 +144,7 @@ lazy val cats = myCrossProject("cats")
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % catsVersion,
       "org.typelevel" %%% "cats-laws" % catsVersion % Test,
-      "org.typelevel" %%% "discipline-scalatest" % "2.1.5" % Test
+      "org.typelevel" %%% "discipline-scalatest" % "2.2.0" % Test
     ),
     initialCommands += s"""
       import $rootPkg.cats._

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringValidateSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringValidateSpec.scala
@@ -56,7 +56,10 @@ class StringValidateSpec extends Properties("StringValidate") {
     val jsErr = showResult[Uri](" /a/b/c") ?=
       "Uri predicate failed: Malformed URI in  /a/b/c at -1"
 
-    jvmErr || jsErr
+    val nativeErr = showResult[Uri](" /a/b/c") ?=
+      "Uri predicate failed: Illegal character in path in  /a/b/c at 1"
+
+    jvmErr || jsErr || nativeErr
   }
 
   property("Uuid.isValid") = secure {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,8 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
 
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.5")
+
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")


### PR DESCRIPTION
Closes https://github.com/fthomas/refined/issues/1090.

This restores the Native builds for core, scalacheck, and shapeless modules. This is sufficient to unblock Circe Native.

There was a boxing related bug when running the Cats tests, so no Native for that today. Scodec could also get Native in the future (bits is cross-published, but not core yet).
