### PR TITLE
enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,5 +9,10 @@ rewriteTokens {
 fileOverride {
   "glob:**/src/*/scala-3.0+/**" {
     runner.dialect = scala3
+    rewrite.scala3.convertToNewSyntax = false
   }
 }
+rewrite.scala3.convertToNewSyntax = true
+runner.dialectOverride.allowAsForImportRename = false
+runner.dialectOverride.allowStarWildcardImport = false
+runner.dialectOverride.allowPostfixStarVarargSplices = false

--- a/build.sbt
+++ b/build.sbt
@@ -364,7 +364,7 @@ lazy val moduleCrossSettings = Def.settings(
   commonSettings
 )
 
-def moduleJvmSettings(name: String): Seq[Def.Setting[_]] =
+def moduleJvmSettings(name: String): Seq[Def.Setting[?]] =
   Def.settings(
     scalaVersion := Scala_2_13,
     javaOptions ++= Seq("-Duser.language=en"),
@@ -385,7 +385,7 @@ def moduleJvmSettings(name: String): Seq[Def.Setting[_]] =
     }
   )
 
-def moduleJsSettings(name: String): Seq[Def.Setting[_]] =
+def moduleJsSettings(name: String): Seq[Def.Setting[?]] =
   Def.settings(
     scalaVersion := Scala_2_13,
     crossScalaVersions := moduleCrossScalaVersionsMatrix(name, JSPlatform),
@@ -403,7 +403,7 @@ def moduleJsSettings(name: String): Seq[Def.Setting[_]] =
     }
   )
 
-def moduleNativeSettings(name: String): Seq[Def.Setting[_]] =
+def moduleNativeSettings(name: String): Seq[Def.Setting[?]] =
   Def.settings(
     crossScalaVersions := moduleCrossScalaVersionsMatrix(name, NativePlatform),
     doctestGenTests := Seq.empty,

--- a/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/boolean.scala
+++ b/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/boolean.scala
@@ -235,7 +235,7 @@ object boolean extends BooleanInference0 {
     implicit def oneOfHConsValidate[T, PH, RH, PT <: HList, RT <: HList](implicit
         vh: Validate.Aux[T, PH, RH],
         vt: Validate.Aux[T, OneOf[PT], OneOf[RT]],
-        toList: ToList[RT, Result[_]]
+        toList: ToList[RT, Result[?]]
     ): Validate.Aux[T, OneOf[PH :: PT], OneOf[vh.Res :: RT]] =
       new Validate[T, OneOf[PH :: PT]] {
         override type R = OneOf[vh.Res :: RT]

--- a/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/collection.scala
+++ b/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/collection.scala
@@ -122,7 +122,7 @@ object collection extends CollectionInference {
   }
 
   object Empty {
-    implicit def emptyValidate[T](implicit ev: T => Iterable[_]): Validate.Plain[T, Empty] =
+    implicit def emptyValidate[T](implicit ev: T => Iterable[?]): Validate.Plain[T, Empty] =
       Validate.fromPredicate(t => ev(t).isEmpty, t => s"isEmpty($t)", Empty())
   }
 
@@ -254,7 +254,7 @@ object collection extends CollectionInference {
   object Size {
     implicit def sizeValidate[T, P, RP](implicit
         v: Validate.Aux[Int, P, RP],
-        ev: T => Iterable[_]
+        ev: T => Iterable[?]
     ): Validate.Aux[T, Size[P], Size[v.Res]] =
       new Validate[T, Size[P]] {
         override type R = Size[v.Res]

--- a/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Resources.scala
+++ b/modules/core/shared/src/main/scala/eu/timepit/refined/internal/Resources.scala
@@ -15,16 +15,16 @@ object Resources {
   val Left = "Left"
   val Right = "Right"
 
-  def predicateResult(r: Result[_]): String =
+  def predicateResult(r: Result[?]): String =
     s"$Predicate ${toLowerCase(r)}"
 
-  def predicateResultDetail(r: Result[_], detail: String): String =
+  def predicateResultDetail(r: Result[?], detail: String): String =
     s"${predicateResult(r)}: $detail"
 
-  def predicateResultDetailDot(r: Result[_], detail: String): String =
+  def predicateResultDetailDot(r: Result[?], detail: String): String =
     s"${predicateResultDetail(r, detail)}."
 
-  def predicateTakingResultDetail(taking: String, r: Result[_], detail: String): String =
+  def predicateTakingResultDetail(taking: String, r: Result[?], detail: String): String =
     s"$Predicate taking $taking ${toLowerCase(r)}: $detail"
 
   def showExprEmptyCollection: String =
@@ -33,10 +33,10 @@ object Resources {
   def showResultEmptyCollection: String =
     s"$Predicate $failed: empty collection."
 
-  def namePredicateResult(name: String, r: Result[_]): String =
+  def namePredicateResult(name: String, r: Result[?]): String =
     s"$name $predicate ${toLowerCase(r)}"
 
-  def namePredicateResultMessage(name: String, r: Result[_], maybeThrowable: Try[_]): String = {
+  def namePredicateResultMessage(name: String, r: Result[?], maybeThrowable: Try[?]): String = {
     val suffix = maybeThrowable match {
       case Success(_) => "."
       case Failure(e) => s": ${e.getMessage}"
@@ -47,7 +47,7 @@ object Resources {
   def isValidName[T](name: String, t: T): String =
     s"""isValid$name("$t")"""
 
-  def toLowerCase(r: Result[_]): String =
+  def toLowerCase(r: Result[?]): String =
     r.morph(passed, failed)
 
   // Not


### PR DESCRIPTION
- Scala 3 report warnings since 3.4 https://github.com/lampepfl/dotty/pull/18813
- Scala 2.12 and 2.13 support new syntax without `-Xsource:3` option https://github.com/scala/scala/pull/10005