### PR TITLE
Compile with JDK 17 and --release 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         scala: [2.12, 2.13, 3]
-        java: [temurin@8]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -41,17 +41,17 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@8]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -103,17 +103,17 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@8)
-        id: setup-java-temurin-8
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Download target directories (2.12)

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,9 +21,9 @@ pull_request_rules:
   - or:
     - author=scala-steward
     - author=scala-steward[bot]
-  - status-success=Test (ubuntu-22.04, 2.12, temurin@8)
-  - status-success=Test (ubuntu-22.04, 2.13, temurin@8)
-  - status-success=Test (ubuntu-22.04, 3, temurin@8)
+  - status-success=Test (ubuntu-22.04, 2.12, temurin@17)
+  - status-success=Test (ubuntu-22.04, 2.13, temurin@17)
+  - status-success=Test (ubuntu-22.04, 3, temurin@17)
   actions:
     merge:
       method: merge

--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ ThisBuild / githubWorkflowPublish := Seq(
     )
   )
 )
-ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Temurin, "8"))
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Temurin, "17"))
 ThisBuild / githubWorkflowBuild :=
   Seq(
     WorkflowStep.Sbt(
@@ -432,7 +432,9 @@ lazy val compileSettings = Def.settings(
     "UTF-8",
     "-feature",
     "-language:existentials,experimental.macros,higherKinds,implicitConversions",
-    "-unchecked"
+    "-unchecked",
+    "-release",
+    "8"
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
According to https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#running-versus-compiling this should allow us to use newer JDKs and our users to stay on Java 8 or above.