### PR TITLE
De-prioritize `intWitnessAs` implicit on Scala 3

### DIFF
--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/WitnessAs.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/WitnessAs.scala
@@ -25,14 +25,7 @@ import scala.compiletime.{constValue, error}
 final case class WitnessAs[A, B](fst: A, snd: B)
 
 object WitnessAs extends WitnessAs1 {
-  def apply[A, B](implicit ev: WitnessAs[A, B]): WitnessAs[A, B] = ev
-
-  implicit def intWitnessAs[B, A <: Int](implicit
-      wa: ValueOf[A],
-      ta: ToInt[A],
-      nb: Numeric[B]
-  ): WitnessAs[A, B] =
-    WitnessAs(wa.value, nb.fromInt(ta.apply()))
+  def apply[A, B](using ev: WitnessAs[A, B]): WitnessAs[A, B] = ev
 
   inline given singletonWitnessAs[B, A <: B]: WitnessAs[A, B] = {
     inline val a = constValue[A]
@@ -40,7 +33,7 @@ object WitnessAs extends WitnessAs1 {
   }
 }
 
-trait WitnessAs1 {
+trait WitnessAs1 extends WitnessAs2 {
   inline given intWitnessAsByte[A <: Int]: WitnessAs[A, Byte] =
     inline constValue[A] match {
       case a if a >= -128 && a <= 127 => WitnessAs(a, a.toByte)
@@ -88,4 +81,13 @@ trait WitnessAs1 {
     inline val a = constValue[A]
     WitnessAs(a, BigDecimal(a))
   }
+}
+
+trait WitnessAs2 {
+  given intWitnessAs[B, A <: Int](using
+      wa: ValueOf[A],
+      ta: ToInt[A],
+      nb: Numeric[B]
+  ): WitnessAs[A, B] =
+    WitnessAs(wa.value, nb.fromInt(ta.apply()))
 }

--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/WitnessAs.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/internal/WitnessAs.scala
@@ -27,7 +27,8 @@ final case class WitnessAs[A, B](fst: A, snd: B)
 object WitnessAs extends WitnessAs1 {
   def apply[A, B](implicit ev: WitnessAs[A, B]): WitnessAs[A, B] = ev
 
-  implicit def intWitnessAs[B, A <: Int](implicit
+  @deprecated("Use one of the specialized instances of intWitnessAs*", "0.11.3")
+  def intWitnessAs[B, A <: Int](implicit
       wa: ValueOf[A],
       ta: ToInt[A],
       nb: Numeric[B]


### PR DESCRIPTION
There are already several specialized instances e.g. `intWitnessAsLong`. These should be higher priority than this generic instance that relies on `Numeric`.

Annoyingly, starting in Scala 3.6 the implicit resolution changes cause the following warning. Fixing the prioritization should address the warning.

```
[warn]    |Given search preference for eu.timepit.refined.internal.WitnessAs[(0 : Int), Long] between alternatives
[warn]    |  (eu.timepit.refined.internal.WitnessAs.intWitnessAsLong :
[warn]    |  [A <: Int]: eu.timepit.refined.internal.WitnessAs[A, Long])
[warn]    |and
[warn]    |  (eu.timepit.refined.internal.WitnessAs.intWitnessAs :
[warn]    |  [B, A <: Int]
[warn]    |    (implicit wa: ValueOf[A], ta: eu.timepit.refined.internal.ToInt[A], nb:
[warn]    |      Numeric[B]): eu.timepit.refined.internal.WitnessAs[A, B]
[warn]    |)
[warn]    |will change.
[warn]    |Current choice           : the first alternative
[warn]    |New choice from Scala 3.7: the second alternative
```

---

Alternatively, perhaps this implicit was ported in error. The equivalent on the Scala 2 side is for `Nat`, which isn't available for Scala 3, so perhaps was swapped for `Int`?

https://github.com/fthomas/refined/blob/20df7ccb625448023a7ecddf9af84ad4f489415f/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/internal/WitnessAs.scala#L31-L36