### PR TITLE
use SAM instead of anonymous class

### DIFF
--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/ToInt.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/ToInt.scala
@@ -11,7 +11,7 @@ object ToInt {
   def apply[N <: Int](implicit toInt: ToInt[N]): ToInt[N] = toInt
 
   inline implicit def materialize[N <: Int]: ToInt[N] =
-    new ToInt[N] { override def apply(): Int = toInt[N] }
+    () => toInt[N]
 
   private inline def toInt[N <: Int]: Int =
     inline erasedValue[N] match {


### PR DESCRIPTION
fix warning with Scala 3.5

```
[warn] -- [E197] Potential Issue Warning: modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/ToInt.scala:14:4 
[warn] 14 |    new ToInt[N] { override def apply(): Int = toInt[N] }
[warn]    |    ^
```