### PR TITLE
optimize `RefinedTypeOps.unapply`

### DIFF
--- a/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/api/RefinedTypeOps.scala
+++ b/modules/core/shared/src/main/scala-3.0+/eu/timepit/refined/api/RefinedTypeOps.scala
@@ -25,8 +25,11 @@ class RefinedTypeOps[FTP, T](implicit rt: RefinedType.AuxT[FTP, T]) extends Seri
   def from(t: T): Either[String, FTP] =
     rt.refine(t)
 
-  def unapply(t: T): Option[FTP] =
-    from(t).toOption
+  def unapply(t: T): Option[FTP] = {
+    val res = rt.validate.validate(t)
+    if (res.isPassed) Some(rt.refType.unsafeWrap(t).asInstanceOf[FTP])
+    else None
+  }
 
   def unsafeFrom(t: T): FTP =
     rt.unsafeRefine(t)

--- a/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/api/RefinedTypeOps.scala
+++ b/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/api/RefinedTypeOps.scala
@@ -34,8 +34,11 @@ class RefinedTypeOps[FTP, T](implicit rt: RefinedType.AuxT[FTP, T]) extends Seri
   def from(t: T): Either[String, FTP] =
     rt.refine(t)
 
-  def unapply(t: T): Option[FTP] =
-    from(t).toOption
+  def unapply(t: T): Option[FTP] = {
+    val res = rt.validate.validate(t)
+    if (res.isPassed) Some(rt.refType.unsafeWrap(t).asInstanceOf[FTP])
+    else None
+  }
 
   def unsafeFrom(t: T): FTP =
     rt.unsafeRefine(t)


### PR DESCRIPTION
avoid Intermediate `Either` objects