### PR TITLE
feat(string): add a splitAt method

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ The library comes with these predefined predicates:
 * `XPath`: checks if a `String` is a valid XPath expression
 * `Trimmed`: checks if a `String` has no leading or trailing whitespace
 * `HexStringSpec`: checks if a `String` represents a hexadecimal number
+* `SplitAt`: split a string at an Index `N`, and then check the conjunction of the predicates `A` on the first part of the string and `B` on its second part
 
 ## Contributors and participation
 

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Resources.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Resources.scala
@@ -86,6 +86,9 @@ object Resources {
   def showResultOrBothFailed(expr: String, left: String, right: String): String =
     s"$Both $predicates of $expr $failed. $Left: $left $Right: $right"
 
+  def showResultInputFailed(expr: String, input: String): String =
+    s"$expr $failed: input $input"
+
   //
 
   val refineNonCompileTimeConstant =

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringInferenceSpec.scala
@@ -71,4 +71,12 @@ class StringInferenceSpec extends Properties("StringInference") {
     Inference[ValidBigDecimal, NonEmpty].isValid
   }
 
+  property("SplitAt =!> NonEmpty") = secure {
+    Inference[SplitAt[W.`1`.T, IPv4, Uuid], NonEmpty].isValid
+  }
+
+  property("SplitAt =!> NonEmpty") = secure {
+    Inference[SplitAt[W.`-1`.T, IPv4, Uuid], NonEmpty].notValid
+  }
+
 }

--- a/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringValidateSpec.scala
+++ b/modules/core/shared/src/test/scala-3.0-/eu/timepit/refined/StringValidateSpec.scala
@@ -7,6 +7,8 @@ import org.scalacheck.{Arbitrary, Properties}
 import org.scalacheck.Prop._
 import shapeless.Witness
 
+
+
 class StringValidateSpec extends Properties("StringValidate") {
 
   property("EndsWith.isValid") = secure {
@@ -143,4 +145,39 @@ class StringValidateSpec extends Properties("StringValidate") {
   validNumber[Double, ValidDouble]("ValidDouble", "a")
   validNumber[BigInt, ValidBigInt]("ValidBigInt", "1.0")
   validNumber[BigDecimal, ValidBigDecimal]("ValidBigDecimal", "a")
+
+  property("SplitAt.isValid") = secure {
+    val ipv4 = "10.0.0.1"
+    val uuid = "9ecce884-47fe-4ba4-a1bb-1a3d71ed6530"
+    val length = Witness(8)
+    val s = s"$ipv4$uuid"
+    isValid[SplitAt[length.T, IPv4, Uuid]](s) ?= s.startsWith(ipv4) && s.endsWith(uuid)
+  }
+
+  property("SplitAt.showResult.example.Failed") = secure {
+    val ipv4 = "whops"
+    val uuid = "9ecce884-47fe-4ba4-a1bb-1a3d71ed6530"
+    val length = Witness(5)
+    val s = s"$ipv4$uuid"
+    showResult[SplitAt[length.T, IPv4, Uuid]](s) ?=
+      s"""Left predicate of splitAt(${length.value.toInt}, $s is a valid IPv4 && isValidUuid(\"$s\")) failed: Predicate failed: $s is a valid IPv4."""
+  }
+
+  property("SplitAt.showResult.length.negative.Failed") = secure {
+    val ipv4 = "whops"
+    val uuid = "9ecce884-47fe-4ba4-a1bb-1a3d71ed6530"
+    val length = Witness(-1)
+    val s = s"$ipv4$uuid"
+    showResult[SplitAt[length.T, IPv4, Uuid]](s) ?=
+      s"""splitAt(${length.value.toInt}, $s is a valid IPv4 && isValidUuid(\"$s\")) failed: input ${length.value.toInt} should be between zero and this string length"""
+  }
+
+  property("SplitAt.showResult.length.big.Failed") = secure {
+    val ipv4 = "whops"
+    val uuid = "9ecce884-47fe-4ba4-a1bb-1a3d71ed6530"
+    val length = Witness(1000)
+    val s = s"$ipv4$uuid"
+    showResult[SplitAt[length.T, IPv4, Uuid]](s) ?=
+      s"""splitAt(${length.value.toInt}, $s is a valid IPv4 && isValidUuid(\"$s\")) failed: input ${length.value.toInt} should be between zero and this string length"""
+  }
 }


### PR DESCRIPTION
closes #1080
A proposal to be able to split a string and verify two predicates on the result. 
I implemented at first a `SplitAt` predicate that take an Index to split the string. Then apply and AND on the two given predicates. 

In the same way I can implement a `SplitBy` predicate that would split into two string when matching the given string input. 

What do you think? 