### PR TITLE
Update Scala Native to 0.5, revert to Scala 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' validateJVM validateJS validateNative
 
       - name: Build project (Scala 3)
-        if: matrix.scala == '3.4.2'
+        if: matrix.scala == '3.3.3'
         run: sbt '++ ${{ matrix.scala }}' validateJVM30 validateJS30 validateNative30
 
       - name: Codecov

--- a/build.sbt
+++ b/build.sbt
@@ -13,14 +13,14 @@ val gitDevUrl = s"git@github.com:$gitHubOwner/$projectName.git"
 
 val Scala_2_12 = "2.12.19"
 val Scala_2_13 = "2.13.14"
-val Scala_3 = "3.4.2"
+val Scala_3 = "3.3.3"
 
-val catsVersion = "2.10.0"
+val catsVersion = "2.12.0"
 val jsonpathVersion = "2.9.0"
 val macroParadiseVersion = "2.1.1"
 val pureconfigVersion = "0.17.6"
-val shapelessVersion = "2.3.11"
-val scalaCheckVersion = "1.17.1"
+val shapelessVersion = "2.3.12"
+val scalaCheckVersion = "1.18.0"
 val scalazVersion = "7.3.8"
 val scodecVersion = "1.11.10"
 val scoptVersion = "4.1.0"
@@ -164,7 +164,7 @@ lazy val cats = myCrossProject("cats")
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % catsVersion,
       "org.typelevel" %%% "cats-laws" % catsVersion % Test,
-      "org.typelevel" %%% "discipline-scalatest" % "2.2.0" % Test
+      "org.typelevel" %%% "discipline-scalatest" % "2.3.0" % Test
     ),
     initialCommands += s"""
       import $rootPkg.cats._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.2")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
 


### PR DESCRIPTION
I noticed that Scala was updated to 3.4.1 (https://github.com/fthomas/refined/pull/1261) perhaps unintentionally - libraries in general are recommended to stay on LTS I believe, unless they use features only present in Scala Next.